### PR TITLE
Support new JWT Auth with token refresh

### DIFF
--- a/src/app/(blank)/login/LoginForm.tsx
+++ b/src/app/(blank)/login/LoginForm.tsx
@@ -15,11 +15,10 @@ export default function LoginForm() {
     setError('')
     setLoading(true)
     try {
-      const res = await fetch('/login', {
+      const res = await fetch('/internal-api/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password }),
-        credentials: 'include'
+        body: JSON.stringify({ username, password })
       })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))
@@ -27,8 +26,8 @@ export default function LoginForm() {
         setLoading(false)
         return
       }
-      const user = await res.json()
-      const userDefaultLibraryId = user?.userDefaultLibraryId
+      const userResponse = await res.json()
+      const userDefaultLibraryId = userResponse?.userDefaultLibraryId
 
       // Get redirect parameter from URL search params
       const urlParams = new URLSearchParams(window.location.search)
@@ -38,7 +37,7 @@ export default function LoginForm() {
       } else if (userDefaultLibraryId) {
         router.replace(`/library/${userDefaultLibraryId}`)
       } else {
-        router.replace('/config')
+        router.replace('/settings')
       }
     } catch (err) {
       setError('Network error. Please try again.')

--- a/src/app/(blank)/login/ServerInitForm.tsx
+++ b/src/app/(blank)/login/ServerInitForm.tsx
@@ -38,8 +38,7 @@ export default function ServerInitForm() {
       const res = await fetch('/init', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-        credentials: 'include'
+        body: JSON.stringify(payload)
       })
       if (!res.ok) {
         const data = await res.json().catch(() => ({}))

--- a/src/app/(blank)/login/page.tsx
+++ b/src/app/(blank)/login/page.tsx
@@ -6,6 +6,7 @@ export const dynamic = 'force-dynamic'
 
 export default async function LoginPage() {
   const status = await getServerStatus()
+  const isServerInitialized = !!status.data?.isInit
 
   if (status.error) {
     return (
@@ -15,5 +16,5 @@ export default async function LoginPage() {
     )
   }
 
-  return <div className="min-h-[calc(100vh-var(--header-height))] flex items-center justify-center">{status.data?.isInit ? <LoginForm /> : <ServerInitForm />}</div>
+  return <div className="min-h-[calc(100vh-var(--header-height))] flex items-center justify-center">{isServerInitialized ? <LoginForm /> : <ServerInitForm />}</div>
 }

--- a/src/app/(main)/LogoutButton.tsx
+++ b/src/app/(main)/LogoutButton.tsx
@@ -10,12 +10,18 @@ export default function LogoutButton() {
   const handleLogout = async () => {
     setLoading(true)
     try {
-      const res = await fetch('/logout', {
-        method: 'POST',
-        credentials: 'include'
+      // Calls the Abs server logout endpoint and clears the NextJS server cookies
+      const res = await fetch('/internal-api/logout', {
+        method: 'POST'
       })
+      if (!res.ok) {
+        console.error('Logout error:', res.status, res.statusText)
+        return
+      }
       router.replace('/login')
     } catch (err) {
+      console.error('Logout error:', err)
+    } finally {
       setLoading(false)
     }
   }

--- a/src/app/(main)/library/[library]/page.tsx
+++ b/src/app/(main)/library/[library]/page.tsx
@@ -5,6 +5,7 @@ import StatusDataFetcher from '../../StatusDataFetcher'
 
 export default async function LibraryPage({ params }: { params: Promise<{ library: string }> }) {
   const { library: libraryId } = await params
+
   const libraryResponse = await Promise.all([getLibrary(libraryId), getLibraryPersonalized(libraryId)])
   const library = libraryResponse[0].data
   const personalized = libraryResponse[1].data

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,5 +1,7 @@
 import { getCurrentUser } from '../../../lib/api'
 
+export const dynamic = 'force-dynamic'
+
 export default async function ConfigPage() {
   const userResponse = await getCurrentUser()
   const user = userResponse.data?.user

--- a/src/app/internal-api/logout/route.ts
+++ b/src/app/internal-api/logout/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { getServerBaseUrl } from '../../../lib/api'
+
+export async function POST(request: Request) {
+  try {
+    const cookieStore = await cookies()
+    const refreshToken = cookieStore.get('refresh_token')?.value
+
+    const audiobookshelfServerUrl = getServerBaseUrl()
+
+    // Make logout request to the Audiobookshelf server
+    const logoutResponse = await fetch(`${audiobookshelfServerUrl}/logout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // Pass refresh token so the session can be deleted on the Abs server
+        ...(refreshToken ? { 'x-refresh-token': refreshToken } : {})
+      }
+    })
+
+    if (!logoutResponse.ok) {
+      return NextResponse.json({ error: 'Logout failed' }, { status: 401 })
+    }
+
+    const response = NextResponse.json({ success: true })
+    // Delete token cookies
+    response.cookies.delete('refresh_token')
+    response.cookies.delete('access_token')
+    return response
+  } catch (error) {
+    console.error('Logout error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/internal-api/refresh/route.ts
+++ b/src/app/internal-api/refresh/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { getServerBaseUrl, getUserDefaultUrlPath, setTokenCookies } from '@/lib/api'
+
+export async function GET(request: Request) {
+  return handleRefresh(request)
+}
+
+export async function POST(request: Request) {
+  return handleRefresh(request)
+}
+
+async function handleRefresh(request: Request) {
+  const audiobookshelfServerUrl = getServerBaseUrl()
+
+  try {
+    const cookieStore = await cookies()
+    const refreshToken = cookieStore.get('refresh_token')?.value
+
+    if (!refreshToken) {
+      return NextResponse.json({ error: 'No refresh token found' }, { status: 401 })
+    }
+
+    // Make refresh request to the Audiobookshelf server
+    const refreshResponse = await fetch(`${audiobookshelfServerUrl}/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        // Passing the refresh token in header is an alternative to using the Abs server cookie
+        'x-refresh-token': refreshToken
+      }
+    })
+
+    if (!refreshResponse.ok) {
+      // Redirect to login page and delete refresh token cookie
+      const redirectUrl = new URL('/login', audiobookshelfServerUrl)
+      redirectUrl.searchParams.set('error', 'Token refresh failed')
+      const response = NextResponse.redirect(redirectUrl)
+      response.cookies.delete('refresh_token')
+      return response
+    }
+
+    const data = await refreshResponse.json()
+    const newAccessToken = data.user.accessToken
+    const newRefreshToken = data.user.refreshToken
+
+    if (!newAccessToken) {
+      return NextResponse.json({ error: 'No new access token received' }, { status: 500 })
+    }
+
+    // Get redirect URL from query parameters or default to user default path
+    const url = new URL(request.url)
+    const redirectUrlPath = url.searchParams.get('redirect') || getUserDefaultUrlPath(data.userDefaultLibraryId)
+    const redirectUrl = new URL(redirectUrlPath, audiobookshelfServerUrl)
+    const response = NextResponse.redirect(redirectUrl)
+
+    setTokenCookies(response, newAccessToken, newRefreshToken)
+
+    return response
+  } catch (error) {
+    console.error('Token refresh error:', error)
+    // Redirect to login page and delete refresh token cookie
+    const redirectUrl = new URL('/login', audiobookshelfServerUrl)
+    redirectUrl.searchParams.set('error', 'Internal server error')
+    const response = NextResponse.redirect(redirectUrl)
+    response.cookies.delete('refresh_token')
+    return response
+  }
+}


### PR DESCRIPTION
This updates the authentication to use the new JWT auth that is in this PR https://github.com/advplyr/audiobookshelf/pull/4444

The JWT auth handles refreshing the tokens when an API returns 401 Unauthorized.

Abs is using NextJS in a non-standard way by starting a NextJS server from the Abs server. This means the JWT auth implemented here may seem convoluted. I'll attempt to explain the why and how.

### A typical web client JWT auth flow
1. Client makes a call to `/login`
2. Server creates an access token and a refresh token
3. Access token is returned to the client & refresh token is stored in a cookie
4. Client stores access token in memory
5. When the client gets a 401 Unauthorized it makes a call to `/auth/refresh` with the refresh token in the cookie

This approach is used in the NuxtJS app in https://github.com/advplyr/audiobookshelf/pull/4444

## Why the typical approach does not work here
NextJS is using server-side rendering. The NextJS server is being started from the Abs server (in `Server.js`).

Since NextJS is making API requests server side in order to get the data necessary to render the page, it cannot use the refresh token cookie that is set on the Abs server. These are server-to-server API requests, not browser-to-server.

Additionally, the NextJS server is segmented so (as far as I could tell) there is no shared memory for the middleware & server components. This is why I have the NextJS server storing both the refresh and access token in cookies.

In short, the NextJS server will manage the refresh & access token cookies as opposed to the Abs server in order to have the tokens available for server side rendering.

## JWT auth flow implemented in this PR

Note: `/internal-api/` endpoints are on the NextJS server. The Abs server is set up to pass these through to NextJS.

#### Login flow (successful)
1. Client makes a call to `/internal-api/login`
2. `/internal-api/login` route makes a call to Abs server `/login`  
    - Login request includes `x-return-tokens` header that tells the Abs server to include the refresh token in the response
3. The Abs server creates an access token, refresh token and a session in the db containing the refresh token
4. `/internal-api/login` route sets a `refresh_token` & `access_token` cookie

#### Refresh flow (successful)
1. When the client navigates to a page requiring auth, `middleware.ts` makes a request to Abs server `/api/authorize`
2. On 401 Unauthorized, `middleware.ts` redirects to `/internal-api/refresh` (with current pathname in `redirect` query param)
3. `/internal-api/refresh` route makes a call to Abs server `/auth/refresh`
    - Refresh token is passed to the Abs server in the `x-refresh-token` header (as opposed to the server using a cookie)
4. Abs server looks up the session using the refresh token, creates new refresh & access tokens, and updates the session
5. `/internal-api/refresh` route sets both token cookies and redirects using the path in the `redirect` query param
7. The result is the client isn't aware of the refresh

#### Logout flow
1. Client calls `/internal-api/logout`
2. `/internal-api/logout` route calls Abs server `/logout`
   - Refresh token is passed to the Abs server in the `x-refresh-token` header
3. The Abs server deletes the session from the db using the refresh token
4. `/internal-api/logout` route clears both cookies & redirects to the login page