### PR TITLE
MultiSelect and Modal

### DIFF
--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Btn from '@/components/ui/Btn'
 import Checkbox from '@/components/ui/Checkbox'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
@@ -16,6 +16,7 @@ import LibraryIcon from '@/components/ui/LibraryIcon'
 import MediaIconPicker from '@/components/ui/MediaIconPicker'
 import MultiSelect from '@/components/ui/MultiSelect'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import Modal from '@/components/modals/Modal'
 
 export default function ComponentsCatalogPage() {
   const { showToast } = useGlobalToast()
@@ -53,6 +54,17 @@ export default function ComponentsCatalogPage() {
   const multiSelectItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
   const [multiSelectValue, setMultiSelectValue] = useState<string[]>(['Apple', 'Banana'])
 
+  // Modal state
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isBasicModalOpen, setIsBasicModalOpen] = useState(false)
+  const [isOuterContentModalOpen, setIsOuterContentModalOpen] = useState(false)
+  const [isResponsiveModalOpen, setIsResponsiveModalOpen] = useState(false)
+  const [isProcessingModalOpen, setIsProcessingModalOpen] = useState(false)
+  const [isPersistentModalOpen, setIsPersistentModalOpen] = useState(false)
+  const [isCustomModalOpen, setIsCustomModalOpen] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [modalMultiSelectValue, setModalMultiSelectValue] = useState<string[]>(['Cherry', 'Date'])
+
   // Dropdown change handlers
   const handleDropdownChange = (value: string | number) => {
     setDropdownValue(String(value))
@@ -81,6 +93,16 @@ export default function ComponentsCatalogPage() {
 
   const handleInputDropdownNewItem = (value: string) => {
     showToast(`New item created: ${value}`, { type: 'success', title: 'Item Created' })
+  }
+
+  // Helper function to simulate processing
+  const handleProcessingDemo = () => {
+    setIsProcessing(true)
+    setTimeout(() => {
+      setIsProcessing(false)
+      setIsProcessingModalOpen(false)
+      showToast('Processing completed!', { type: 'success', title: 'Success' })
+    }, 3000)
   }
 
   // ContextMenuDropdown sample data
@@ -450,6 +472,229 @@ export default function ComponentsCatalogPage() {
         </div>
       </section>
 
+      {/* Modal Components */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Modal Components</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Basic Modal</h3>
+            <p className="text-gray-400 text-sm mb-4">A simple modal with default settings and close functionality.</p>
+            <Btn onClick={() => setIsBasicModalOpen(true)}>Open Basic Modal</Btn>
+
+            <Modal isOpen={isBasicModalOpen} onClose={() => setIsBasicModalOpen(false)}>
+              <div className="bg-gray-800 rounded-lg p-6 max-w-md">
+                <h3 className="text-xl font-semibold text-white mb-4">Basic Modal Example</h3>
+                <p className="text-gray-300 mb-6">
+                  This is a basic modal dialog. You can close it by clicking the close button, pressing Escape, or clicking outside the modal content.
+                </p>
+                <div className="flex justify-end gap-3">
+                  <Btn onClick={() => setIsBasicModalOpen(false)} color="bg-gray-600">
+                    Close
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Processing Modal</h3>
+            <p className="text-gray-400 text-sm mb-4">A modal with a processing overlay that prevents interaction during operations.</p>
+            <Btn onClick={() => setIsProcessingModalOpen(true)}>Open Processing Modal</Btn>
+
+            <Modal isOpen={isProcessingModalOpen} onClose={() => setIsProcessingModalOpen(false)} processing={isProcessing} width={500} height={300}>
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Processing Example</h3>
+                <p className="text-gray-300 mb-6 flex-1">
+                  Click the "Start Processing" button to see the processing overlay in action. The modal will be disabled during processing.
+                </p>
+                <div className="flex justify-end gap-3">
+                  <Btn onClick={() => setIsProcessingModalOpen(false)} color="bg-gray-600">
+                    Cancel
+                  </Btn>
+                  <Btn onClick={handleProcessingDemo} color="bg-blue-600" disabled={isProcessing}>
+                    {isProcessing ? 'Processing...' : 'Start Processing'}
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Persistent Modal</h3>
+            <p className="text-gray-400 text-sm mb-4">A modal that cannot be closed by clicking outside or pressing Escape.</p>
+            <Btn onClick={() => setIsPersistentModalOpen(true)}>Open Persistent Modal</Btn>
+
+            <Modal
+              isOpen={isPersistentModalOpen}
+              onClose={() => setIsPersistentModalOpen(false)}
+              persistent={true}
+              width={450}
+              height={250}
+              bgOpacityClass="bg-primary/90"
+            >
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Persistent Modal</h3>
+                <p className="text-gray-300 mb-6 flex-1">
+                  This modal is persistent - you can only close it by clicking the "Close" button. Background clicks and Escape key are disabled.
+                </p>
+                <div className="flex justify-center">
+                  <Btn onClick={() => setIsPersistentModalOpen(false)} color="bg-red-600">
+                    Close Modal
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Custom Styled Modal</h3>
+            <p className="text-gray-400 text-sm mb-4">A modal with custom dimensions and Tailwind z-index/opacity classes.</p>
+            <Btn onClick={() => setIsCustomModalOpen(true)}>Open Custom Modal</Btn>
+
+            <Modal
+              isOpen={isCustomModalOpen}
+              onClose={() => setIsCustomModalOpen(false)}
+              width={800}
+              height={600}
+              zIndexClass="z-[100]"
+              bgOpacityClass="bg-primary/50"
+              contentMarginTop={20}
+            >
+              <div className="bg-gradient-to-br from-blue-900 to-purple-900 rounded-lg p-8 h-full flex flex-col">
+                <h3 className="text-2xl font-bold text-white mb-6">Custom Styled Modal</h3>
+                <div className="flex-1 space-y-4">
+                  <p className="text-blue-100">This modal demonstrates custom styling options:</p>
+                  <ul className="list-disc list-inside text-blue-100 space-y-2">
+                    <li>Custom width (800px) and height (600px)</li>
+                    <li>Higher z-index (z-[100]) using Tailwind classes</li>
+                    <li>Lower background opacity (bg-primary/50) using Tailwind classes</li>
+                    <li>Custom margin top (20px)</li>
+                    <li>Gradient background styling</li>
+                  </ul>
+                  <div className="bg-blue-800/30 rounded p-4 mt-4">
+                    <h4 className="text-lg font-semibold text-white mb-2">Modal Features</h4>
+                    <p className="text-blue-100 text-sm">
+                      The Modal component supports focus management, keyboard navigation, smooth animations, and portal rendering for proper z-index handling.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex justify-end gap-3 pt-6 border-t border-blue-700">
+                  <Btn onClick={() => setIsCustomModalOpen(false)} color="bg-blue-600">
+                    Close Custom Modal
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Modal with Outer Content</h3>
+            <p className="text-gray-400 text-sm mb-4">A modal that can display content outside the main modal area.</p>
+            <Btn onClick={() => setIsOuterContentModalOpen(true)}>Open with Outer Content</Btn>
+
+            <Modal
+              isOpen={isOuterContentModalOpen}
+              onClose={() => setIsOuterContentModalOpen(false)}
+              width={400}
+              height={300}
+              outerContent={<div className="absolute top-10 left-10 bg-yellow-500 text-black px-3 py-1 rounded text-sm font-semibold">Outer Content!</div>}
+            >
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Modal with Outer Content</h3>
+                <p className="text-gray-300 mb-6 flex-1">
+                  This modal has additional content rendered outside the main modal container. Check the yellow badge in the top-left corner.
+                </p>
+                <div className="flex justify-end">
+                  <Btn onClick={() => setIsOuterContentModalOpen(false)} color="bg-gray-600">
+                    Close
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Responsive Modal</h3>
+            <p className="text-gray-400 text-sm mb-4">A modal that adapts to different screen sizes using string dimensions.</p>
+            <Btn onClick={() => setIsResponsiveModalOpen(true)}>Open Responsive Modal</Btn>
+
+            <Modal isOpen={isResponsiveModalOpen} onClose={() => setIsResponsiveModalOpen(false)} width="90vw" height="80vh">
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Responsive Modal</h3>
+                <div className="flex-1 space-y-4">
+                  <p className="text-gray-300">This modal uses viewport units for its dimensions:</p>
+                  <ul className="list-disc list-inside text-gray-300 space-y-2">
+                    <li>Width: 90vw (90% of viewport width)</li>
+                    <li>Height: 80vh (80% of viewport height)</li>
+                    <li>Automatically adapts to screen size</li>
+                    <li>Perfect for mobile devices</li>
+                  </ul>
+                  <div className="bg-gray-700 rounded p-4">
+                    <p className="text-sm text-gray-300">Try resizing your browser window to see how the modal adapts to different screen sizes.</p>
+                  </div>
+                </div>
+                <div className="flex justify-end pt-4 border-t border-gray-600">
+                  <Btn onClick={() => setIsResponsiveModalOpen(false)} color="bg-gray-600">
+                    Close
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </div>
+      </section>
+
+      {/* MultiSelect in Modal */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Advanced Modal Examples</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">MultiSelect within Modal Dialog</h3>
+            <p className="text-gray-400 text-sm mb-4">This example shows how MultiSelect works inside a modal dialog.</p>
+            <Btn onClick={() => setIsModalOpen(true)}>Open Modal with MultiSelect</Btn>
+
+            <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} width={600}>
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6 border-b border-gray-600 pb-4">
+                  <h3 className="text-xl font-semibold text-white">Edit Tags</h3>
+                </div>
+
+                {/* Content */}
+                <div className="space-y-4 flex-1">
+                  <p className="text-gray-300 text-sm">Select or add tags for this item.</p>
+
+                  <MultiSelect
+                    selectedItems={modalMultiSelectValue}
+                    onSelectedItemsChanged={setModalMultiSelectValue}
+                    items={multiSelectItems}
+                    label="Item Tags"
+                    onNewItem={(item) => showToast(`New tag created: ${item}`, { type: 'success', title: 'Tag Created' })}
+                    onRemovedItem={(item) => showToast(`Removed tag: ${item}`, { type: 'info', title: 'Tag Removed' })}
+                    showEdit
+                    onEdit={(item) => showToast(`Edited tag: ${item}`, { type: 'info', title: 'Tag Edited' })}
+                  />
+
+                  <div className="text-xs text-gray-400 mt-2">
+                    Current selection: {modalMultiSelectValue.length > 0 ? modalMultiSelectValue.join(', ') : 'None'}
+                  </div>
+                </div>
+
+                {/* Footer */}
+                <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-600">
+                  <Btn onClick={() => setIsModalOpen(false)} color="bg-gray-600">
+                    Cancel
+                  </Btn>
+                  <Btn onClick={() => setIsModalOpen(false)} color="bg-blue-600">
+                    Save Changes
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </div>
+      </section>
+
       {/* Checkbox Components */}
       <section className="mb-12">
         <h2 className="text-2xl font-semibold mb-6 text-gray-400">Checkbox Components</h2>
@@ -793,6 +1038,10 @@ export default function ComponentsCatalogPage() {
             <li>
               <code className="bg-gray-700 px-2 py-1 rounded">ToastContainer.tsx</code> - Container component for managing multiple toast notifications
             </li>
+            <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">Modal.tsx</code> - Full-featured modal dialog component with portal rendering, animations, focus
+              management, and customizable styling
+            </li>
           </ul>
         </div>
       </section>
@@ -974,6 +1223,24 @@ export default function ComponentsCatalogPage() {
               </p>
               <p className="mb-2 text-sm text-gray-400">
                 Note: Global toast is automatically available in all pages. No need to include ToastContainer manually.
+              </p>
+            </div>
+            <div>
+              <h4 className="font-medium text-white mb-2">Modal Component</h4>
+              <p className="mb-2">
+                Import: <code className="bg-gray-700 px-2 py-1 rounded">import Modal from '@/components/modals/Modal'</code>
+              </p>
+              <p className="mb-2">
+                Props: <code className="bg-gray-700 px-2 py-1 rounded">isOpen</code>, <code className="bg-gray-700 px-2 py-1 rounded">onClose</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">children</code>, <code className="bg-gray-700 px-2 py-1 rounded">processing</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">persistent</code>, <code className="bg-gray-700 px-2 py-1 rounded">width</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">height</code>, <code className="bg-gray-700 px-2 py-1 rounded">zIndexClass</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">bgOpacityClass</code>, <code className="bg-gray-700 px-2 py-1 rounded">contentMarginTop</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">outerContent</code>
+              </p>
+              <p className="mb-2 text-sm text-gray-400">
+                Features: portal rendering, smooth animations, focus management, keyboard navigation (Escape), backdrop click to close, processing overlay,
+                persistent mode, customizable dimensions and styling
               </p>
             </div>
           </div>

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import Btn from '@/components/ui/Btn'
 import Checkbox from '@/components/ui/Checkbox'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
@@ -14,10 +14,11 @@ import InputDropdown from '@/components/ui/InputDropdown'
 import FileInput from '@/components/ui/FileInput'
 import LibraryIcon from '@/components/ui/LibraryIcon'
 import MediaIconPicker from '@/components/ui/MediaIconPicker'
-import MultiSelect from '@/components/ui/MultiSelect'
+import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
 import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import Modal from '@/components/modals/Modal'
+import TwoStageMultiSelect from '@/components/ui/TwoStageMultiSelect'
 
 export default function ComponentsCatalogPage() {
   const { showToast } = useGlobalToast()
@@ -53,7 +54,7 @@ export default function ComponentsCatalogPage() {
 
   // MultiSelect sample data
   const multiSelectItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
-  const [multiSelectValue, setMultiSelectValue] = useState<string[]>(['Apple', 'Banana'])
+  const [multiSelectValue, setMultiSelectValue] = useState<(string | MultiSelectItem)[]>(['Apple', 'Banana'])
 
   const multiSelectDropdownItems = [
     { text: 'Red', value: '#ff0000' },
@@ -62,7 +63,7 @@ export default function ComponentsCatalogPage() {
     { text: 'Yellow', value: '#ffff00' },
     { text: 'Purple', value: '#800080' }
   ]
-  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<string[]>(['#ff0000', '#0000ff'])
+  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<(string | MultiSelectItem)[]>(['#ff0000', '#0000ff'])
 
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -73,7 +74,7 @@ export default function ComponentsCatalogPage() {
   const [isPersistentModalOpen, setIsPersistentModalOpen] = useState(false)
   const [isCustomModalOpen, setIsCustomModalOpen] = useState(false)
   const [isProcessing, setIsProcessing] = useState(false)
-  const [modalMultiSelectValue, setModalMultiSelectValue] = useState<string[]>(['Cherry', 'Date'])
+  const [modalMultiSelectValue, setModalMultiSelectValue] = useState<(string | MultiSelectItem)[]>(['Cherry', 'Date'])
 
   // Dropdown change handlers
   const handleDropdownChange = (value: string | number) => {
@@ -451,7 +452,7 @@ export default function ComponentsCatalogPage() {
               items={multiSelectItems}
               label="Select Fruits"
               onNewItem={(item) => showToast(`New item created: ${item}`, { type: 'success', title: 'Item Created' })}
-              onRemovedItem={(item) => showToast(`Removed: ${item}`, { type: 'info', title: 'Item Removed' })}
+              onRemovedItem={(item) => showToast(`Removed: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Removed' })}
             />
           </div>
 
@@ -463,9 +464,9 @@ export default function ComponentsCatalogPage() {
               items={multiSelectItems}
               label="Select Fruits"
               onNewItem={(item) => showToast(`New item created: ${item}`, { type: 'success', title: 'Item Created' })}
-              onRemovedItem={(item) => showToast(`Removed: ${item}`, { type: 'info', title: 'Item Removed' })}
+              onRemovedItem={(item) => showToast(`Removed: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Removed' })}
               showEdit
-              onEdit={(item) => showToast(`Edited: ${item}`, { type: 'info', title: 'Item Edited' })}
+              onEdit={(item) => showToast(`Edited: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Edited' })}
             />
           </div>
 
@@ -493,7 +494,7 @@ export default function ComponentsCatalogPage() {
               onSelectedItemsChanged={setMultiSelectDropdownSelectedItems}
               items={multiSelectDropdownItems}
               label="Select Colors"
-              onRemovedItem={(item) => showToast(`Removed: ${item}`, { type: 'info', title: 'Item Removed' })}
+              onRemovedItem={(item) => showToast(`Removed: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Removed' })}
             />
           </div>
           <div className="bg-gray-800 p-6 rounded-lg">
@@ -707,13 +708,14 @@ export default function ComponentsCatalogPage() {
                     items={multiSelectItems}
                     label="Item Tags"
                     onNewItem={(item) => showToast(`New tag created: ${item}`, { type: 'success', title: 'Tag Created' })}
-                    onRemovedItem={(item) => showToast(`Removed tag: ${item}`, { type: 'info', title: 'Tag Removed' })}
+                    onRemovedItem={(item) => showToast(`Removed tag: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Tag Removed' })}
                     showEdit
-                    onEdit={(item) => showToast(`Edited tag: ${item}`, { type: 'info', title: 'Tag Edited' })}
+                    onEdit={(item) => showToast(`Edited tag: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Tag Edited' })}
                   />
 
                   <div className="text-xs text-gray-400 mt-2">
-                    Current selection: {modalMultiSelectValue.length > 0 ? modalMultiSelectValue.join(', ') : 'None'}
+                    Current selection:{' '}
+                    {modalMultiSelectValue.length > 0 ? modalMultiSelectValue.map((i) => (typeof i === 'string' ? i : i.text)).join(', ') : 'None'}
                   </div>
                 </div>
 

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -18,7 +18,6 @@ import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
 import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import Modal from '@/components/modals/Modal'
-import TwoStageMultiSelect from '@/components/ui/TwoStageMultiSelect'
 
 export default function ComponentsCatalogPage() {
   const { showToast } = useGlobalToast()

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -15,6 +15,7 @@ import FileInput from '@/components/ui/FileInput'
 import LibraryIcon from '@/components/ui/LibraryIcon'
 import MediaIconPicker from '@/components/ui/MediaIconPicker'
 import MultiSelect from '@/components/ui/MultiSelect'
+import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import Modal from '@/components/modals/Modal'
 
@@ -53,6 +54,15 @@ export default function ComponentsCatalogPage() {
   // MultiSelect sample data
   const multiSelectItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
   const [multiSelectValue, setMultiSelectValue] = useState<string[]>(['Apple', 'Banana'])
+
+  const multiSelectDropdownItems = [
+    { text: 'Red', value: '#ff0000' },
+    { text: 'Green', value: '#00ff00' },
+    { text: 'Blue', value: '#0000ff' },
+    { text: 'Yellow', value: '#ffff00' },
+    { text: 'Purple', value: '#800080' }
+  ]
+  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<string[]>(['#ff0000', '#0000ff'])
 
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -466,6 +476,33 @@ export default function ComponentsCatalogPage() {
               onSelectedItemsChanged={setMultiSelectValue}
               items={multiSelectItems}
               label="Select Fruits"
+              disabled
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* MultiSelectDropdown Components */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold mb-6 text-gray-400">MultiSelectDropdown Components</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Default MultiSelectDropdown</h3>
+            <MultiSelectDropdown
+              selectedItems={multiSelectDropdownSelectedItems}
+              onSelectedItemsChanged={setMultiSelectDropdownSelectedItems}
+              items={multiSelectDropdownItems}
+              label="Select Colors"
+              onRemovedItem={(item) => showToast(`Removed: ${item}`, { type: 'info', title: 'Item Removed' })}
+            />
+          </div>
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Disabled MultiSelectDropdown</h3>
+            <MultiSelectDropdown
+              selectedItems={multiSelectDropdownSelectedItems}
+              onSelectedItemsChanged={setMultiSelectDropdownSelectedItems}
+              items={multiSelectDropdownItems}
+              label="Select Colors"
               disabled
             />
           </div>
@@ -1033,6 +1070,10 @@ export default function ComponentsCatalogPage() {
               new item creation
             </li>
             <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">MultiSelectDropdown.tsx</code> - A multi-select component that uses a dropdown menu instead of a
+              text input.
+            </li>
+            <li>
               <code className="bg-gray-700 px-2 py-1 rounded">Toast.tsx</code> - Toast notification component with auto-dismiss, animations, and multiple types
             </li>
             <li>
@@ -1180,6 +1221,17 @@ export default function ComponentsCatalogPage() {
                 <code className="bg-gray-700 px-2 py-1 rounded">label</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
                 <code className="bg-gray-700 px-2 py-1 rounded">editable</code>, <code className="bg-gray-700 px-2 py-1 rounded">showAllWhenEmpty</code>,{' '}
                 <code className="bg-gray-700 px-2 py-1 rounded">onNewItem</code>, <code className="bg-gray-700 px-2 py-1 rounded">className</code>
+              </p>
+            </div>
+            <div>
+              <h4 className="font-medium text-white mb-2">MultiSelectDropdown Component</h4>
+              <p className="mb-2">
+                Import: <code className="bg-gray-700 px-2 py-1 rounded">import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'</code>
+              </p>
+              <p className="mb-2">
+                Props: <code className="bg-gray-700 px-2 py-1 rounded">value</code>, <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">items</code> (MultiSelectItem[]), <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
+                <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>
               </p>
             </div>
             <div>

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -14,6 +14,7 @@ import InputDropdown from '@/components/ui/InputDropdown'
 import FileInput from '@/components/ui/FileInput'
 import LibraryIcon from '@/components/ui/LibraryIcon'
 import MediaIconPicker from '@/components/ui/MediaIconPicker'
+import MultiSelect from '@/components/ui/MultiSelect'
 import { useGlobalToast } from '@/contexts/ToastContext'
 
 export default function ComponentsCatalogPage() {
@@ -47,6 +48,10 @@ export default function ComponentsCatalogPage() {
   const [inputDropdownValue, setInputDropdownValue] = useState('')
   const [inputDropdownValue2, setInputDropdownValue2] = useState('')
   const [inputDropdownValue3, setInputDropdownValue3] = useState('')
+
+  // MultiSelect sample data
+  const multiSelectItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
+  const [multiSelectValue, setMultiSelectValue] = useState<string[]>(['Apple', 'Banana'])
 
   // Dropdown change handlers
   const handleDropdownChange = (value: string | number) => {
@@ -398,6 +403,49 @@ export default function ComponentsCatalogPage() {
           <div className="bg-gray-800 p-6 rounded-lg">
             <h3 className="text-lg font-medium mb-4">Input Dropdown without Label</h3>
             <InputDropdown value={inputDropdownValue} onChange={handleInputDropdownChange} items={inputDropdownItems} />
+          </div>
+        </div>
+      </section>
+
+      {/* MultiSelect Components */}
+      <section className="mb-12">
+        <h2 className="text-2xl font-semibold mb-6 text-gray-400">MultiSelect Components</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Default MultiSelect</h3>
+            <MultiSelect
+              selectedItems={multiSelectValue}
+              onSelectedItemsChanged={setMultiSelectValue}
+              items={multiSelectItems}
+              label="Select Fruits"
+              onNewItem={(item) => showToast(`New item created: ${item}`, { type: 'success', title: 'Item Created' })}
+              onRemovedItem={(item) => showToast(`Removed: ${item}`, { type: 'info', title: 'Item Removed' })}
+            />
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">MultiSelect with Edit</h3>
+            <MultiSelect
+              selectedItems={multiSelectValue}
+              onSelectedItemsChanged={setMultiSelectValue}
+              items={multiSelectItems}
+              label="Select Fruits"
+              onNewItem={(item) => showToast(`New item created: ${item}`, { type: 'success', title: 'Item Created' })}
+              onRemovedItem={(item) => showToast(`Removed: ${item}`, { type: 'info', title: 'Item Removed' })}
+              showEdit
+              onEdit={(item) => showToast(`Edited: ${item}`, { type: 'info', title: 'Item Edited' })}
+            />
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Disabled MultiSelect</h3>
+            <MultiSelect
+              selectedItems={multiSelectValue}
+              onSelectedItemsChanged={setMultiSelectValue}
+              items={multiSelectItems}
+              label="Select Fruits"
+              disabled
+            />
           </div>
         </div>
       </section>

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -137,7 +137,7 @@ export default function Modal({
         onMouseUp={mouseupModal}
         cy-id="modal-content"
       >
-        <ModalProvider>{children}</ModalProvider>
+        <ModalProvider modalRef={wrapperRef as React.RefObject<HTMLDivElement>}>{children}</ModalProvider>
 
         {/* Processing overlay */}
         {processing && (

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import React, { useState, useRef, useEffect, useCallback, useMemo, ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { useClickOutside } from '@/hooks/useClickOutside'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
+import { mergeClasses } from '@/lib/merge-classes'
+import { ModalProvider } from '@/contexts/ModalContext'
+
+export interface ModalProps {
+  isOpen: boolean
+  processing?: boolean
+  persistent?: boolean
+  width?: string | number
+  height?: string | number
+  contentMarginTop?: number
+  zIndexClass?: string
+  bgOpacityClass?: string
+  children?: ReactNode
+  outerContent?: ReactNode
+  onClose?: () => void
+}
+
+export default function Modal({
+  isOpen,
+  processing = false,
+  persistent = false,
+  width = 500,
+  height = 'unset',
+  contentMarginTop = 50,
+  zIndexClass = 'z-50',
+  bgOpacityClass = 'bg-primary/75',
+  children,
+  outerContent,
+  onClose
+}: ModalProps) {
+  const [preventClickoutside, setPreventClickoutside] = useState(false)
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const dummyRef = useRef<HTMLDivElement>(null) // For useClickOutside trigger ref
+
+  const modalHeight = useMemo(() => {
+    if (typeof height === 'string') {
+      return height
+    }
+    return `${height}px`
+  }, [height])
+
+  const modalWidth = useMemo(() => {
+    if (typeof width === 'string') {
+      return width
+    }
+    return `${width}px`
+  }, [width])
+
+  const mousedownModal = useCallback(() => {
+    setPreventClickoutside(true)
+  }, [])
+
+  const mouseupModal = useCallback(() => {
+    setPreventClickoutside(false)
+  }, [])
+
+  const clickClose = useCallback(() => {
+    onClose?.()
+  }, [onClose])
+
+  const clickBg = useCallback(
+    (event: MouseEvent | React.MouseEvent) => {
+      if (!isOpen) return
+      if (preventClickoutside) {
+        setPreventClickoutside(false)
+        return
+      }
+      if (processing || persistent) return
+
+      const target = event.target as HTMLElement
+      if (target && target.classList.contains('modal-bg')) {
+        onClose?.()
+      }
+    },
+    [isOpen, preventClickoutside, processing, persistent, onClose]
+  )
+
+  const handleClickOutside = useCallback(() => {
+    if (!isOpen || preventClickoutside || processing || persistent) return
+    onClose?.()
+  }, [isOpen, preventClickoutside, processing, persistent, onClose])
+
+  // Use click outside hook
+  useClickOutside(contentRef, dummyRef, handleClickOutside)
+
+  if (!isOpen) {
+    return null
+  }
+
+  const modalContent = (
+    <div
+      ref={wrapperRef}
+      role="dialog"
+      aria-modal="true"
+      className={mergeClasses('modal modal-bg w-full h-full fixed top-0 left-0 items-center justify-center flex', zIndexClass, bgOpacityClass)}
+      onClick={clickBg}
+      cy-id="modal-wrapper"
+    >
+      {/* Background gradient */}
+      <div className="absolute inset-x-0 top-0 w-full h-36 bg-gradient-to-t from-transparent via-gray-900/50 to-gray-800/70 opacity-90 pointer-events-none" />
+
+      {/* Close button */}
+      <button
+        className="absolute top-4 right-4 landscape:top-4 landscape:right-4 md:portrait:top-5 md:portrait:right-5 lg:top-5 lg:right-5 inline-flex text-gray-200 hover:text-white z-10 transition-colors"
+        aria-label="Close modal"
+        onClick={clickClose}
+        cy-id="modal-close-button"
+      >
+        <span className="material-symbols text-2xl landscape:text-2xl md:portrait:text-4xl lg:text-4xl">close</span>
+      </button>
+
+      {/* Outer content slot */}
+      {outerContent}
+
+      {/* Main modal content */}
+      <div
+        ref={contentRef}
+        tabIndex={0}
+        style={{
+          minWidth: '380px',
+          minHeight: '200px',
+          maxWidth: '100vw',
+          height: modalHeight,
+          width: modalWidth,
+          marginTop: `${contentMarginTop}px`
+        }}
+        className="relative text-white outline-none focus:outline-none"
+        onMouseDown={mousedownModal}
+        onMouseUp={mouseupModal}
+        cy-id="modal-content"
+      >
+        <ModalProvider>{children}</ModalProvider>
+
+        {/* Processing overlay */}
+        {processing && (
+          <div className="absolute inset-0 w-full h-full bg-gray-900/60 rounded-lg flex items-center justify-center" cy-id="modal-processing-overlay">
+            <LoadingIndicator />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+
+  return createPortal(modalContent, document.body)
+}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -267,7 +267,6 @@ export default function Dropdown({
         dropdownId={dropdownId}
         onItemClick={(item) => handleOptionClick(item.value)}
         menuMaxHeight={menuMaxHeight}
-        className="-mt-px"
         showNoItemsMessage={false}
         ref={menuRef}
       />

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -12,6 +12,7 @@ export interface DropdownMenuItem {
 interface DropdownMenuProps {
   showMenu: boolean
   items: DropdownMenuItem[]
+  multiSelect?: boolean
   focusedIndex: number
   dropdownId: string
   onItemClick?: (item: DropdownMenuItem) => void
@@ -31,6 +32,7 @@ interface DropdownMenuProps {
 export default function DropdownMenu({
   showMenu,
   items,
+  multiSelect = false,
   focusedIndex,
   dropdownId,
   onItemClick,
@@ -108,6 +110,7 @@ export default function DropdownMenu({
           id={`${dropdownId}-listbox`}
           tabIndex={-1}
           style={{ maxHeight: menuMaxHeight }}
+          aria-multiselectable={multiSelect}
         >
           {menuItems}
           {showNoItemsMessage && !items.length && (

--- a/src/components/ui/InputDropdown.tsx
+++ b/src/components/ui/InputDropdown.tsx
@@ -266,7 +266,7 @@ export default function InputDropdown({
           showSelectedIndicator={true}
           noItemsText="No items"
           menuMaxHeight="224px"
-          className="mt-0 z-50"
+          className="z-50"
           showNoItemsMessage={true}
           ref={menuRef}
         />

--- a/src/components/ui/MediaIconPicker.tsx
+++ b/src/components/ui/MediaIconPicker.tsx
@@ -214,7 +214,7 @@ export default function MediaIconPicker({ value, disabled = false, label = 'Icon
           id={listboxId}
           role="listbox"
           aria-label={`${label} options`}
-          className={`absolute z-10 -mt-px bg-primary border border-black-200 shadow-lg max-h-56 w-48 rounded-md py-1 overflow-auto focus:outline-hidden sm:text-sm ${getMenuAlignmentClasses()}`}
+          className={`absolute z-10 mt-0.5 bg-primary border border-black-200 shadow-lg max-h-56 w-48 rounded-md py-1 overflow-auto focus:outline-hidden sm:text-sm ${getMenuAlignmentClasses()}`}
           onKeyDown={handleKeyDown}
         >
           <div className="flex justify-center items-center flex-wrap">

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -622,6 +622,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           noItemsText="No items"
           menuMaxHeight="224px"
           className="z-60"
+          triggerRef={inputWrapperRef as React.RefObject<HTMLElement>}
         />
       </div>
     </div>

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -472,7 +472,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
           role="list"
           style={{ minHeight: 36 }}
           className={mergeClasses(
-            'flex-wrap relative w-full shadow-xs flex items-center border border-gray-600 rounded-sm px-2 py-1',
+            'flex-wrap relative w-full shadow-xs flex items-center border border-gray-600 rounded-sm px-2 py-1 focus-within:outline',
             disabled ? 'bg-black-300 text-gray-400 cursor-not-allowed' : 'bg-primary cursor-text'
           )}
           onClick={handleInputWrapperClick}

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -1,0 +1,538 @@
+import React, { useState, useRef, useEffect, useCallback, useId, useMemo } from 'react'
+import DropdownMenu from './DropdownMenu'
+import type { DropdownMenuItem } from './DropdownMenu'
+import { mergeClasses } from '@/lib/merge-classes'
+
+interface MultiSelectProps {
+  selectedItems: string[]
+  items: string[]
+  label?: string
+  disabled?: boolean
+  showEdit?: boolean
+  menuDisabled?: boolean
+  onSelectedItemsChanged: (val: string[]) => void
+  onEdit?: (item: string) => void
+  onRemovedItem?: (item: string) => void
+  onNewItem?: (item: string) => void
+}
+
+export const MultiSelect: React.FC<MultiSelectProps> = ({
+  selectedItems = [],
+  items,
+  label,
+  disabled = false,
+  showEdit = false,
+  menuDisabled = false,
+  onSelectedItemsChanged,
+  onEdit,
+  onRemovedItem,
+  onNewItem
+}) => {
+  const [textInput, setTextInput] = useState<string | null>(null)
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [filteredItems, setFilteredItems] = useState<string[] | null>(null)
+  // focusIndex: null = none, >=0 = dropdown item, <0 = pill (e.g. -1 = last pill)
+  const [focusIndex, setFocusIndex] = useState<number | null>(null)
+  const identifier = useId()
+
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const inputWrapperRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  const showMenu = isMenuOpen && !menuDisabled
+
+  const itemsToShow = useMemo(() => {
+    return !textInput || !filteredItems ? items : filteredItems
+  }, [textInput, filteredItems, items])
+
+  const dropdownItems: DropdownMenuItem[] = useMemo(() => {
+    return itemsToShow.map((item, idx) => ({
+      text: String(item),
+      value: item
+    }))
+  }, [itemsToShow])
+
+  const openMenu = useCallback((index: number | null) => {
+    setIsMenuOpen(true)
+    setFocusIndex(index)
+  }, [])
+
+  const closeMenu = useCallback(() => {
+    setIsMenuOpen(false)
+    setFocusIndex(null)
+  }, [])
+
+  const resetInput = useCallback(() => {
+    setTextInput(null)
+    setFocusIndex(null)
+  }, [])
+
+  // Search logic with debouncing
+  useEffect(() => {
+    // Only search if the input is focused
+    if (document.activeElement !== inputRef.current) return
+
+    // Clear existing timeout
+    if (typingTimeoutRef.current) {
+      clearTimeout(typingTimeoutRef.current)
+    }
+
+    // Set new timeout to wait for user to stop typing
+    const newTimeout = setTimeout(() => {
+      openMenu(null)
+      if (!textInput) {
+        setFilteredItems(null)
+      } else {
+        const results = items.filter((i) => String(i).toLowerCase().includes(textInput.toLowerCase()))
+        setFilteredItems(results || [])
+      }
+    }, 200)
+
+    typingTimeoutRef.current = newTimeout
+
+    // Cleanup function to clear timeout on unmount or dependency change
+    return () => {
+      if (newTimeout) {
+        clearTimeout(newTimeout)
+      }
+    }
+  }, [textInput, items, openMenu])
+
+  // Keyboard navigation for dropdown menu
+  const menuNavigationHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return
+    const itemCount = dropdownItems.length
+    const pillCount = selectedItems.length
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault()
+        if (!isMenuOpen) {
+          openMenu(0)
+        } else {
+          setFocusIndex((prev) => {
+            if (prev == null || prev < 0) return 0
+            return prev < itemCount - 1 ? prev + 1 : prev
+          })
+        }
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        if (!isMenuOpen) {
+          openMenu(itemCount - 1)
+        } else {
+          setFocusIndex((prev) => {
+            if (prev == null || prev < 0) return itemCount - 1
+            return prev > 0 ? prev - 1 : prev
+          })
+        }
+        break
+      }
+      case 'Enter': {
+        e.preventDefault()
+        if (focusIndex !== null && focusIndex >= 0 && focusIndex < itemCount) {
+          handleDropdownItemClick(dropdownItems[focusIndex])
+        } else if (focusIndex !== null && focusIndex < 0) {
+          const pillIdx = selectedItems.length + focusIndex
+          if (pillIdx >= 0 && selectedItems[pillIdx]) {
+            if (showEdit) {
+              onEdit?.(selectedItems[pillIdx])
+            }
+          }
+        } else if (textInput) {
+          submitForm()
+        }
+        break
+      }
+      case 'Escape': {
+        e.preventDefault()
+        closeMenu()
+        // Do NOT blur the input here
+        break
+      }
+      case 'Home': {
+        e.preventDefault()
+        openMenu(0)
+        break
+      }
+      case 'End': {
+        e.preventDefault()
+        openMenu(itemCount - 1)
+        break
+      }
+      case 'Tab': {
+        closeMenu()
+        inputRef.current?.blur()
+        break
+      }
+      case 'ArrowLeft': {
+        if (!textInput && pillCount > 0) {
+          e.preventDefault()
+          setFocusIndex((prev) => {
+            // If not on a pill, go to last pill
+            if (prev == null || prev >= 0) return -1
+            // If on a pill, go to previous pill (more negative)
+            if (Math.abs(prev) < pillCount) return prev - 1
+            return prev
+          })
+        }
+        break
+      }
+      case 'ArrowRight': {
+        if (!textInput && pillCount > 0) {
+          e.preventDefault()
+          setFocusIndex((prev) => {
+            // If not on a pill, stay on input
+            if (prev == null || prev >= 0) return null
+            // If on a pill, move right (less negative)
+            if (prev < -1) return prev + 1
+            // If at -1 (last pill), move to input
+            return null
+          })
+        }
+        break
+      }
+      case 'Backspace': {
+        if (focusIndex !== null && focusIndex < 0) {
+          const pillIdx = selectedItems.length + focusIndex
+          if (pillIdx >= 0 && selectedItems[pillIdx]) {
+            removeItem(selectedItems[pillIdx])
+            setFocusIndex((prev) => {
+              if (prev === null) return null
+              // If there are still pills to the left, stay on the previous pill
+              if (Math.abs(prev) < selectedItems.length) return prev - 1
+              // Otherwise, unfocus
+              return null
+            })
+          }
+        } else if (!textInput && selectedItems.length > 0) {
+          removeItem(selectedItems[selectedItems.length - 1])
+        }
+        break
+      }
+      case 'Delete': {
+        if (focusIndex !== null && focusIndex < 0) {
+          const pillIdx = selectedItems.length + focusIndex
+          if (pillIdx >= 0 && selectedItems[pillIdx]) {
+            removeItem(selectedItems[pillIdx])
+            setFocusIndex((prev) => {
+              if (prev === null) return null
+              if (Math.abs(prev) < selectedItems.length) return prev - 1
+              return null
+            })
+          }
+        }
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  const addPastedItems = useCallback(
+    (pastedItems: string[]) => {
+      const itemsToAdd = pastedItems
+        .filter((item) => !selectedItems.some((i) => i.toLowerCase() === item.toLowerCase()))
+        .map((item) => {
+          const itemExists = items.find((i) => i.toLowerCase() === item.toLowerCase())
+          return itemExists || item
+        })
+      if (itemsToAdd.length) {
+        onSelectedItemsChanged([...selectedItems, ...itemsToAdd])
+        itemsToAdd.forEach((item) => {
+          const itemExists = items.find((i) => i.toLowerCase() === item.toLowerCase())
+          if (!itemExists) {
+            onNewItem?.(item)
+          }
+        })
+        resetInput()
+      }
+    },
+    [selectedItems, onSelectedItemsChanged, onNewItem, items, resetInput]
+  )
+
+  const inputPaste = useCallback(
+    (e: React.ClipboardEvent<HTMLInputElement>) => {
+      const pastedText = e.clipboardData?.getData('text') || ''
+      const pastedItems = [
+        ...new Set(
+          pastedText
+            .split(';')
+            .map((i) => i.trim())
+            .filter((i) => i)
+        )
+      ]
+      addPastedItems(pastedItems)
+      e.preventDefault()
+    },
+    [selectedItems, addPastedItems]
+  )
+
+  // Option click
+  const addSelectedItem = useCallback(
+    (itemValue: string) => {
+      let newSelected: string[]
+      if (selectedItems.includes(itemValue)) {
+        //newSelected = selectedItems.filter((s) => s !== itemValue)
+        //onRemovedItem?.(itemValue)
+        return
+      } else {
+        newSelected = selectedItems.concat([itemValue])
+      }
+      resetInput()
+      onSelectedItemsChanged(newSelected)
+    },
+    [selectedItems, onSelectedItemsChanged, resetInput]
+  )
+
+  // Handle dropdown menu item click
+  const handleDropdownItemClick = useCallback(
+    (item: DropdownMenuItem) => {
+      addSelectedItem(String(item.value))
+    },
+    [addSelectedItem]
+  )
+
+  // Check if item is selected
+  const isItemSelected = useCallback(
+    (item: DropdownMenuItem) => {
+      return selectedItems.includes(String(item.value))
+    },
+    [selectedItems]
+  )
+
+  // Remove item
+  const removeItem = useCallback(
+    (item: string) => {
+      const remaining = selectedItems.filter((i) => i !== item)
+      onSelectedItemsChanged(remaining)
+      onRemovedItem?.(item)
+    },
+    [selectedItems, onSelectedItemsChanged, onRemovedItem]
+  )
+
+  // Insert new item
+  const insertNewItem = useCallback(
+    (item: string) => {
+      const newSelected = [...selectedItems, item]
+      onSelectedItemsChanged(newSelected)
+      onNewItem?.(item)
+      resetInput()
+    },
+    [selectedItems, onSelectedItemsChanged, onNewItem, resetInput]
+  )
+
+  // Submit form
+  const submitForm = useCallback(() => {
+    if (!textInput) return
+    const cleaned = textInput.trim()
+    if (!cleaned) {
+      resetInput()
+    } else {
+      const matchedItem = items.find((i) => i === cleaned)
+      if (matchedItem) {
+        addSelectedItem(matchedItem)
+      } else {
+        insertNewItem(cleaned)
+      }
+    }
+    if (inputRef.current) inputRef.current.style.width = '24px'
+  }, [textInput, items, addSelectedItem, insertNewItem, resetInput])
+
+  // Focus/blur logic
+  const inputFocus = useCallback(() => {
+    openMenu(null)
+  }, [openMenu])
+
+  const inputBlur = useCallback(() => {
+    if (!isMenuOpen) return
+    setTimeout(() => {
+      if (document.activeElement === inputRef.current) return
+      closeMenu()
+      if (textInput) submitForm()
+    }, 50)
+  }, [isMenuOpen, textInput, submitForm, closeMenu])
+
+  // Clean up on unmount
+  useEffect(() => {
+    return () => {
+      // Clear any pending search timeout
+      if (typingTimeoutRef.current) {
+        clearTimeout(typingTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  // Handle input changes
+  const handleInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setFocusIndex(null)
+    setTextInput(e.target.value)
+  }, [])
+
+  // Reset pill focus on input change or click
+  useEffect(() => {
+    if (focusIndex !== null && focusIndex < 0) setFocusIndex(null)
+  }, [textInput])
+
+  // Compute the id of the currently focused descendant for aria-activedescendant
+  let activeDescendantId: string | undefined = undefined
+  if (focusIndex !== null) {
+    if (focusIndex < 0) {
+      // pill
+      const pillIdx = selectedItems.length + focusIndex
+      if (pillIdx >= 0) activeDescendantId = `${identifier}-pill-${pillIdx}`
+    } else {
+      // menu item
+      activeDescendantId = `${identifier}-menuitem-${focusIndex}`
+    }
+  }
+
+  const focusPill = useCallback(
+    (idx: number) => {
+      if (!disabled) {
+        // Focus input first, then set focus index
+        inputRef.current?.focus()
+        setFocusIndex(idx - selectedItems.length)
+      }
+    },
+    [disabled, selectedItems]
+  )
+
+  const handlePillClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>, idx: number) => {
+      e.stopPropagation()
+      e.preventDefault()
+      focusPill(idx)
+    },
+    [focusPill]
+  )
+
+  // Handler for input wrapper click
+  const handleInputWrapperClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!disabled) {
+        inputRef.current?.focus()
+      }
+    },
+    [disabled]
+  )
+
+  return (
+    <div className="w-full">
+      {label && (
+        <label htmlFor={identifier} className={`px-1 text-sm font-semibold ${disabled ? 'text-gray-400' : ''}`}>
+          {label}
+        </label>
+      )}
+      <div ref={wrapperRef} className="relative">
+        <div
+          ref={inputWrapperRef}
+          role="list"
+          style={{ minHeight: 36 }}
+          className={mergeClasses(
+            'flex-wrap relative w-full shadow-xs flex items-center border border-gray-600 rounded-sm px-2 py-1',
+            disabled ? 'bg-black-300 text-gray-400 cursor-not-allowed' : 'bg-primary cursor-text'
+          )}
+          onClick={handleInputWrapperClick}
+          onMouseDown={(e) => e.preventDefault()}
+        >
+          {selectedItems.map((item, idx) => (
+            <div
+              key={item}
+              id={`${identifier}-pill-${idx}`}
+              role="listitem"
+              className={mergeClasses(
+                'rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center justify-center relative',
+                !disabled && focusIndex === idx - selectedItems.length ? 'ring z-10' : ''
+              )}
+              style={{ minWidth: showEdit ? 44 : 22 }}
+              tabIndex={-1}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={(e) => handlePillClick(e, idx)}
+            >
+              {!disabled && (
+                <div
+                  className={mergeClasses(
+                    'w-full h-full rounded-full absolute top-0 left-0 px-1 bg-bg/75 flex items-center justify-end opacity-0 hover:opacity-100'
+                  )}
+                >
+                  {showEdit && (
+                    <button
+                      type="button"
+                      aria-label="Edit"
+                      className="material-symbols text-white hover:text-warning cursor-pointer"
+                      style={{ fontSize: '1.1rem' }}
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={(e) => {
+                        e.preventDefault()
+                        onEdit?.(item)
+                      }}
+                      tabIndex={-1}
+                    >
+                      edit
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    aria-label="Remove"
+                    className="material-symbols text-white hover:text-error focus:text-error cursor-pointer"
+                    style={{ fontSize: '1.1rem' }}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      removeItem(item)
+                    }}
+                    tabIndex={-1}
+                  >
+                    close
+                  </button>
+                </div>
+              )}
+              {item}
+            </div>
+          ))}
+          {!disabled && (
+            <input
+              value={textInput ?? ''}
+              ref={inputRef}
+              id={identifier}
+              disabled={disabled}
+              className="bg-transparent border-none outline-none px-1 flex-1 min-w-6 text-sm"
+              autoComplete="off"
+              onKeyDown={menuNavigationHandler}
+              onFocus={inputFocus}
+              onBlur={inputBlur}
+              onPaste={inputPaste}
+              onChange={handleInputChange}
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={showMenu}
+              aria-controls={`${identifier}-listbox`}
+              aria-haspopup="listbox"
+              aria-disabled={disabled}
+              aria-activedescendant={activeDescendantId}
+            />
+          )}
+        </div>
+        <DropdownMenu
+          showMenu={showMenu}
+          items={dropdownItems}
+          multiSelect={true}
+          focusedIndex={focusIndex !== null && focusIndex >= 0 ? focusIndex : -1}
+          dropdownId={identifier}
+          onItemClick={handleDropdownItemClick}
+          isItemSelected={isItemSelected}
+          showSelectedIndicator={true}
+          showNoItemsMessage={true}
+          noItemsText="No items"
+          menuMaxHeight="224px"
+          className="z-60"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default MultiSelect

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -140,9 +140,6 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   const isDuplicate = useCallback(
     (itemValue: string) => {
       const isDupe = selectedItemValues.some((v) => v.toLowerCase() === itemValue.toLowerCase())
-      if (isDupe) {
-        showToast(`Item ${itemValue} has already been selected.`, { type: 'warning', title: 'Item already selected' })
-      }
       return isDupe
     },
     [selectedItemValues, showToast]
@@ -151,6 +148,7 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
   const addSelectedItem = useCallback(
     (itemValue: string) => {
       if (isDuplicate(itemValue)) {
+        removeItem(itemValue)
         resetInput()
         return
       }

--- a/src/components/ui/MultiSelectDropdown.tsx
+++ b/src/components/ui/MultiSelectDropdown.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import MultiSelect, { type MultiSelectProps } from './MultiSelect'
+
+type MultiSelectDropdownProps = Omit<MultiSelectProps, 'showInput' | 'allowNew' | 'onNewItem'>
+
+const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({ ...rest }) => {
+  return <MultiSelect showInput={false} allowNew={false} {...rest} />
+}
+
+export default MultiSelectDropdown

--- a/src/components/ui/Pill.tsx
+++ b/src/components/ui/Pill.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { mergeClasses } from '@/lib/merge-classes'
+import { MultiSelectItem } from './MultiSelect'
 
 interface PillProps {
-  item: string
+  item: MultiSelectItem
   id: string
   isFocused: boolean
   disabled: boolean
   showEdit: boolean
   onClick: (e: React.MouseEvent<HTMLDivElement>) => void
   onEdit?: (item: string) => void
-  onRemove: (item: string) => void
+  onRemove: (item: MultiSelectItem) => void
 }
 
 export const Pill: React.FC<PillProps> = ({ item, id, isFocused, disabled, showEdit, onClick, onEdit, onRemove }) => {
@@ -39,7 +40,7 @@ export const Pill: React.FC<PillProps> = ({ item, id, isFocused, disabled, showE
               onMouseDown={(e) => e.preventDefault()}
               onClick={(e) => {
                 e.preventDefault()
-                onEdit?.(item)
+                onEdit?.(item.value)
               }}
               tabIndex={-1}
             >
@@ -62,7 +63,7 @@ export const Pill: React.FC<PillProps> = ({ item, id, isFocused, disabled, showE
           </button>
         </div>
       )}
-      {item}
+      {item.text}
     </div>
   )
 }

--- a/src/components/ui/Pill.tsx
+++ b/src/components/ui/Pill.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+
+interface PillProps {
+  item: string
+  id: string
+  isFocused: boolean
+  disabled: boolean
+  showEdit: boolean
+  onClick: (e: React.MouseEvent<HTMLDivElement>) => void
+  onEdit?: (item: string) => void
+  onRemove: (item: string) => void
+}
+
+export const Pill: React.FC<PillProps> = ({ item, id, isFocused, disabled, showEdit, onClick, onEdit, onRemove }) => {
+  return (
+    <div
+      id={id}
+      role="listitem"
+      className={mergeClasses(
+        'rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center justify-center relative',
+        !disabled && isFocused ? 'ring z-10' : ''
+      )}
+      style={{ minWidth: showEdit ? 44 : 22 }}
+      tabIndex={-1}
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onClick}
+    >
+      {!disabled && (
+        <div
+          className={mergeClasses('w-full h-full rounded-full absolute top-0 left-0 px-1 bg-bg/75 flex items-center justify-end opacity-0 hover:opacity-100')}
+        >
+          {showEdit && (
+            <button
+              type="button"
+              aria-label="Edit"
+              className="material-symbols text-white hover:text-warning cursor-pointer"
+              style={{ fontSize: '1.1rem' }}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={(e) => {
+                e.preventDefault()
+                onEdit?.(item)
+              }}
+              tabIndex={-1}
+            >
+              edit
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Remove"
+            className="material-symbols text-white hover:text-error focus:text-error cursor-pointer"
+            style={{ fontSize: '1.1rem' }}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={(e) => {
+              e.stopPropagation()
+              onRemove(item)
+            }}
+            tabIndex={-1}
+          >
+            close
+          </button>
+        </div>
+      )}
+      {item}
+    </div>
+  )
+}
+
+export default Pill

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,11 +1,23 @@
 'use client'
 
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, RefObject } from 'react'
 
-const ModalContext = createContext(false)
+interface ModalContextType {
+  modalRef: RefObject<HTMLDivElement> | null
+}
 
-export const useIsInsideModal = () => useContext(ModalContext)
+const ModalContext = createContext<ModalContextType>({
+  modalRef: null
+})
 
-export const ModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  return <ModalContext.Provider value={true}>{children}</ModalContext.Provider>
+export const useModalRef = () => {
+  const context = useContext(ModalContext)
+  return context.modalRef
+}
+
+export const ModalProvider: React.FC<{
+  children: React.ReactNode
+  modalRef: RefObject<HTMLDivElement>
+}> = ({ children, modalRef }) => {
+  return <ModalContext.Provider value={{ modalRef }}>{children}</ModalContext.Provider>
 }

--- a/src/contexts/ModalContext.tsx
+++ b/src/contexts/ModalContext.tsx
@@ -1,0 +1,11 @@
+'use client'
+
+import React, { createContext, useContext } from 'react'
+
+const ModalContext = createContext(false)
+
+export const useIsInsideModal = () => useContext(ModalContext)
+
+export const ModalProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <ModalContext.Provider value={true}>{children}</ModalContext.Provider>
+}

--- a/src/hooks/useMenuPosition.ts
+++ b/src/hooks/useMenuPosition.ts
@@ -1,0 +1,116 @@
+import { useCallback, useRef, useEffect, RefObject } from 'react'
+
+interface MenuPosition {
+  top: string
+  left: string
+  width: string
+}
+
+interface UseMenuPositionOptions {
+  triggerRef: RefObject<HTMLElement>
+  menuRef: RefObject<HTMLElement>
+  isOpen: boolean
+  onPositionChange: (position: MenuPosition) => void
+  onClose?: () => void
+  disable?: boolean
+}
+
+/**
+ * Hook to calculate and manage menu positioning relative to a trigger element
+ */
+export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange, onClose, disable = false }: UseMenuPositionOptions): (() => void) => {
+  if (disable) return () => {}
+
+  const positionRef = useRef<MenuPosition>({} as MenuPosition)
+  const menuHeightRef = useRef<number>(0)
+  const triggerWidthRef = useRef<number>(0)
+  const triggerHeightRef = useRef<number>(0)
+  const menuObserverRef = useRef<ResizeObserver | null>(null)
+  const triggerObserverRef = useRef<ResizeObserver | null>(null)
+
+  const recalcMenuPos = useCallback(
+    (event?: Event) => {
+      if (!menuRef.current || !triggerRef.current) {
+        return
+      }
+
+      const triggerBoundingBox = triggerRef.current.getBoundingClientRect()
+
+      const left = `${triggerBoundingBox.x}px`
+      const width = `${triggerBoundingBox.width}px`
+      const top = `${triggerBoundingBox.bottom + window.scrollY}px`
+
+      // Always position below trigger for now
+      const position: MenuPosition = { top, left, width }
+
+      // Only update if position has changed
+      if (position.top !== positionRef.current.top || position.left !== positionRef.current.left || position.width !== positionRef.current.width) {
+        positionRef.current = position
+        onPositionChange(position)
+      }
+    },
+    [onPositionChange, onClose, menuRef, triggerRef]
+  )
+
+  // Set up event listeners and ResizeObserver when menu is open
+  useEffect(() => {
+    if (isOpen) {
+      const handleScroll = (event: Event): void => {
+        // Check if the scroll event originated from within the menu
+        if (menuRef.current && event.target && !menuRef.current.contains(event.target as Node)) {
+          recalcMenuPos(event)
+        }
+      }
+
+      window.addEventListener('resize', recalcMenuPos)
+      window.addEventListener('scroll', handleScroll, true)
+
+      // Set up ResizeObserver to track menu height changes
+      if (menuRef.current) {
+        menuObserverRef.current = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+          for (const entry of entries) {
+            const newHeight = entry.borderBoxSize[0]?.blockSize || entry.target.clientHeight
+            if (newHeight !== menuHeightRef.current) {
+              menuHeightRef.current = newHeight
+              recalcMenuPos()
+            }
+          }
+        })
+        menuObserverRef.current.observe(menuRef.current)
+      }
+
+      if (triggerRef.current) {
+        triggerObserverRef.current = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+          for (const entry of entries) {
+            const newWidth = entry.borderBoxSize[0]?.inlineSize || entry.target.clientWidth
+            const newHeight = entry.borderBoxSize[0]?.blockSize || entry.target.clientHeight
+
+            // Check if either width or height changed
+            if (newWidth !== triggerWidthRef.current || newHeight !== triggerHeightRef.current) {
+              triggerWidthRef.current = newWidth
+              triggerHeightRef.current = newHeight
+              recalcMenuPos()
+            }
+          }
+        })
+        triggerObserverRef.current.observe(triggerRef.current)
+      }
+
+      // Initial position calculation
+      recalcMenuPos()
+
+      return () => {
+        window.removeEventListener('resize', recalcMenuPos)
+        window.removeEventListener('scroll', handleScroll, true)
+        if (menuObserverRef.current) {
+          menuObserverRef.current.disconnect()
+        }
+        if (triggerObserverRef.current) {
+          triggerObserverRef.current.disconnect()
+        }
+      }
+    }
+  }, [isOpen, recalcMenuPos, menuRef, triggerRef])
+
+  return recalcMenuPos
+}

--- a/src/hooks/useMenuPosition.ts
+++ b/src/hooks/useMenuPosition.ts
@@ -13,12 +13,21 @@ interface UseMenuPositionOptions {
   onPositionChange: (position: MenuPosition) => void
   onClose?: () => void
   disable?: boolean
+  portalContainerRef?: RefObject<HTMLElement>
 }
 
 /**
  * Hook to calculate and manage menu positioning relative to a trigger element
  */
-export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange, onClose, disable = false }: UseMenuPositionOptions): (() => void) => {
+export const useMenuPosition = ({
+  triggerRef,
+  menuRef,
+  isOpen,
+  onPositionChange,
+  onClose,
+  disable = false,
+  portalContainerRef
+}: UseMenuPositionOptions): (() => void) => {
   if (disable) return () => {}
 
   const positionRef = useRef<MenuPosition>({} as MenuPosition)
@@ -27,6 +36,7 @@ export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange,
   const triggerHeightRef = useRef<number>(0)
   const menuObserverRef = useRef<ResizeObserver | null>(null)
   const triggerObserverRef = useRef<ResizeObserver | null>(null)
+  const portalObserverRef = useRef<ResizeObserver | null>(null)
 
   const recalcMenuPos = useCallback(
     (event?: Event) => {
@@ -35,10 +45,19 @@ export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange,
       }
 
       const triggerBoundingBox = triggerRef.current.getBoundingClientRect()
-
-      const left = `${triggerBoundingBox.x}px`
+      let left: string, top: string
       const width = `${triggerBoundingBox.width}px`
-      const top = `${triggerBoundingBox.bottom + window.scrollY}px`
+
+      if (portalContainerRef?.current) {
+        const portalRect = portalContainerRef.current.getBoundingClientRect()
+        // Position relative to the portal container
+        left = `${triggerBoundingBox.left - portalRect.left + portalContainerRef.current.scrollLeft}px`
+        top = `${triggerBoundingBox.bottom - portalRect.top + portalContainerRef.current.scrollTop}px`
+      } else {
+        // Position relative to the window/document
+        left = `${triggerBoundingBox.x}px`
+        top = `${triggerBoundingBox.bottom + window.scrollY}px`
+      }
 
       // Always position below trigger for now
       const position: MenuPosition = { top, left, width }
@@ -49,12 +68,13 @@ export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange,
         onPositionChange(position)
       }
     },
-    [onPositionChange, onClose, menuRef, triggerRef]
+    [onPositionChange, onClose, menuRef, triggerRef, portalContainerRef]
   )
 
   // Set up event listeners and ResizeObserver when menu is open
   useEffect(() => {
     if (isOpen) {
+      const scrollTarget = portalContainerRef?.current || window
       const handleScroll = (event: Event): void => {
         // Check if the scroll event originated from within the menu
         if (menuRef.current && event.target && !menuRef.current.contains(event.target as Node)) {
@@ -63,7 +83,7 @@ export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange,
       }
 
       window.addEventListener('resize', recalcMenuPos)
-      window.addEventListener('scroll', handleScroll, true)
+      scrollTarget.addEventListener('scroll', handleScroll, true)
 
       // Set up ResizeObserver to track menu height changes
       if (menuRef.current) {
@@ -96,21 +116,31 @@ export const useMenuPosition = ({ triggerRef, menuRef, isOpen, onPositionChange,
         triggerObserverRef.current.observe(triggerRef.current)
       }
 
+      if (portalContainerRef?.current) {
+        portalObserverRef.current = new ResizeObserver(() => {
+          recalcMenuPos()
+        })
+        portalObserverRef.current.observe(portalContainerRef.current)
+      }
+
       // Initial position calculation
       recalcMenuPos()
 
       return () => {
         window.removeEventListener('resize', recalcMenuPos)
-        window.removeEventListener('scroll', handleScroll, true)
+        scrollTarget.removeEventListener('scroll', handleScroll, true)
         if (menuObserverRef.current) {
           menuObserverRef.current.disconnect()
         }
         if (triggerObserverRef.current) {
           triggerObserverRef.current.disconnect()
         }
+        if (portalObserverRef.current) {
+          portalObserverRef.current.disconnect()
+        }
       }
     }
-  }, [isOpen, recalcMenuPos, menuRef, triggerRef])
+  }, [isOpen, recalcMenuPos, menuRef, triggerRef, portalContainerRef])
 
   return recalcMenuPos
 }


### PR DESCRIPTION
This migrates ui/MultiSelect and modals/Modal.

Features:
- MultiSelect support with improved keyboard navigation
   - Support existing keys +
      - Left/right arrow for pill navigation
      - Backspace/Delete on highlighted pill deletes pill and moves highlight left/right
      - Enter on highlighted pill calls onEdit if showEdit is true
      - Backspace when no pill is highlighted and input is empty deletes the last pill
      - Escape closes menu
      - Tab/Shift+Tab moves to next/previous component
      - Home/End highlights first/last menu item
   - Native focus _always_ remains on the input
      - Visual focus (highlight) is moved with keyboard navigation between pills and menu-items.
      - Aria-activedescendat points to the highlighted pill/menu-item
   - Aria attributes and roles are properly set
   - Pill refactored into separate component
   - Uses DropdownMenu
   - Similar styling to other dropdown components
- DropdownMenu now supports createPortal
   - However MultiSelect currently uses non-portal version
      - Seems like non-portal version can be used in Modal with no clipping, _please verify_
   - useMenuPosition added to tracj trigger position/width and update menu position/width
   - Added 2px spacing between dropdown and trigger elements in all dropdown components
      - Reason: not to obstruct trigger's focus outline.
   - Fixed a couple of scrolling issues (using wheel and drag-n-drop)
- Migrated a slightly dumbed down version of Modal to test component behavior in a modal
   - ModalContext provider allows components to know if they're inside a modal.
- Added MultiSelect and Modal examples to component catalog
   - Included an example of MultiSelect inside a modal

New functionality is still not well tested. This is mostly to show progress and request for comments at this point.