### PR TITLE
Make Pill editable inline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/react-transition-group": "^4.4.12",
-        "cypress": "^14.5.0",
+        "cypress": "^14.5.3",
         "cypress-plugin-tab": "^1.0.5",
         "cypress-real-events": "^1.14.0",
         "tailwindcss": "^4",
@@ -67,9 +67,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.8.tgz",
-      "integrity": "sha512-h0NFgh1mJmm1nr4jCwkGHwKneVYKghUyWe6TMNrk0B9zsjAJxpg8C4/+BAcmLgCPa1vj1V8rNUaILl+zYRUWBQ==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
+      "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -79,7 +79,7 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~4.0.0",
+        "form-data": "~4.0.4",
         "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -1754,14 +1754,14 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.0.tgz",
-      "integrity": "sha512-1HOnKvWep0LkWuFwPeWkZ0TDl7ivi2/Mz+WNU4dfkeLJaFndS3Ow6TXT7YjuTqLFI2peJKzPKljVUFdymI2K5g==",
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.3.tgz",
+      "integrity": "sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.8",
+        "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/react-transition-group": "^4.4.12",
-    "cypress": "^14.5.0",
+    "cypress": "^14.5.3",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-real-events": "^1.14.0",
     "tailwindcss": "^4",

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -18,7 +18,6 @@ import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
 import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import Modal from '@/components/modals/Modal'
-import TwoStageMultiSelect from '@/components/ui/TwoStageMultiSelect'
 
 export default function ComponentsCatalogPage() {
   const { showToast } = useGlobalToast()
@@ -596,16 +595,6 @@ export default function ComponentsCatalogPage() {
               items={multiSelectItems}
               label="Select Fruits"
               disabled
-            />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Two-Stage MultiSelect</h3>
-            <TwoStageMultiSelect
-              selectedItems={seriesSelectedItems}
-              onSelectedItemsChanged={setSeriesSelectedItems}
-              items={seriesItems}
-              label="Select Series"
             />
           </div>
         </div>

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -18,6 +18,7 @@ import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
 import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import Modal from '@/components/modals/Modal'
+import TwoStageMultiSelect from '@/components/ui/TwoStageMultiSelect'
 
 export default function ComponentsCatalogPage() {
   const { showToast } = useGlobalToast()
@@ -52,8 +53,20 @@ export default function ComponentsCatalogPage() {
   const [inputDropdownValue3, setInputDropdownValue3] = useState('')
 
   // MultiSelect sample data
-  const multiSelectItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
-  const [multiSelectValue, setMultiSelectValue] = useState<(string | MultiSelectItem)[]>(['Apple', 'Banana'])
+  const multiSelectItems: MultiSelectItem[] = [
+    { text: 'Apple', value: 'apple' },
+    { text: 'Banana', value: 'banana' },
+    { text: 'Cherry', value: 'cherry' },
+    { text: 'Date', value: 'date' },
+    { text: 'Elderberry', value: 'elderberry' },
+    { text: 'Fig', value: 'fig' },
+    { text: 'Grape', value: 'grape' },
+    { text: 'Honeydew', value: 'honeydew' }
+  ]
+  const [multiSelectValue, setMultiSelectValue] = useState<MultiSelectItem[]>([
+    { text: 'Apple', value: 'apple' },
+    { text: 'Banana', value: 'banana' }
+  ])
 
   const multiSelectDropdownItems = [
     { text: 'Red', value: '#ff0000' },
@@ -62,7 +75,10 @@ export default function ComponentsCatalogPage() {
     { text: 'Yellow', value: '#ffff00' },
     { text: 'Purple', value: '#800080' }
   ]
-  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<(string | MultiSelectItem)[]>(['#ff0000', '#0000ff'])
+  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<MultiSelectItem[]>([
+    { text: 'Red', value: '#ff0000' },
+    { text: 'Blue', value: '#0000ff' }
+  ])
 
   // Modal state
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -73,7 +89,97 @@ export default function ComponentsCatalogPage() {
   const [isPersistentModalOpen, setIsPersistentModalOpen] = useState(false)
   const [isCustomModalOpen, setIsCustomModalOpen] = useState(false)
   const [isProcessing, setIsProcessing] = useState(false)
-  const [modalMultiSelectValue, setModalMultiSelectValue] = useState<(string | MultiSelectItem)[]>(['Cherry', 'Date'])
+  const [modalMultiSelectValue, setModalMultiSelectValue] = useState<MultiSelectItem[]>([
+    { text: 'Cherry', value: 'cherry' },
+    { text: 'Date', value: 'date' }
+  ])
+
+  // MultiSelect handlers
+  const handleMultiSelectItemAdded = (item: MultiSelectItem) => {
+    if (!item.value) {
+      // New item
+      if (multiSelectValue.find((i) => i.text === item.text)) {
+        showToast(`Item already exists: ${item.text}`, { type: 'info', title: 'Item Already Exists' })
+        return
+      }
+      item.value = 'new-' + item.text.toLowerCase().replace(/ /g, '-')
+      showToast(`New item created: ${item.text}`, { type: 'success', title: 'Item Created' })
+    }
+    const newItems = [...multiSelectValue, item]
+    setMultiSelectValue(newItems)
+  }
+
+  const handleMultiSelectItemRemoved = (item: MultiSelectItem) => {
+    const newItems = multiSelectValue.filter((i) => i.value !== item.value)
+    setMultiSelectValue(newItems)
+    showToast(`Removed: ${item.text}`, { type: 'info', title: 'Item Removed' })
+  }
+
+  const handleMultiSelectItemEdited = (item: MultiSelectItem, index: number) => {
+    if (multiSelectValue.find((i) => i.text.toLowerCase() === item.text.toLowerCase())) {
+      showToast(`Item already exists: ${item.text}`, { type: 'info', title: 'Item Already Exists' })
+      return
+    }
+    item.value = multiSelectItems.find((i) => i.text.toLowerCase() === item.text.toLowerCase())?.value || 'new-' + item.text.toLowerCase().replace(/ /g, '-')
+    const newItems = [...multiSelectValue]
+    newItems[index] = item
+    setMultiSelectValue(newItems)
+    showToast(`Edited: ${item.value}, ${item.text}`, { type: 'info', title: 'Item Edited' })
+  }
+
+  const handleModalMultiSelectItemAdded = (item: MultiSelectItem) => {
+    if (!item.value) {
+      // New item
+      if (!modalMultiSelectValue.find((i) => i.text === item.text)) {
+        item.value = 'new-' + item.text.toLowerCase().replace(/ /g, '-')
+        showToast(`New item created: ${item.text}`, { type: 'success', title: 'Item Created' })
+      } else {
+        showToast(`Item already exists: ${item.text}`, { type: 'info', title: 'Item Already Exists' })
+        return
+      }
+    }
+    const newItems = [...modalMultiSelectValue, item]
+    setModalMultiSelectValue(newItems)
+  }
+
+  const handleModalMultiSelectItemRemoved = (item: MultiSelectItem) => {
+    const newItems = modalMultiSelectValue.filter((i) => i.value !== item.value)
+    setModalMultiSelectValue(newItems)
+    showToast(`Removed tag: ${item.text}`, { type: 'info', title: 'Tag Removed' })
+  }
+
+  const handleModalMultiSelectItemEdited = (item: MultiSelectItem, index: number) => {
+    if (modalMultiSelectValue.find((i) => i.text.toLowerCase() === item.text.toLowerCase())) {
+      showToast(`Item already exists: ${item.text}`, { type: 'info', title: 'Item Already Exists' })
+      return
+    }
+    item.value = multiSelectItems.find((i) => i.text.toLowerCase() === item.text.toLowerCase())?.value || 'new-' + item.text.toLowerCase().replace(/ /g, '-')
+    const newItems = [...modalMultiSelectValue]
+    newItems[index] = item
+    setModalMultiSelectValue(newItems)
+    showToast(`Edited tag: ${item.value}, ${item.text}`, { type: 'info', title: 'Tag Edited' })
+  }
+
+  const handleMultiSelectDropdownItemAdded = (item: MultiSelectItem) => {
+    if (!item.value) {
+      // New item
+      if (!multiSelectDropdownSelectedItems.find((i) => i.text === item.text)) {
+        item.value = 'new-' + item.text.toLowerCase().replace(/ /g, '-')
+        showToast(`New item created: ${item.text}`, { type: 'success', title: 'Item Created' })
+      } else {
+        showToast(`Item already exists: ${item.text}`, { type: 'info', title: 'Item Already Exists' })
+        return
+      }
+    }
+    const newItems = [...multiSelectDropdownSelectedItems, item]
+    setMultiSelectDropdownSelectedItems(newItems)
+  }
+
+  const handleMultiSelectDropdownItemRemoved = (item: MultiSelectItem) => {
+    const newItems = multiSelectDropdownSelectedItems.filter((i) => i.value !== item.value)
+    setMultiSelectDropdownSelectedItems(newItems)
+    showToast(`Removed: ${item.text}`, { type: 'info', title: 'Item Removed' })
+  }
 
   // Dropdown change handlers
   const handleDropdownChange = (value: string | number) => {
@@ -157,6 +263,20 @@ export default function ComponentsCatalogPage() {
     { text: 'Delete Item', action: 'delete' },
     { text: 'Empty', action: 'empty', subitems: [] }
   ]
+
+  const seriesItems: MultiSelectItem[] = [
+    { text: 'Lord of the Rings', value: '1' },
+    { text: 'Foundation', value: '2' },
+    { text: 'The Hitchhikers Guide to the Galaxy', value: '3' },
+    { text: 'The Chronicles of Narnia', value: '4' },
+    { text: 'Harry Potter', value: '5' },
+    { text: 'The Hunger Games', value: '6' },
+    { text: 'A very very very very very very very very very very very very long series name', value: '7' }
+  ]
+  const [seriesSelectedItems, setSeriesSelectedItems] = useState<MultiSelectItem[]>([
+    { value: '1', text: 'Lord of the Rings#1' },
+    { value: '3', text: 'The Hitchhikers Guide to the Galaxy#2' }
+  ])
 
   return (
     <div className="p-8 w-full max-w-7xl mx-auto">
@@ -447,11 +567,10 @@ export default function ComponentsCatalogPage() {
             <h3 className="text-lg font-medium mb-4">Default MultiSelect</h3>
             <MultiSelect
               selectedItems={multiSelectValue}
-              onSelectedItemsChanged={setMultiSelectValue}
+              onItemAdded={handleMultiSelectItemAdded}
+              onItemRemoved={handleMultiSelectItemRemoved}
               items={multiSelectItems}
               label="Select Fruits"
-              onNewItem={(item) => showToast(`New item created: ${item}`, { type: 'success', title: 'Item Created' })}
-              onRemovedItem={(item) => showToast(`Removed: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Removed' })}
             />
           </div>
 
@@ -459,13 +578,12 @@ export default function ComponentsCatalogPage() {
             <h3 className="text-lg font-medium mb-4">MultiSelect with Edit</h3>
             <MultiSelect
               selectedItems={multiSelectValue}
-              onSelectedItemsChanged={setMultiSelectValue}
+              onItemAdded={handleMultiSelectItemAdded}
+              onItemRemoved={handleMultiSelectItemRemoved}
+              onItemEdited={handleMultiSelectItemEdited}
               items={multiSelectItems}
               label="Select Fruits"
-              onNewItem={(item) => showToast(`New item created: ${item}`, { type: 'success', title: 'Item Created' })}
-              onRemovedItem={(item) => showToast(`Removed: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Removed' })}
               showEdit
-              onEdit={(item) => showToast(`Edited: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Edited' })}
             />
           </div>
 
@@ -473,10 +591,21 @@ export default function ComponentsCatalogPage() {
             <h3 className="text-lg font-medium mb-4">Disabled MultiSelect</h3>
             <MultiSelect
               selectedItems={multiSelectValue}
-              onSelectedItemsChanged={setMultiSelectValue}
+              onItemAdded={handleMultiSelectItemAdded}
+              onItemRemoved={handleMultiSelectItemRemoved}
               items={multiSelectItems}
               label="Select Fruits"
               disabled
+            />
+          </div>
+
+          <div className="bg-gray-800 p-6 rounded-lg">
+            <h3 className="text-lg font-medium mb-4">Two-Stage MultiSelect</h3>
+            <TwoStageMultiSelect
+              selectedItems={seriesSelectedItems}
+              onSelectedItemsChanged={setSeriesSelectedItems}
+              items={seriesItems}
+              label="Select Series"
             />
           </div>
         </div>
@@ -490,17 +619,18 @@ export default function ComponentsCatalogPage() {
             <h3 className="text-lg font-medium mb-4">Default MultiSelectDropdown</h3>
             <MultiSelectDropdown
               selectedItems={multiSelectDropdownSelectedItems}
-              onSelectedItemsChanged={setMultiSelectDropdownSelectedItems}
+              onItemAdded={handleMultiSelectDropdownItemAdded}
+              onItemRemoved={handleMultiSelectDropdownItemRemoved}
               items={multiSelectDropdownItems}
               label="Select Colors"
-              onRemovedItem={(item) => showToast(`Removed: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Item Removed' })}
             />
           </div>
           <div className="bg-gray-800 p-6 rounded-lg">
             <h3 className="text-lg font-medium mb-4">Disabled MultiSelectDropdown</h3>
             <MultiSelectDropdown
               selectedItems={multiSelectDropdownSelectedItems}
-              onSelectedItemsChanged={setMultiSelectDropdownSelectedItems}
+              onItemAdded={handleMultiSelectDropdownItemAdded}
+              onItemRemoved={handleMultiSelectDropdownItemRemoved}
               items={multiSelectDropdownItems}
               label="Select Colors"
               disabled
@@ -703,18 +833,16 @@ export default function ComponentsCatalogPage() {
 
                   <MultiSelect
                     selectedItems={modalMultiSelectValue}
-                    onSelectedItemsChanged={setModalMultiSelectValue}
+                    onItemAdded={handleModalMultiSelectItemAdded}
+                    onItemRemoved={handleModalMultiSelectItemRemoved}
+                    onItemEdited={handleModalMultiSelectItemEdited}
                     items={multiSelectItems}
                     label="Item Tags"
-                    onNewItem={(item) => showToast(`New tag created: ${item}`, { type: 'success', title: 'Tag Created' })}
-                    onRemovedItem={(item) => showToast(`Removed tag: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Tag Removed' })}
                     showEdit
-                    onEdit={(item) => showToast(`Edited tag: ${typeof item === 'string' ? item : item.text}`, { type: 'info', title: 'Tag Edited' })}
                   />
 
                   <div className="text-xs text-gray-400 mt-2">
-                    Current selection:{' '}
-                    {modalMultiSelectValue.length > 0 ? modalMultiSelectValue.map((i) => (typeof i === 'string' ? i : i.text)).join(', ') : 'None'}
+                    Current selection: {modalMultiSelectValue.length > 0 ? modalMultiSelectValue.map((i) => i.text).join(', ') : 'None'}
                   </div>
                 </div>
 

--- a/src/components/ui/Pill.tsx
+++ b/src/components/ui/Pill.tsx
@@ -260,7 +260,7 @@ export const Pill: React.FC<PillProps> = ({
       cy-id={id}
       role="listitem"
       className={mergeClasses(
-        'rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center justify-center relative',
+        'group rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center justify-center relative',
         !disabled && isFocused ? 'ring z-10' : ''
       )}
       style={{ minWidth: showEditButton ? 44 : 22 }}
@@ -274,14 +274,15 @@ export const Pill: React.FC<PillProps> = ({
     >
       {!disabled && (
         <div
-          className={mergeClasses('w-full h-full rounded-full absolute top-0 left-0 px-1 bg-bg/75 flex items-center justify-end opacity-0 hover:opacity-100')}
+          className={mergeClasses(
+            'absolute top-0 -right-1 -translate-y-1/2 flex flex-row-reverse items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-20'
+          )}
         >
           {showEditButton && (
             <button
               type="button"
               aria-label="Edit"
-              className="material-symbols text-white hover:text-warning cursor-pointer"
-              style={{ fontSize: '1.1rem' }}
+              className="material-symbols flex h-3 w-3 items-center justify-center rounded-full bg-bg-alt text-sm text-white hover:text-warning cursor-pointer"
               onMouseDown={(e) => e.preventDefault()}
               onClick={handleEditButtonClick}
               tabIndex={-1}
@@ -292,8 +293,7 @@ export const Pill: React.FC<PillProps> = ({
           <button
             type="button"
             aria-label="Remove"
-            className="material-symbols text-white hover:text-error focus:text-error cursor-pointer"
-            style={{ fontSize: '1.1rem' }}
+            className="material-symbols flex h-3 w-3 items-center justify-center rounded-full bg-bg-alt text-sm text-white hover:text-error focus:text-error cursor-pointer"
             onMouseDown={(e) => e.preventDefault()}
             onClick={(e) => {
               e.stopPropagation()
@@ -305,7 +305,7 @@ export const Pill: React.FC<PillProps> = ({
           </button>
         </div>
       )}
-      {item}
+      <span className="relative group-hover:opacity-75 transition-opacity duration-300">{item}</span>
     </div>
   )
 }

--- a/src/components/ui/Pill.tsx
+++ b/src/components/ui/Pill.tsx
@@ -273,11 +273,7 @@ export const Pill: React.FC<PillProps> = ({
       }}
     >
       {!disabled && (
-        <div
-          className={mergeClasses(
-            'absolute top-0 -right-1 -translate-y-1/2 flex flex-row-reverse items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-20'
-          )}
-        >
+        <div className="absolute top-0 -right-1 -translate-y-1/2 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-20">
           {showEditButton && (
             <button
               type="button"

--- a/src/components/ui/Pill.tsx
+++ b/src/components/ui/Pill.tsx
@@ -1,47 +1,289 @@
-import React from 'react'
+import React, { useState, useRef, useEffect, useCallback } from 'react'
 import { mergeClasses } from '@/lib/merge-classes'
-import { MultiSelectItem } from './MultiSelect'
 
 interface PillProps {
-  item: MultiSelectItem
+  item: string
   id: string
   isFocused: boolean
   disabled: boolean
-  showEdit: boolean
-  onClick: (e: React.MouseEvent<HTMLDivElement>) => void
+  showEditButton: boolean
+  isEditing?: boolean
+  onEditButtonClick?: () => void
+  onClick: () => void
   onEdit?: (item: string) => void
-  onRemove: (item: MultiSelectItem) => void
+  onRemove: (item: string) => void
+  onEditDone?: (shouldRefocus?: boolean) => void
 }
 
-export const Pill: React.FC<PillProps> = ({ item, id, isFocused, disabled, showEdit, onClick, onEdit, onRemove }) => {
+export const Pill: React.FC<PillProps> = ({
+  item,
+  id,
+  isFocused,
+  disabled,
+  showEditButton,
+  isEditing = false,
+  onEditButtonClick,
+  onClick,
+  onEdit,
+  onRemove,
+  onEditDone
+}) => {
+  const [editValue, setEditValue] = useState(item)
+  const [isInputReady, setIsInputReady] = useState(false)
+
+  const editInputRef = useRef<HTMLInputElement>(null)
+  const cancelButtonRef = useRef<HTMLButtonElement>(null)
+  const saveButtonRef = useRef<HTMLButtonElement>(null)
+  const sizerRef = useRef<HTMLSpanElement>(null)
+  const inputWidthRef = useRef<number>(20)
+  const pillContainerRef = useRef<HTMLDivElement>(null)
+
+  // Update edit value when entering edit mode
+  useEffect(() => {
+    if (isEditing) {
+      setEditValue(item)
+    }
+  }, [isEditing, item])
+
+  const updatePillMaxWidth = useCallback(() => {
+    if (pillContainerRef.current) {
+      const pillElement = pillContainerRef.current
+      const parentElement = pillElement.parentElement
+      if (!parentElement) return
+
+      const parentStyle = window.getComputedStyle(parentElement)
+      const parentPaddingLeft = parseFloat(parentStyle.paddingLeft)
+      const parentPaddingRight = parseFloat(parentStyle.paddingRight)
+      const parentContentWidth = parentElement.clientWidth - parentPaddingLeft - parentPaddingRight
+
+      const pillStyle = window.getComputedStyle(pillElement)
+      const pillMarginLeft = parseFloat(pillStyle.marginLeft)
+      const pillMarginRight = parseFloat(pillStyle.marginRight)
+
+      const maxPillWidth = parentContentWidth - pillMarginLeft - pillMarginRight
+      pillElement.style.maxWidth = `${maxPillWidth}px`
+    }
+  }, [])
+
+  // Dynamically calculate and set the max width for the pill container, and update on resize.
+  useEffect(() => {
+    if (isEditing) {
+      updatePillMaxWidth()
+      window.addEventListener('resize', updatePillMaxWidth)
+
+      return () => {
+        window.removeEventListener('resize', updatePillMaxWidth)
+        if (pillContainerRef.current) {
+          pillContainerRef.current.style.maxWidth = ''
+        }
+      }
+    }
+  }, [isEditing, updatePillMaxWidth])
+
+  // Focus the edit input when editing starts and input is rendered
+  useEffect(() => {
+    if (isEditing && editInputRef.current && isInputReady) {
+      editInputRef.current.focus()
+      //editInputRef.current.select()
+    }
+  }, [isEditing, isInputReady])
+
+  // Calculate input width and prepare input for rendering
+  useEffect(() => {
+    if (isEditing && sizerRef.current && !isInputReady) {
+      if (sizerRef.current) {
+        if (editValue) {
+          const sizerWidth = sizerRef.current.getBoundingClientRect().width
+          const newWidth = Math.max(20, sizerWidth)
+          inputWidthRef.current = newWidth
+        } else {
+          inputWidthRef.current = 20
+        }
+        setIsInputReady(true)
+      }
+    }
+  }, [isEditing, editValue, isInputReady])
+
+  // Update width while typing
+  useEffect(() => {
+    if (isEditing && sizerRef.current && isInputReady) {
+      if (sizerRef.current) {
+        const sizerWidth = sizerRef.current.getBoundingClientRect().width
+        const newWidth = Math.max(20, sizerWidth)
+        inputWidthRef.current = newWidth
+        editInputRef.current?.style.setProperty('width', `${newWidth}px`)
+      }
+    }
+  }, [editValue, isEditing, isInputReady])
+
+  // Start editing when edit button is clicked
+  const handleEditButtonClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (!disabled && showEditButton) {
+        onEditButtonClick?.()
+      }
+    },
+    [disabled, showEditButton, onEditButtonClick]
+  )
+
+  // Handle edit input changes
+  const handleEditInputChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditValue(e.target.value)
+  }, [])
+
+  // Save the edit
+  const handleSaveEdit = useCallback(() => {
+    if (editValue.trim() && editValue !== item) {
+      onEdit?.(editValue.trim())
+    }
+    onEditDone?.(true) // Refocus input when explicitly saving
+  }, [editValue, item, onEdit, onEditDone])
+
+  const handleCancelEdit = useCallback(() => {
+    setEditValue(item)
+    onEditDone?.(true)
+  }, [item, onEditDone])
+
+  // Handle input blur - only exit edit mode, don't save
+  const handleInputBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      const newFocusTarget = e.relatedTarget as HTMLElement
+
+      // Only exit edit mode if focus is moving outside the pill container
+      if (!pillContainerRef.current?.contains(newFocusTarget)) {
+        onEditDone?.(false)
+      }
+    },
+    [onEditDone]
+  )
+
+  // Handle edit input key events
+  const handleEditInputKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        handleSaveEdit()
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        handleCancelEdit()
+      }
+    },
+    [handleSaveEdit, handleCancelEdit]
+  )
+
+  // Tab trap for edit mode
+  const handlePillKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      e.preventDefault()
+
+      // Get all focusable elements in the edit mode
+      const focusableElements = [editInputRef.current, cancelButtonRef.current, saveButtonRef.current].filter(Boolean) as HTMLElement[]
+
+      const currentIndex = focusableElements.indexOf(document.activeElement as HTMLElement)
+      const nextIndex = e.shiftKey ? (currentIndex - 1 + focusableElements.length) % focusableElements.length : (currentIndex + 1) % focusableElements.length
+
+      focusableElements[nextIndex]?.focus()
+    }
+  }, [])
+
+  // If editing, show the input field
+  if (isEditing) {
+    return (
+      <div
+        ref={pillContainerRef}
+        id={id}
+        cy-id={id}
+        role="listitem"
+        aria-label={`Editing ${item}`}
+        className={mergeClasses(
+          'rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center justify-center relative',
+          'ring z-10'
+        )}
+        tabIndex={-1}
+        onMouseDown={(e) => e.preventDefault()}
+        onKeyDown={handlePillKeyDown}
+      >
+        <span ref={sizerRef} className="absolute invisible whitespace-pre px-1 text-xs">
+          {editValue}
+        </span>
+        {isInputReady && (
+          <input
+            ref={editInputRef}
+            type="text"
+            value={editValue}
+            onChange={handleEditInputChange}
+            onKeyDown={handleEditInputKeyDown}
+            onBlur={handleInputBlur}
+            className="bg-transparent border-none outline-none text-xs text-center flex-1"
+            style={{ minWidth: '20px', width: `${inputWidthRef.current}px` }}
+            autoComplete="off"
+            aria-label={`Edit ${item}`}
+            aria-describedby={`${id}-edit-instructions`}
+          />
+        )}
+        <div className="flex items-center gap-1 ml-1" role="group" aria-label="Edit actions">
+          <button
+            type="button"
+            aria-label="Cancel edit"
+            className="material-symbols text-white focus:text-error hover:text-error cursor-pointer"
+            style={{ fontSize: '1rem' }}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleCancelEdit}
+            ref={cancelButtonRef}
+          >
+            close
+          </button>
+          <button
+            type="button"
+            aria-label="Save edit"
+            className="material-symbols text-white focus:text-success hover:text-success cursor-pointer"
+            style={{ fontSize: '1rem' }}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleSaveEdit}
+            ref={saveButtonRef}
+          >
+            check
+          </button>
+        </div>
+        <div id={`${id}-edit-instructions`} className="sr-only">
+          Press Enter to save or Escape to cancel
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div
       id={id}
+      cy-id={id}
       role="listitem"
       className={mergeClasses(
         'rounded-full px-2 py-1 mx-0.5 my-0.5 text-xs bg-bg flex flex-nowrap break-all items-center justify-center relative',
         !disabled && isFocused ? 'ring z-10' : ''
       )}
-      style={{ minWidth: showEdit ? 44 : 22 }}
+      style={{ minWidth: showEditButton ? 44 : 22 }}
       tabIndex={-1}
       onMouseDown={(e) => e.preventDefault()}
-      onClick={onClick}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onClick()
+      }}
     >
       {!disabled && (
         <div
           className={mergeClasses('w-full h-full rounded-full absolute top-0 left-0 px-1 bg-bg/75 flex items-center justify-end opacity-0 hover:opacity-100')}
         >
-          {showEdit && (
+          {showEditButton && (
             <button
               type="button"
               aria-label="Edit"
               className="material-symbols text-white hover:text-warning cursor-pointer"
               style={{ fontSize: '1.1rem' }}
               onMouseDown={(e) => e.preventDefault()}
-              onClick={(e) => {
-                e.preventDefault()
-                onEdit?.(item.value)
-              }}
+              onClick={handleEditButtonClick}
               tabIndex={-1}
             >
               edit
@@ -63,7 +305,7 @@ export const Pill: React.FC<PillProps> = ({ item, id, isFocused, disabled, showE
           </button>
         </div>
       )}
-      {item.text}
+      {item}
     </div>
   )
 }


### PR DESCRIPTION
This makes the Pill component editable inline.

In edit mode, the pill has an input and Cancel and OK icon buttons.
- Tab moves between the input and the Cancel and OK buttons, and is trapped in pill while in edit mode.
- Enter calls onEdit with the new text and exits edit mode.
- Escape just exits edit mode
- Clicking outside the pill exits edit mode
- The pill's input width is automatically set based on the input's size, but it's max width does not surpass the pill's parent width (input wrapper in the case of multi-select)
- MultiSelect checks that the new value (after edit) is not a duplicate of another existing pill

This also includes some simplifying changes in MutliSelect interfaces:
- Props and callback arguments are all of type MultiSelectItem (simplifies logic inside MultiSelect)
- Removed setSelectedItemsChanged
   - Now there are just 3 callbacks, onItemAdded, onItemRemoved, and onItemEdited
   - onItemAdded is called with `value: ''` for new items.