### PR TITLE
Migrate RangeInput and ReadIconBtn

### DIFF
--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -1082,14 +1082,6 @@ export function RangeInputExamples() {
           <RangeInput value={rangeValue3} onChange={setRangeValue3} min={0} max={200} step={10} label="Custom Range With Step" />
         </Example>
 
-        <Example title="Minimum Value">
-          <RangeInput value={rangeValue4} onChange={setRangeValue4} label="Minimum Value" />
-        </Example>
-
-        <Example title="Maximum Value">
-          <RangeInput value={rangeValue5} onChange={setRangeValue5} label="Maximum Value" />
-        </Example>
-
         <Example title="Disabled RangeInput">
           <RangeInput value={50} onChange={() => {}} disabled label="Disabled Range" />
         </Example>

--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -539,8 +539,6 @@ export function ReadIconBtnExamples() {
   const [isRead2, setIsRead2] = useState(true)
   const [isRead3, setIsRead3] = useState(false)
   const [isRead4, setIsRead4] = useState(true)
-  const [isRead5, setIsRead5] = useState(false)
-  const [isRead6, setIsRead6] = useState(true)
 
   const { showToast } = useGlobalToast()
 
@@ -591,21 +589,21 @@ export function ReadIconBtnExamples() {
 
         <Example title="Disabled Read Button">
           <div className="flex items-center gap-4">
-            <ReadIconBtn isRead={isRead4} disabled />
+            <ReadIconBtn isRead={true} disabled />
             <span className="text-sm text-gray-400">Disabled state</span>
           </div>
         </Example>
 
-        <Example title="Borderless Disabled Read Button">
+        <Example title="Borderless Disabled Unread Button">
           <div className="flex items-center gap-4">
-            <ReadIconBtn isRead={isRead5} borderless disabled />
+            <ReadIconBtn isRead={false} borderless disabled />
             <span className="text-sm text-gray-400">Borderless disabled</span>
           </div>
         </Example>
 
         <Example title="Custom Styled Read Button">
           <div className="flex items-center gap-4">
-            <ReadIconBtn isRead={isRead6} onClick={() => handleReadToggle(isRead6, setIsRead6)} className="bg-blue-600 hover:bg-blue-700" />
+            <ReadIconBtn isRead={isRead4} onClick={() => handleReadToggle(isRead4, setIsRead4)} className="bg-blue-600 hover:bg-blue-700" />
             <span className="text-sm text-gray-400">Custom background color</span>
           </div>
         </Example>

--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -1,0 +1,1485 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { useState } from 'react'
+import Btn from '@/components/ui/Btn'
+import Checkbox from '@/components/ui/Checkbox'
+import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
+import type { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
+import Dropdown from '@/components/ui/Dropdown'
+import type { DropdownItem } from '@/components/ui/Dropdown'
+import FileInput from '@/components/ui/FileInput'
+import IconBtn from '@/components/ui/IconBtn'
+import InputDropdown from '@/components/ui/InputDropdown'
+import LibraryIcon from '@/components/ui/LibraryIcon'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
+import LoadingSpinner from '@/components/widgets/LoadingSpinner'
+import MediaIconPicker from '@/components/ui/MediaIconPicker'
+import Modal from '@/components/modals/Modal'
+import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
+import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
+import RangeInput from '@/components/ui/RangeInput'
+import TwoStageMultiSelect, { TwoStageMultiSelectContent } from '@/components/ui/TwoStageMultiSelect'
+import { useGlobalToast } from '@/contexts/ToastContext'
+
+interface ComponentExamplesProps {
+  title: string
+  component?: string
+  description?: string
+  children: ReactNode
+}
+
+function ComponentExamples({ title, children }: ComponentExamplesProps) {
+  return (
+    <section className="mb-12">
+      <h2 className="text-2xl font-semibold mb-6 text-gray-400">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+interface ComponentInfoProps {
+  component?: string
+  description?: string
+  children?: React.ReactNode
+}
+
+function ComponentInfo({ component, description, children }: ComponentInfoProps) {
+  if (!component && !description) return null
+  return (
+    <div className="w-full mb-6">
+      <div className="bg-gray-800 p-6 rounded-lg">
+        <p className="mb-2">
+          {component && (
+            <>
+              <span className="font-bold">Component:</span>
+              <code className="bg-gray-700 rounded py-1 px-2">{component}</code>
+              <span> - </span>
+            </>
+          )}
+          {description && <span>{description}</span>}
+        </p>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+interface ExampleProps {
+  title: string
+  children: ReactNode
+}
+
+function Example({ title, children }: ExampleProps) {
+  return (
+    <div className="bg-gray-800 p-6 rounded-lg">
+      <h3 className="text-lg font-medium mb-4">{title}</h3>
+      {children}
+    </div>
+  )
+}
+
+function ExamplesBlock({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">{children}</div>
+}
+
+// Button Examples
+export function BtnExamples() {
+  return (
+    <ComponentExamples title="Buttons">
+      <ComponentInfo component="Btn" description="Button component with various states (loading, disabled, small, link)">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import Btn from '@/components/ui/Btn'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">color</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">small</code>, <code className="bg-gray-700 px-2 py-1 rounded">loading</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">to</code> (for navigation)
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Primary Button">
+          <Btn>Primary Button</Btn>
+        </Example>
+
+        <Example title="Small Button">
+          <Btn small>Small Button</Btn>
+        </Example>
+
+        <Example title="Loading Button">
+          <Btn loading>Loading...</Btn>
+        </Example>
+
+        <Example title="Small Loading Button">
+          <Btn small loading>
+            Loading...
+          </Btn>
+        </Example>
+
+        <Example title="Disabled Button">
+          <Btn disabled>Disabled Button</Btn>
+        </Example>
+
+        <Example title="Button with Progress">
+          <Btn loading progress="75%">
+            Uploading...
+          </Btn>
+        </Example>
+
+        <Example title="Link Button">
+          <Btn to="/settings">Go to Settings</Btn>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// Checkbox Examples
+export function CheckboxExamples() {
+  return (
+    <ComponentExamples title="Checkboxes">
+      <ComponentInfo component="Checkbox" description="Checkbox component with different sizes and states">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import Checkbox from '@/components/ui/Checkbox'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>, <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">small</code>, <code className="bg-gray-700 px-2 py-1 rounded">medium</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">partial</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Checkbox">
+          <Checkbox value={false} onChange={() => {}} label="Accept terms and conditions" />
+        </Example>
+
+        <Example title="Checked Checkbox">
+          <Checkbox value={true} onChange={() => {}} label="Subscribe to newsletter" />
+        </Example>
+
+        <Example title="Small Checkbox">
+          <Checkbox value={false} onChange={() => {}} label="Enable notifications" small />
+        </Example>
+
+        <Example title="Medium Checkbox">
+          <Checkbox value={false} onChange={() => {}} label="Medium size checkbox" medium />
+        </Example>
+
+        <Example title="Disabled Checkbox">
+          <Checkbox value={false} onChange={() => {}} label="Disabled checkbox" disabled />
+        </Example>
+
+        <Example title="Partial Checkbox">
+          <Checkbox value={false} onChange={() => {}} label="Partial state checkbox" partial />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// ContextMenuDropdown Examples
+export function ContextMenuDropdownExamples() {
+  const { showToast } = useGlobalToast()
+
+  // ContextMenuDropdown sample data
+  const contextMenuItems: ContextMenuDropdownItem[] = [
+    { text: 'Edit', action: 'edit' },
+    { text: 'Delete', action: 'delete' },
+    {
+      text: 'More Options',
+      action: 'more',
+      subitems: [
+        { text: 'Copy', action: 'copy' },
+        { text: 'Move', action: 'move' },
+        { text: 'Share', action: 'share' }
+      ]
+    },
+    {
+      text: 'More Options 2',
+      action: 'more2',
+      subitems: [
+        { text: 'Copy 2', action: 'copy2' },
+        { text: 'Move 2', action: 'move2' },
+        { text: 'Share 2', action: 'share2' }
+      ]
+    }
+  ]
+
+  const contextMenuItemsWithData: ContextMenuDropdownItem[] = [
+    { text: 'Edit Item', action: 'edit' },
+    { text: 'Delete Item', action: 'delete' },
+    {
+      text: 'Advanced',
+      action: 'advanced',
+      subitems: [
+        { text: 'Duplicate', action: 'duplicate', data: { id: 1 } },
+        { text: 'Archive', action: 'archive', data: { id: 1 } }
+      ]
+    }
+  ]
+
+  const contextMenuItemsWithEmptySubitems: ContextMenuDropdownItem[] = [
+    { text: 'Edit Item', action: 'edit' },
+    { text: 'Delete Item', action: 'delete' },
+    { text: 'Empty', action: 'empty', subitems: [] }
+  ]
+
+  return (
+    <ComponentExamples title="Context Menu Dropdowns">
+      <ComponentInfo component="ContextMenuDropdown" description="Context menu dropdown with submenus, loading states, and custom triggers">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">items</code> (ContextMenuItem[]),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">processing</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">iconClass</code>, <code className="bg-gray-700 px-2 py-1 rounded">menuWidth</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onAction</code>, <code className="bg-gray-700 px-2 py-1 rounded">children</code> (ReactNode or
+          function)
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Context Menu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItems}
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+            <span className="text-sm text-gray-400">Click to see menu</span>
+          </div>
+        </Example>
+
+        <Example title="Left Aligned Context Menu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItems}
+              menuAlign="left"
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+            <span className="text-sm text-gray-400">Click to see menu</span>
+          </div>
+        </Example>
+
+        <Example title="Context Menu with Data">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItemsWithData}
+              onAction={(action) =>
+                showToast(`Action: ${action.action} ${action.data ? `, Data: ${JSON.stringify(action.data)}` : ''}`, {
+                  type: 'info',
+                  title: 'Context Menu Action'
+                })
+              }
+            />
+            <span className="text-sm text-gray-400">Click to see menu with data</span>
+          </div>
+        </Example>
+
+        <Example title="Disabled Context Menu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItems}
+              disabled={true}
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+            <span className="text-sm text-gray-400">Disabled state</span>
+          </div>
+        </Example>
+
+        <Example title="Processing Context Menu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItems}
+              processing={true}
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+            <span className="text-sm text-gray-400">Loading state</span>
+          </div>
+        </Example>
+
+        <Example title="Custom Icon Context Menu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItems}
+              iconClass="text-blue-400"
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+            <span className="text-sm text-gray-400">Custom icon color</span>
+          </div>
+        </Example>
+
+        <Example title="Wide Context Menu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItems}
+              menuWidth={250}
+              menuAlign="left"
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+            <span className="text-sm text-gray-400">Wider menu</span>
+          </div>
+        </Example>
+
+        <Example title="Context Menu with Empty Submenu">
+          <div className="flex items-center gap-4">
+            <ContextMenuDropdown
+              items={contextMenuItemsWithEmptySubitems}
+              onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
+            />
+          </div>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// Dropdown Examples
+export function DropdownExamples() {
+  // Dropdown sample data
+  const dropdownItems: DropdownItem[] = [
+    { text: 'Option 1', value: 'option1' },
+    { text: 'Option 2', value: 'option2' },
+    { text: 'Option 3', value: 'option3' },
+    { text: 'Option 4', value: 'option4' }
+  ]
+
+  const dropdownItemsWithSubtext: DropdownItem[] = [
+    { text: 'English', value: 'en', subtext: 'US' },
+    { text: 'Spanish', value: 'es', subtext: 'ES' },
+    { text: 'French', value: 'fr', subtext: 'FR' },
+    { text: 'German', value: 'de', subtext: 'DE' }
+  ]
+
+  const [dropdownValue, setDropdownValue] = useState('option1')
+  const [dropdownValue2, setDropdownValue2] = useState('en')
+  const [dropdownValue3, setDropdownValue3] = useState('option1')
+
+  // Dropdown change handlers
+  const handleDropdownChange = (value: string | number) => {
+    setDropdownValue(String(value))
+  }
+
+  const handleDropdownChange2 = (value: string | number) => {
+    setDropdownValue2(String(value))
+  }
+
+  const handleDropdownChange3 = (value: string | number) => {
+    setDropdownValue3(String(value))
+  }
+
+  return (
+    <ComponentExamples title="Dropdowns">
+      <ComponentInfo component="Dropdown" description="Select dropdown component with labels, subtext, and various states">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import Dropdown from '@/components/ui/Dropdown'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>, <code className="bg-gray-700 px-2 py-1 rounded">items</code> (DropdownItem[]),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">label</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">small</code>, <code className="bg-gray-700 px-2 py-1 rounded">menuMaxHeight</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Dropdown">
+          <Dropdown value={dropdownValue} onChange={handleDropdownChange} items={dropdownItems} label="Select Option" />
+        </Example>
+
+        <Example title="Dropdown with Subtext">
+          <Dropdown value={dropdownValue2} onChange={handleDropdownChange2} items={dropdownItemsWithSubtext} label="Language" />
+        </Example>
+
+        <Example title="Small Dropdown">
+          <Dropdown value={dropdownValue3} onChange={handleDropdownChange3} items={dropdownItems} label="Small Option" small />
+        </Example>
+
+        <Example title="Disabled Dropdown">
+          <Dropdown value="option1" items={dropdownItems} label="Disabled Option" disabled />
+        </Example>
+
+        <Example title="Dropdown without Label">
+          <Dropdown value={dropdownValue} onChange={handleDropdownChange} items={dropdownItems} />
+        </Example>
+
+        <Example title="Custom Height Dropdown">
+          <Dropdown value={dropdownValue} onChange={handleDropdownChange} items={dropdownItems} label="Custom Height" menuMaxHeight="100px" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// FileInput Examples
+export function FileInputExamples() {
+  const { showToast } = useGlobalToast()
+
+  return (
+    <ComponentExamples title="File Inputs">
+      <ComponentInfo component="FileInput" description="File input component with customizable accept types and responsive design">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import FileInput from '@/components/ui/FileInput'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">accept</code> (file types to accept),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code> (callback with selected file),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">children</code> (ReactNode for button content),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code> (custom CSS classes)
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default File Input">
+          <FileInput onChange={(file) => showToast(`Selected file: ${file.name}`, { type: 'success', title: 'File Selected' })}>Choose File</FileInput>
+        </Example>
+
+        <Example title="Document File Input">
+          <FileInput
+            accept=".pdf, .doc, .docx, .txt"
+            onChange={(file) => showToast(`Selected document: ${file.name}`, { type: 'success', title: 'Document Selected' })}
+            ariaLabel="Upload Document"
+          >
+            Upload Document
+          </FileInput>
+        </Example>
+
+        <Example title="All Files Input">
+          <FileInput
+            accept="*"
+            onChange={(file) => showToast(`Selected file: ${file.name}`, { type: 'success', title: 'File Selected' })}
+            ariaLabel="Upload Any File"
+          >
+            Choose Any File
+          </FileInput>
+        </Example>
+
+        <Example title="Custom Styled File Input">
+          <FileInput
+            accept=".png, .jpg, .jpeg"
+            onChange={(file) => showToast(`Selected image: ${file.name}`, { type: 'success', title: 'Image Selected' })}
+            className="border-2 border-dashed border-blue-400 rounded-lg bg-blue-50"
+            ariaLabel="Upload Image"
+          >
+            Drop Image Here
+          </FileInput>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// IconBtn Examples
+export function IconBtnExamples() {
+  return (
+    <ComponentExamples title="Icon Buttons">
+      <ComponentInfo component="IconBtn" description="Icon button component with material symbols, loading states, and customization options">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import IconBtn from '@/components/ui/IconBtn'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">icon</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">bgColor</code>, <code className="bg-gray-700 px-2 py-1 rounded">outlined</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">borderless</code>, <code className="bg-gray-700 px-2 py-1 rounded">loading</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">size</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">iconFontSize</code>, <code className="bg-gray-700 px-2 py-1 rounded">ariaLabel</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Basic Icon Button">
+          <IconBtn icon="&#xe3c9;" ariaLabel="Edit" />
+        </Example>
+
+        <Example title="Icon Button with Background Color">
+          <IconBtn icon="&#xe5ca;" bgColor="bg-red-500" ariaLabel="Close" />
+        </Example>
+
+        <Example title="Outlined Icon Button">
+          <IconBtn icon="&#xe3c9;" outlined ariaLabel="Edit" />
+        </Example>
+
+        <Example title="Borderless Icon Button">
+          <IconBtn icon="&#xe3c9;" borderless ariaLabel="Edit" />
+        </Example>
+
+        <Example title="Loading Icon Button">
+          <IconBtn icon="&#xe3c9;" loading ariaLabel="Loading" />
+        </Example>
+
+        <Example title="Disabled Icon Button">
+          <IconBtn icon="&#xe3c9;" disabled ariaLabel="Edit" />
+        </Example>
+
+        <Example title="Small Icon Button">
+          <IconBtn icon="&#xe3c9;" size={8} ariaLabel="Edit" />
+        </Example>
+
+        <Example title="Large Icon Button">
+          <IconBtn icon="&#xe3c9;" size={12} ariaLabel="Edit" />
+        </Example>
+
+        <Example title="Custom Icon Font Size">
+          <IconBtn icon="&#xe3c9;" iconFontSize="text-2xl" ariaLabel="Edit" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// InputDropdown Examples
+export function InputDropdownExamples() {
+  const { showToast } = useGlobalToast()
+
+  // InputDropdown sample data
+  const inputDropdownItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
+  const [inputDropdownValue, setInputDropdownValue] = useState('')
+  const [inputDropdownValue2, setInputDropdownValue2] = useState('')
+  const [inputDropdownValue3, setInputDropdownValue3] = useState('')
+
+  // InputDropdown change handlers
+  const handleInputDropdownChange = (value: string | number) => {
+    setInputDropdownValue(String(value))
+  }
+
+  const handleInputDropdownChange2 = (value: string | number) => {
+    setInputDropdownValue2(String(value))
+  }
+
+  const handleInputDropdownChange3 = (value: string | number) => {
+    setInputDropdownValue3(String(value))
+  }
+
+  const handleInputDropdownNewItem = (value: string) => {
+    showToast(`New item created: ${value}`, { type: 'success', title: 'Item Created' })
+  }
+
+  return (
+    <ComponentExamples title="Input Dropdowns">
+      <ComponentInfo component="InputDropdown" description="Input dropdown component that allows typing and filtering with optional new item creation">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import InputDropdown from '@/components/ui/InputDropdown'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>, <code className="bg-gray-700 px-2 py-1 rounded">items</code> (string[] or number[]),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">label</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">editable</code>, <code className="bg-gray-700 px-2 py-1 rounded">showAllWhenEmpty</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onNewItem</code>, <code className="bg-gray-700 px-2 py-1 rounded">className</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Input Dropdown">
+          <InputDropdown value={inputDropdownValue} onChange={handleInputDropdownChange} items={inputDropdownItems} label="Select Fruit" />
+        </Example>
+
+        <Example title="Input Dropdown with New Item Creation">
+          <InputDropdown
+            value={inputDropdownValue2}
+            onChange={handleInputDropdownChange2}
+            items={inputDropdownItems}
+            label="Add or Select Fruit"
+            onNewItem={handleInputDropdownNewItem}
+          />
+        </Example>
+
+        <Example title="Show All When Empty">
+          <InputDropdown
+            value={inputDropdownValue3}
+            onChange={handleInputDropdownChange3}
+            items={inputDropdownItems}
+            label="Fruit with Show All"
+            showAllWhenEmpty
+          />
+        </Example>
+
+        <Example title="Disabled Input Dropdown">
+          <InputDropdown value="Apple" items={inputDropdownItems} label="Disabled Fruit" disabled />
+        </Example>
+
+        <Example title="Input Dropdown without Label">
+          <InputDropdown value={inputDropdownValue} onChange={handleInputDropdownChange} items={inputDropdownItems} />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// LibraryIcon Examples
+export function LibraryIconExamples() {
+  return (
+    <ComponentExamples title="Library Icons">
+      <ComponentInfo component="LibraryIcon" description="Library icon component using absicons font with validation and fallback">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import LibraryIcon from '@/components/ui/LibraryIcon'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">icon</code> (icon name from absicons, defaults to
+          'audiobookshelf'), <code className="bg-gray-700 px-2 py-1 rounded">fontSize</code> (CSS font size class, defaults to 'text-lg'),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">size</code> (5 or 6 for container size, defaults to 5),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code> (additional CSS classes)
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Library Icon">
+          <div className="bg-gray-700 p-2 rounded-lg">
+            <LibraryIcon />
+          </div>
+        </Example>
+
+        <Example title="Large Size">
+          <div className="bg-gray-700 p-2 rounded-lg">
+            <LibraryIcon size={6} />
+          </div>
+        </Example>
+
+        <Example title="Custom Icon">
+          <LibraryIcon icon="books-1" />
+        </Example>
+
+        <Example title="Custom Font Size">
+          <LibraryIcon fontSize="text-3xl" />
+        </Example>
+
+        <Example title="Custom Icon with Large Size">
+          <LibraryIcon icon="headphones" size={6} fontSize="text-3xl" />
+        </Example>
+
+        <Example title="Invalid Icon (Falls Back to Default)">
+          <LibraryIcon icon="invalid-icon" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// Loading Examples
+export function LoadingExamples() {
+  return (
+    <ComponentExamples title="Loading Indicators">
+      <ComponentInfo component="LoadingIndicator" description="Loading indicator component with animated dots">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import LoadingIndicator from '@/components/ui/LoadingIndicator'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> No props required - displays animated loading dots
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <div className="col-span-1 md:col-span-2 lg:col-span-3">
+          <ComponentInfo component="LoadingSpinner" description="Loading spinner component with various sizes and customization options">
+            <p className="mb-2">
+              <span className="font-bold">Import:</span>{' '}
+              <code className="bg-gray-700 px-2 py-1 rounded">import LoadingSpinner from '@/components/widgets/LoadingSpinner'</code>
+            </p>
+            <p className="mb-2">
+              <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">size</code> (la-sm, la-lg, la-2x, la-3x),{' '}
+              <code className="bg-gray-700 px-2 py-1 rounded">dark</code>, <code className="bg-gray-700 px-2 py-1 rounded">color</code>,{' '}
+              <code className="bg-gray-700 px-2 py-1 rounded">className</code>
+            </p>
+          </ComponentInfo>
+        </div>
+
+        <Example title="Loading Indicator">
+          <LoadingIndicator />
+        </Example>
+
+        <Example title="Loading Spinner (Default - Small)">
+          <LoadingSpinner />
+        </Example>
+
+        <Example title="Loading Spinner (Large)">
+          <LoadingSpinner size="la-lg" />
+        </Example>
+
+        <Example title="Loading Spinner (2x)">
+          <LoadingSpinner size="la-2x" />
+        </Example>
+
+        <Example title="Loading Spinner (3x)">
+          <LoadingSpinner size="la-3x" />
+        </Example>
+
+        <Example title="Loading Spinner (Dark - Large)">
+          <div className="bg-gray-500 p-6 rounded-lg">
+            <LoadingSpinner size="la-lg" dark />
+          </div>
+        </Example>
+
+        <Example title="Loading Spinner (Custom Color - Large)">
+          <LoadingSpinner size="la-lg" color="#ff6b6b" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// MediaIconPicker Examples
+export function MediaIconPickerExamples() {
+  const [mediaIconValue, setMediaIconValue] = useState('audiobookshelf')
+
+  return (
+    <ComponentExamples title="Media Icon Pickers">
+      <ComponentInfo component="MediaIconPicker" description="Icon picker component for selecting library icons with dropdown menu">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import MediaIconPicker from '@/components/ui/MediaIconPicker'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code> (selected icon name, defaults to 'database'),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code> (callback when icon is selected),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">label</code> (label text, defaults to 'Icon'),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code> (disables the picker),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code> (additional CSS classes),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">align</code> (menu alignment, defaults to 'left', options: 'left', 'right', 'center')
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Media Icon Picker">
+          <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} />
+        </Example>
+
+        <Example title="Custom Label & Value">
+          <MediaIconPicker value="books-1" onChange={setMediaIconValue} label="Choose Books Icon" />
+        </Example>
+
+        <Example title="Disabled State">
+          <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} label="Disabled Picker" disabled />
+        </Example>
+
+        <Example title="Menu Alignment (Right)">
+          <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} align="right" />
+        </Example>
+
+        <Example title="Menu Alignment (Center)">
+          <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} align="center" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// MultiSelect Examples
+export function MultiSelectExamples() {
+  const { showToast } = useGlobalToast()
+
+  // MultiSelect sample data
+  const multiSelectItems: MultiSelectItem[] = [
+    { content: 'Apple', value: 'apple' },
+    { content: 'Banana', value: 'banana' },
+    { content: 'Cherry', value: 'cherry' },
+    { content: 'Date', value: 'date' },
+    { content: 'Elderberry', value: 'elderberry' },
+    { content: 'Fig', value: 'fig' },
+    { content: 'Grape', value: 'grape' },
+    { content: 'Honeydew', value: 'honeydew' }
+  ]
+  const [multiSelectValue, setMultiSelectValue] = useState<MultiSelectItem[]>([
+    { content: 'Apple', value: 'apple' },
+    { content: 'Banana', value: 'banana' }
+  ])
+
+  // MultiSelect handlers
+  const handleMultiSelectItemAdded = (item: MultiSelectItem) => {
+    const newItems = [...multiSelectValue, item]
+    setMultiSelectValue(newItems)
+    if (item.value.startsWith('new-')) {
+      showToast(`New item created: ${item.content}`, { type: 'success', title: 'Item Created' })
+    }
+  }
+
+  const handleMultiSelectItemRemoved = (item: MultiSelectItem) => {
+    const newItems = multiSelectValue.filter((i) => i.value !== item.value)
+    setMultiSelectValue(newItems)
+    showToast(`Removed: ${item.content}`, { type: 'info', title: 'Item Removed' })
+  }
+
+  const handleMultiSelectItemEdited = (item: MultiSelectItem, index: number) => {
+    const newItems = [...multiSelectValue]
+    newItems[index] = item
+    setMultiSelectValue(newItems)
+    showToast(`Edited: ${item.content}`, { type: 'info', title: 'Item Edited' })
+  }
+
+  return (
+    <ComponentExamples title="Multi Selects">
+      <div className="col-span-1 md:col-span-2 lg:col-span-3">
+        <ComponentInfo component="MultiSelect" description="Multi-select component with item management, editing, and validation">
+          <p className="mb-2">
+            <span className="font-bold">Import:</span>{' '}
+            <code className="bg-gray-700 px-2 py-1 rounded">
+              import MultiSelect, {'{'} MultiSelectItem {'}'} from '@/components/ui/MultiSelect'
+            </code>
+          </p>
+          <p className="mb-2">
+            <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">selectedItems</code> (MultiSelectItem[]),{' '}
+            <code className="bg-gray-700 px-2 py-1 rounded">onItemAdded</code>, <code className="bg-gray-700 px-2 py-1 rounded">onItemRemoved</code>,{' '}
+            <code className="bg-gray-700 px-2 py-1 rounded">onItemEdited</code>, <code className="bg-gray-700 px-2 py-1 rounded">items</code>{' '}
+            (MultiSelectItem[]), <code className="bg-gray-700 px-2 py-1 rounded">label</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
+            <code className="bg-gray-700 px-2 py-1 rounded">showEdit</code>, <code className="bg-gray-700 px-2 py-1 rounded">onValidate</code>
+          </p>
+        </ComponentInfo>
+      </div>
+
+      <ExamplesBlock>
+        <Example title="Default MultiSelect">
+          <MultiSelect
+            selectedItems={multiSelectValue}
+            onItemAdded={handleMultiSelectItemAdded}
+            onItemRemoved={handleMultiSelectItemRemoved}
+            items={multiSelectItems}
+            label="Select Fruits"
+          />
+        </Example>
+
+        <Example title="MultiSelect with Edit">
+          <MultiSelect
+            selectedItems={multiSelectValue}
+            onItemAdded={handleMultiSelectItemAdded}
+            onItemRemoved={handleMultiSelectItemRemoved}
+            onItemEdited={handleMultiSelectItemEdited}
+            items={multiSelectItems}
+            label="Select Fruits"
+            showEdit
+          />
+        </Example>
+
+        <Example title="Disabled MultiSelect">
+          <MultiSelect
+            selectedItems={multiSelectValue}
+            onItemAdded={handleMultiSelectItemAdded}
+            onItemRemoved={handleMultiSelectItemRemoved}
+            items={multiSelectItems}
+            label="Select Fruits"
+            disabled
+          />
+        </Example>
+
+        <Example title="MultiSelect with Validation">
+          <MultiSelect
+            selectedItems={multiSelectValue}
+            onItemAdded={handleMultiSelectItemAdded}
+            onItemRemoved={handleMultiSelectItemRemoved}
+            onItemEdited={handleMultiSelectItemEdited}
+            items={multiSelectItems}
+            label="Select Fruits"
+            showEdit
+            onValidate={(content) => {
+              if (content.includes(' ')) {
+                return 'A fruit name cannot contain any spaces'
+              }
+              return null
+            }}
+          />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// MultiSelectDropdown Examples
+export function MultiSelectDropdownExamples() {
+  const { showToast } = useGlobalToast()
+
+  const multiSelectDropdownItems = [
+    { content: 'Red', value: '#ff0000' },
+    { content: 'Green', value: '#00ff00' },
+    { content: 'Blue', value: '#0000ff' },
+    { content: 'Yellow', value: '#ffff00' },
+    { content: 'Purple', value: '#800080' }
+  ]
+  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<MultiSelectItem[]>([
+    { content: 'Red', value: '#ff0000' },
+    { content: 'Blue', value: '#0000ff' }
+  ])
+
+  const handleMultiSelectDropdownItemAdded = (item: MultiSelectItem) => {
+    const newItems = [...multiSelectDropdownSelectedItems, item]
+    setMultiSelectDropdownSelectedItems(newItems)
+    if (item.value.startsWith('new-')) {
+      showToast(`New item created: ${item.content}`, { type: 'success', title: 'Item Created' })
+    }
+  }
+
+  const handleMultiSelectDropdownItemRemoved = (item: MultiSelectItem) => {
+    const newItems = multiSelectDropdownSelectedItems.filter((i) => i.value !== item.value)
+    setMultiSelectDropdownSelectedItems(newItems)
+    showToast(`Removed: ${item.content}`, { type: 'info', title: 'Item Removed' })
+  }
+
+  return (
+    <ComponentExamples title="Multi Select Dropdowns">
+      <ComponentInfo component="MultiSelectDropdown" description="Multi-select dropdown component with item management">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">selectedItems</code> (MultiSelectItem[]),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onItemAdded</code>, <code className="bg-gray-700 px-2 py-1 rounded">onItemRemoved</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">items</code> (MultiSelectItem[]), <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default MultiSelectDropdown">
+          <MultiSelectDropdown
+            selectedItems={multiSelectDropdownSelectedItems}
+            onItemAdded={handleMultiSelectDropdownItemAdded}
+            onItemRemoved={handleMultiSelectDropdownItemRemoved}
+            items={multiSelectDropdownItems}
+            label="Select Colors"
+          />
+        </Example>
+        <Example title="Disabled MultiSelectDropdown">
+          <MultiSelectDropdown
+            selectedItems={multiSelectDropdownSelectedItems}
+            onItemAdded={handleMultiSelectDropdownItemAdded}
+            onItemRemoved={handleMultiSelectDropdownItemRemoved}
+            items={multiSelectDropdownItems}
+            label="Select Colors"
+            disabled
+          />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// RangeInput Examples
+export function RangeInputExamples() {
+  // RangeInput sample data
+  const [rangeValue1, setRangeValue1] = useState(50)
+  const [rangeValue2, setRangeValue2] = useState(25)
+  const [rangeValue3, setRangeValue3] = useState(75)
+  const [rangeValue4, setRangeValue4] = useState(0)
+  const [rangeValue5, setRangeValue5] = useState(100)
+
+  return (
+    <ComponentExamples title="Range Inputs">
+      <ComponentInfo component="RangeInput" description="Accessible range input component with customizable min/max/step values, labels, and disabled state">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import RangeInput from '@/components/ui/RangeInput'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>, <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">min</code>, <code className="bg-gray-700 px-2 py-1 rounded">max</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">step</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code>, <code className="bg-gray-700 px-2 py-1 rounded">aria-describedby</code>
+        </p>
+        <p className="mb-2 text-sm text-gray-400">
+          Features: accessible with proper ARIA attributes, keyboard navigation, screen reader support, customizable styling, flexible layout (with/without
+          label)
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default RangeInput">
+          <RangeInput value={rangeValue1} onChange={setRangeValue1} label="Volume Control" />
+        </Example>
+
+        <Example title="RangeInput without Label">
+          <RangeInput value={rangeValue2} onChange={setRangeValue2} />
+        </Example>
+
+        <Example title="Custom Range (0-200)">
+          <RangeInput value={rangeValue3} onChange={setRangeValue3} min={0} max={200} step={10} label="Custom Range With Step" />
+        </Example>
+
+        <Example title="Minimum Value">
+          <RangeInput value={rangeValue4} onChange={setRangeValue4} label="Minimum Value" />
+        </Example>
+
+        <Example title="Maximum Value">
+          <RangeInput value={rangeValue5} onChange={setRangeValue5} label="Maximum Value" />
+        </Example>
+
+        <Example title="Disabled RangeInput">
+          <RangeInput value={50} onChange={() => {}} disabled label="Disabled Range" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// ToastNotification Examples
+export function ToastNotificationExamples() {
+  const { showToast } = useGlobalToast()
+
+  return (
+    <ComponentExamples title="Toasts">
+      <ComponentInfo component="Global Toast Hook" description="Global toast hook for easy toast management throughout the app">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">
+            import {'{'} useGlobalToast {'}'} from '@/contexts/ToastContext'
+          </code>
+        </p>
+        <p className="mb-2">
+          Usage: <br />
+          <code className="bg-gray-700 px-2 py-1 rounded">
+            const {'{'} showToast {'}'} = useGlobalToast()
+          </code>
+          <br />
+          <code className="bg-gray-700 px-2 py-1 rounded">...</code>
+          <br />
+          <code className="bg-gray-700 px-2 py-1 rounded">
+            showToast(message, {'{'} type, title, duration {'}'})
+          </code>
+        </p>
+        <p className="mb-2 text-sm text-gray-400">Note: Global toast is automatically available in all pages. No need to include ToastContainer manually.</p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Success Toast">
+          <Btn onClick={() => showToast('Operation completed successfully!', { type: 'success', title: 'Success' })}>Show Success</Btn>
+        </Example>
+
+        <Example title="Error Toast">
+          <Btn onClick={() => showToast('Something went wrong!', { type: 'error', title: 'Error' })}>Show Error</Btn>
+        </Example>
+
+        <Example title="Warning Toast">
+          <Btn onClick={() => showToast('Please be careful!', { type: 'warning', title: 'Warning' })}>Show Warning</Btn>
+        </Example>
+
+        <Example title="Info Toast">
+          <Btn onClick={() => showToast('Here is some information.', { type: 'info', title: 'Information' })}>Show Info</Btn>
+        </Example>
+
+        <Example title="Long Duration Toast">
+          <Btn onClick={() => showToast('This toast will stay for 10 seconds.', { type: 'info', title: 'Long Toast', duration: 10000 })}>Show Long Toast</Btn>
+        </Example>
+
+        <Example title="No Auto-Dismiss Toast">
+          <Btn onClick={() => showToast('This toast will not auto-dismiss.', { type: 'warning', title: 'Persistent', duration: 0 })}>Show Persistent</Btn>
+        </Example>
+
+        <Example title="Toast with Title Only">
+          <Btn onClick={() => showToast('Just a simple message.', { type: 'info' })}>Show Simple</Btn>
+        </Example>
+
+        <Example title="Multiple Toasts">
+          <Btn
+            onClick={() => {
+              showToast('First notification', { type: 'info', title: 'First' })
+              setTimeout(() => showToast('Second notification', { type: 'success', title: 'Second' }), 500)
+              setTimeout(() => showToast('Third notification', { type: 'warning', title: 'Third' }), 1000)
+            }}
+          >
+            Show Multiple
+          </Btn>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// TwoStageMultiSelect Examples
+export function TwoStageMultiSelectExamples() {
+  const { showToast } = useGlobalToast()
+
+  const [twoStageMultiSelectValue, setTwoStageMultiSelectValue] = useState<MultiSelectItem<TwoStageMultiSelectContent>[]>([
+    { value: '1', content: { value: 'Harry Potter', modifier: '1' } },
+    { value: '2', content: { value: 'Lord of the Rings', modifier: '3' } }
+  ])
+
+  const twoStageMultiSelectItems = [
+    { value: '1', content: 'Harry Potter' },
+    { value: '2', content: 'Lord of the Rings' },
+    { value: '3', content: 'The Hitchhikers Guide to the Galaxy' },
+    { value: '4', content: 'The Chronicles of Narnia' },
+    { value: '5', content: 'The Hunger Games' },
+    { value: '6', content: 'Foundation' },
+    { value: '7', content: 'A song of ice and fire' },
+    { value: '8', content: 'Robots' }
+  ]
+
+  const handleTwoStageMultiSelectItemAdded = (item: any) => {
+    const newItems = [...twoStageMultiSelectValue, item]
+    setTwoStageMultiSelectValue(newItems)
+    if (item.value.startsWith('new-')) {
+      console.log('new item', item)
+      showToast(`New item created: ${item.content.value}${item.content.modifier ? ` #${item.content.modifier}` : ''}`, {
+        type: 'success',
+        title: 'Item Created'
+      })
+    }
+  }
+
+  const handleTwoStageMultiSelectItemRemoved = (item: any) => {
+    const newItems = twoStageMultiSelectValue.filter((i) => i.value !== item.value)
+    setTwoStageMultiSelectValue(newItems)
+    showToast(`Removed: ${item.content.value}${item.content.modifier ? ` #${item.content.modifier}` : ''}`, { type: 'info', title: 'Item Removed' })
+  }
+
+  const handleTwoStageMultiSelectItemEdited = (item: any, index: number) => {
+    const newItems = [...twoStageMultiSelectValue]
+    newItems[index] = item
+    setTwoStageMultiSelectValue(newItems)
+  }
+
+  return (
+    <ComponentExamples title="Two Stage Multi Selects">
+      <ComponentInfo component="TwoStageMultiSelect" description="Two-stage multi-select component with primary and modifier values">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">
+            import TwoStageMultiSelect, {'{'} TwoStageMultiSelectContent {'}'} from '@/components/ui/TwoStageMultiSelect'
+          </code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">selectedItems</code>{' '}
+          (MultiSelectItem&lt;TwoStageMultiSelectContent&gt;[]), <code className="bg-gray-700 px-2 py-1 rounded">onItemAdded</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onItemRemoved</code>, <code className="bg-gray-700 px-2 py-1 rounded">onItemEdited</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">items</code>, <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onValidate</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default TwoStageMultiSelect">
+          <TwoStageMultiSelect
+            selectedItems={twoStageMultiSelectValue}
+            onItemAdded={handleTwoStageMultiSelectItemAdded}
+            onItemRemoved={handleTwoStageMultiSelectItemRemoved}
+            onItemEdited={handleTwoStageMultiSelectItemEdited}
+            items={twoStageMultiSelectItems}
+            label="Select Series and Sequence"
+            onValidate={(content) => {
+              if (content.modifier && content.modifier.includes(' ')) {
+                return 'A sequence cannot contain any spaces'
+              }
+              return null
+            }}
+          />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// AdvancedModal Examples
+export function AdvancedModalExamples() {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const { showToast } = useGlobalToast()
+
+  // MultiSelect sample data
+  const multiSelectItems: MultiSelectItem[] = [
+    { content: 'Apple', value: 'apple' },
+    { content: 'Banana', value: 'banana' },
+    { content: 'Cherry', value: 'cherry' },
+    { content: 'Date', value: 'date' },
+    { content: 'Elderberry', value: 'elderberry' },
+    { content: 'Fig', value: 'fig' },
+    { content: 'Grape', value: 'grape' },
+    { content: 'Honeydew', value: 'honeydew' }
+  ]
+  const [multiSelectValue, setMultiSelectValue] = useState<MultiSelectItem[]>([
+    { content: 'Apple', value: 'apple' },
+    { content: 'Banana', value: 'banana' }
+  ])
+
+  // MultiSelect handlers
+  const handleMultiSelectItemAdded = (item: MultiSelectItem) => {
+    const newItems = [...multiSelectValue, item]
+    setMultiSelectValue(newItems)
+    if (item.value.startsWith('new-')) {
+      showToast(`New item created: ${item.content}`, { type: 'success', title: 'Item Created' })
+    }
+  }
+
+  const handleMultiSelectItemRemoved = (item: MultiSelectItem) => {
+    const newItems = multiSelectValue.filter((i) => i.value !== item.value)
+    setMultiSelectValue(newItems)
+    showToast(`Removed: ${item.content}`, { type: 'info', title: 'Item Removed' })
+  }
+
+  const handleMultiSelectItemEdited = (item: MultiSelectItem, index: number) => {
+    const newItems = [...multiSelectValue]
+    newItems[index] = item
+    setMultiSelectValue(newItems)
+    showToast(`Edited: ${item.content}`, { type: 'info', title: 'Item Edited' })
+  }
+
+  return (
+    <ComponentExamples title="Advanced Modal Examples">
+      <ExamplesBlock>
+        <Example title="MultiSelect within Modal Dialog">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">This example shows how MultiSelect works inside a modal dialog.</p>
+            <Btn onClick={() => setIsModalOpen(true)}>Open Modal with MultiSelect</Btn>
+
+            <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} width={600}>
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-6 border-b border-gray-600 pb-4">
+                  <h3 className="text-xl font-semibold text-white">Edit Tags</h3>
+                </div>
+
+                {/* Content */}
+                <div className="space-y-4 flex-1">
+                  <p className="text-gray-300 text-sm">Select or add tags for this item.</p>
+
+                  <MultiSelect
+                    selectedItems={multiSelectValue}
+                    onItemAdded={handleMultiSelectItemAdded}
+                    onItemRemoved={handleMultiSelectItemRemoved}
+                    onItemEdited={handleMultiSelectItemEdited}
+                    items={multiSelectItems}
+                    label="Item Tags"
+                    showEdit
+                  />
+
+                  <div className="text-xs text-gray-400 mt-2">
+                    Current selection: {multiSelectValue.length > 0 ? multiSelectValue.map((i) => i.content).join(', ') : 'None'}
+                  </div>
+                </div>
+
+                {/* Footer */}
+                <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-600">
+                  <Btn onClick={() => setIsModalOpen(false)} color="bg-gray-600">
+                    Cancel
+                  </Btn>
+                  <Btn onClick={() => setIsModalOpen(false)} color="bg-blue-600">
+                    Save Changes
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// Modal Examples
+export function ModalExamples() {
+  const [isBasicModalOpen, setIsBasicModalOpen] = useState(false)
+  const [isProcessingModalOpen, setIsProcessingModalOpen] = useState(false)
+  const [isPersistentModalOpen, setIsPersistentModalOpen] = useState(false)
+  const [isCustomModalOpen, setIsCustomModalOpen] = useState(false)
+  const [isOuterContentModalOpen, setIsOuterContentModalOpen] = useState(false)
+  const [isResponsiveModalOpen, setIsResponsiveModalOpen] = useState(false)
+  const [isProcessing, setIsProcessing] = useState(false)
+  const { showToast } = useGlobalToast()
+
+  const handleProcessingDemo = () => {
+    setIsProcessing(true)
+    setTimeout(() => {
+      setIsProcessing(false)
+      showToast('Processing completed!', { type: 'success', title: 'Processing Demo' })
+    }, 3000)
+  }
+
+  return (
+    <ComponentExamples title="Modals">
+      <ComponentInfo component="Modal" description="Modal dialog component with backdrop, animations, and various customization options">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import Modal from '@/components/modals/Modal'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">isOpen</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onClose</code>, <code className="bg-gray-700 px-2 py-1 rounded">children</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">width</code>, <code className="bg-gray-700 px-2 py-1 rounded">height</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">persistent</code>, <code className="bg-gray-700 px-2 py-1 rounded">processing</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">zIndexClass</code>, <code className="bg-gray-700 px-2 py-1 rounded">bgOpacityClass</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">contentMarginTop</code>, <code className="bg-gray-700 px-2 py-1 rounded">outerContent</code>
+        </p>
+        <p className="mb-2 text-sm text-gray-400">
+          Features: portal rendering, smooth animations, focus management, keyboard navigation (Escape), backdrop click to close, processing overlay, persistent
+          mode, customizable dimensions and styling
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Basic Modal">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">A simple modal with default settings and close functionality.</p>
+            <Btn onClick={() => setIsBasicModalOpen(true)}>Open Basic Modal</Btn>
+
+            <Modal isOpen={isBasicModalOpen} onClose={() => setIsBasicModalOpen(false)}>
+              <div className="bg-gray-800 rounded-lg p-6 max-w-md">
+                <h3 className="text-xl font-semibold text-white mb-4">Basic Modal Example</h3>
+                <p className="text-gray-300 mb-6">
+                  This is a basic modal dialog. You can close it by clicking the close button, pressing Escape, or clicking outside the modal content.
+                </p>
+                <div className="flex justify-end gap-3">
+                  <Btn onClick={() => setIsBasicModalOpen(false)} color="bg-gray-600">
+                    Close
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+
+        <Example title="Processing Modal">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">A modal with a processing overlay that prevents interaction during operations.</p>
+            <Btn onClick={() => setIsProcessingModalOpen(true)}>Open Processing Modal</Btn>
+
+            <Modal isOpen={isProcessingModalOpen} onClose={() => setIsProcessingModalOpen(false)} processing={isProcessing} width={500} height={300}>
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Processing Example</h3>
+                <p className="text-gray-300 mb-6 flex-1">
+                  Click the "Start Processing" button to see the processing overlay in action. The modal will be disabled during processing.
+                </p>
+                <div className="flex justify-end gap-3">
+                  <Btn onClick={() => setIsProcessingModalOpen(false)} color="bg-gray-600">
+                    Cancel
+                  </Btn>
+                  <Btn onClick={handleProcessingDemo} color="bg-blue-600" disabled={isProcessing}>
+                    {isProcessing ? 'Processing...' : 'Start Processing'}
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+
+        <Example title="Persistent Modal">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">A modal that cannot be closed by clicking outside or pressing Escape.</p>
+            <Btn onClick={() => setIsPersistentModalOpen(true)}>Open Persistent Modal</Btn>
+
+            <Modal
+              isOpen={isPersistentModalOpen}
+              onClose={() => setIsPersistentModalOpen(false)}
+              persistent={true}
+              width={450}
+              height={250}
+              bgOpacityClass="bg-primary/90"
+            >
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Persistent Modal</h3>
+                <p className="text-gray-300 mb-6 flex-1">
+                  This modal is persistent - you can only close it by clicking the "Close" button. Background clicks and Escape key are disabled.
+                </p>
+                <div className="flex justify-center">
+                  <Btn onClick={() => setIsPersistentModalOpen(false)} color="bg-red-600">
+                    Close Modal
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+
+        <Example title="Custom Styled Modal">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">A modal with custom dimensions and Tailwind z-index/opacity classes.</p>
+            <Btn onClick={() => setIsCustomModalOpen(true)}>Open Custom Modal</Btn>
+
+            <Modal
+              isOpen={isCustomModalOpen}
+              onClose={() => setIsCustomModalOpen(false)}
+              width={800}
+              height={600}
+              zIndexClass="z-[100]"
+              bgOpacityClass="bg-primary/50"
+              contentMarginTop={20}
+            >
+              <div className="bg-gradient-to-br from-blue-900 to-purple-900 rounded-lg p-8 h-full flex flex-col">
+                <h3 className="text-2xl font-bold text-white mb-6">Custom Styled Modal</h3>
+                <div className="flex-1 space-y-4">
+                  <p className="text-blue-100">This modal demonstrates custom styling options:</p>
+                  <ul className="list-disc list-inside text-blue-100 space-y-2">
+                    <li>Custom width (800px) and height (600px)</li>
+                    <li>Higher z-index (z-[100]) using Tailwind classes</li>
+                    <li>Lower background opacity (bg-primary/50) using Tailwind classes</li>
+                    <li>Custom margin top (20px)</li>
+                    <li>Gradient background styling</li>
+                  </ul>
+                  <div className="bg-blue-800/30 rounded p-4 mt-4">
+                    <h4 className="text-lg font-semibold text-white mb-2">Modal Features</h4>
+                    <p className="text-blue-100 text-sm">
+                      The Modal component supports focus management, keyboard navigation, smooth animations, and portal rendering for proper z-index handling.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex justify-end gap-3 pt-6 border-t border-blue-700">
+                  <Btn onClick={() => setIsCustomModalOpen(false)} color="bg-blue-600">
+                    Close Custom Modal
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+
+        <Example title="Modal with Outer Content">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">A modal that can display content outside the main modal area.</p>
+            <Btn onClick={() => setIsOuterContentModalOpen(true)}>Open with Outer Content</Btn>
+
+            <Modal
+              isOpen={isOuterContentModalOpen}
+              onClose={() => setIsOuterContentModalOpen(false)}
+              width={400}
+              height={300}
+              outerContent={<div className="absolute top-10 left-10 bg-yellow-500 text-black px-3 py-1 rounded text-sm font-semibold">Outer Content!</div>}
+            >
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Modal with Outer Content</h3>
+                <p className="text-gray-300 mb-6 flex-1">
+                  This modal has additional content rendered outside the main modal container. Check the yellow badge in the top-left corner.
+                </p>
+                <div className="flex justify-end">
+                  <Btn onClick={() => setIsOuterContentModalOpen(false)} color="bg-gray-600">
+                    Close
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+
+        <Example title="Responsive Modal">
+          <div>
+            <p className="text-gray-400 text-sm mb-4">A modal that adapts to different screen sizes using string dimensions.</p>
+            <Btn onClick={() => setIsResponsiveModalOpen(true)}>Open Responsive Modal</Btn>
+
+            <Modal isOpen={isResponsiveModalOpen} onClose={() => setIsResponsiveModalOpen(false)} width="90vw" height="80vh">
+              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
+                <h3 className="text-xl font-semibold text-white mb-4">Responsive Modal</h3>
+                <div className="flex-1 space-y-4">
+                  <p className="text-gray-300">This modal uses viewport units for its dimensions:</p>
+                  <ul className="list-disc list-inside text-gray-300 space-y-2">
+                    <li>Width: 90vw (90% of viewport width)</li>
+                    <li>Height: 80vh (80% of viewport height)</li>
+                    <li>Automatically adapts to screen size</li>
+                    <li>Perfect for mobile devices</li>
+                  </ul>
+                  <div className="bg-gray-700 rounded p-4">
+                    <p className="text-sm text-gray-300">Try resizing your browser window to see how the modal adapts to different screen sizes.</p>
+                  </div>
+                </div>
+                <div className="flex justify-end pt-4 border-t border-gray-600">
+                  <Btn onClick={() => setIsResponsiveModalOpen(false)} color="bg-gray-600">
+                    Close
+                  </Btn>
+                </div>
+              </div>
+            </Modal>
+          </div>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}

--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -566,42 +566,42 @@ export function ReadIconBtnExamples() {
       </ComponentInfo>
 
       <ExamplesBlock>
-        <Example title="Default Read Button (Unread)">
+        <Example title="Default Button (Unread)">
           <div className="flex items-center gap-4">
             <ReadIconBtn isRead={isRead1} onClick={() => handleReadToggle(isRead1, setIsRead1)} />
             <span className="text-sm text-gray-400">Click to toggle read status</span>
           </div>
         </Example>
 
-        <Example title="Default Read Button (Read)">
+        <Example title="Default Button (Read)">
           <div className="flex items-center gap-4">
             <ReadIconBtn isRead={isRead2} onClick={() => handleReadToggle(isRead2, setIsRead2)} />
             <span className="text-sm text-gray-400">Click to toggle read status</span>
           </div>
         </Example>
 
-        <Example title="Borderless Read Button">
+        <Example title="Borderless Button (Unread)">
           <div className="flex items-center gap-4">
             <ReadIconBtn isRead={isRead3} borderless onClick={() => handleReadToggle(isRead3, setIsRead3)} />
             <span className="text-sm text-gray-400">Borderless style</span>
           </div>
         </Example>
 
-        <Example title="Disabled Read Button">
+        <Example title="Disabled Button (Read)">
           <div className="flex items-center gap-4">
             <ReadIconBtn isRead={true} disabled />
             <span className="text-sm text-gray-400">Disabled state</span>
           </div>
         </Example>
 
-        <Example title="Borderless Disabled Unread Button">
+        <Example title="Borderless Disabled Button (Unread)">
           <div className="flex items-center gap-4">
             <ReadIconBtn isRead={false} borderless disabled />
             <span className="text-sm text-gray-400">Borderless disabled</span>
           </div>
         </Example>
 
-        <Example title="Custom Styled Read Button">
+        <Example title="Custom Styled Button (Read)">
           <div className="flex items-center gap-4">
             <ReadIconBtn isRead={isRead4} onClick={() => handleReadToggle(isRead4, setIsRead4)} className="bg-blue-600 hover:bg-blue-700" />
             <span className="text-sm text-gray-400">Custom background color</span>

--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -19,6 +19,7 @@ import Modal from '@/components/modals/Modal'
 import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
 import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
 import RangeInput from '@/components/ui/RangeInput'
+import ReadIconBtn from '@/components/ui/ReadIconBtn'
 import TwoStageMultiSelect, { TwoStageMultiSelectContent } from '@/components/ui/TwoStageMultiSelect'
 import { useGlobalToast } from '@/contexts/ToastContext'
 
@@ -526,6 +527,87 @@ export function IconBtnExamples() {
 
         <Example title="Custom Icon Font Size">
           <IconBtn icon="&#xe3c9;" iconFontSize="text-2xl" ariaLabel="Edit" />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// ReadIconBtn Examples
+export function ReadIconBtnExamples() {
+  const [isRead1, setIsRead1] = useState(false)
+  const [isRead2, setIsRead2] = useState(true)
+  const [isRead3, setIsRead3] = useState(false)
+  const [isRead4, setIsRead4] = useState(true)
+  const [isRead5, setIsRead5] = useState(false)
+  const [isRead6, setIsRead6] = useState(true)
+
+  const { showToast } = useGlobalToast()
+
+  const handleReadToggle = (isRead: boolean, setRead: (value: boolean) => void) => {
+    setRead(!isRead)
+    showToast(!isRead ? 'Marked as finished' : 'Marked as not finished', { type: 'success', title: 'Read Status Updated' })
+  }
+
+  return (
+    <ComponentExamples title="Read Icon Buttons">
+      <ComponentInfo component="ReadIconBtn" description="Read status toggle button using IconBtn with BeenHere icon and visual state indication">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import ReadIconBtn from '@/components/ui/ReadIconBtn'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">isRead</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">borderless</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onClick</code>, <code className="bg-gray-700 px-2 py-1 rounded">className</code>
+        </p>
+        <p className="mb-2 text-sm text-gray-400">
+          Features: uses IconBtn with e52d (BeenHere) icon, visual distinction between read/unread states with color coding, proper ARIA labels, event handling
+          with stopPropagation, and all IconBtn features (disabled, borderless, etc.)
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Read Button (Unread)">
+          <div className="flex items-center gap-4">
+            <ReadIconBtn isRead={isRead1} onClick={() => handleReadToggle(isRead1, setIsRead1)} />
+            <span className="text-sm text-gray-400">Click to toggle read status</span>
+          </div>
+        </Example>
+
+        <Example title="Default Read Button (Read)">
+          <div className="flex items-center gap-4">
+            <ReadIconBtn isRead={isRead2} onClick={() => handleReadToggle(isRead2, setIsRead2)} />
+            <span className="text-sm text-gray-400">Click to toggle read status</span>
+          </div>
+        </Example>
+
+        <Example title="Borderless Read Button">
+          <div className="flex items-center gap-4">
+            <ReadIconBtn isRead={isRead3} borderless onClick={() => handleReadToggle(isRead3, setIsRead3)} />
+            <span className="text-sm text-gray-400">Borderless style</span>
+          </div>
+        </Example>
+
+        <Example title="Disabled Read Button">
+          <div className="flex items-center gap-4">
+            <ReadIconBtn isRead={isRead4} disabled />
+            <span className="text-sm text-gray-400">Disabled state</span>
+          </div>
+        </Example>
+
+        <Example title="Borderless Disabled Read Button">
+          <div className="flex items-center gap-4">
+            <ReadIconBtn isRead={isRead5} borderless disabled />
+            <span className="text-sm text-gray-400">Borderless disabled</span>
+          </div>
+        </Example>
+
+        <Example title="Custom Styled Read Button">
+          <div className="flex items-center gap-4">
+            <ReadIconBtn isRead={isRead6} onClick={() => handleReadToggle(isRead6, setIsRead6)} className="bg-blue-600 hover:bg-blue-700" />
+            <span className="text-sm text-gray-400">Custom background color</span>
+          </div>
         </Example>
       </ExamplesBlock>
     </ComponentExamples>

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -11,6 +11,7 @@ import {
   MultiSelectDropdownExamples,
   ModalExamples,
   RangeInputExamples,
+  ReadIconBtnExamples,
   CheckboxExamples,
   FileInputExamples,
   LibraryIconExamples,
@@ -44,6 +45,11 @@ export default function ComponentsCatalogPage() {
                 <li>
                   <a href="#icon-button-components" className="hover:text-blue-400 transition-colors">
                     Icon Buttons
+                  </a>
+                </li>
+                <li>
+                  <a href="#read-icon-button-components" className="hover:text-blue-400 transition-colors">
+                    Read Icon Buttons
                   </a>
                 </li>
                 <li>
@@ -132,6 +138,9 @@ export default function ComponentsCatalogPage() {
       </div>
       <div id="icon-button-components">
         <IconBtnExamples />
+      </div>
+      <div id="read-icon-button-components">
+        <ReadIconBtnExamples />
       </div>
       <div id="context-menu-dropdown-components">
         <ContextMenuDropdownExamples />

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -1,292 +1,26 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
-import Btn from '@/components/ui/Btn'
-import Checkbox from '@/components/ui/Checkbox'
-import LoadingIndicator from '@/components/ui/LoadingIndicator'
-import LoadingSpinner from '@/components/widgets/LoadingSpinner'
-import IconBtn from '@/components/ui/IconBtn'
-import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
-import type { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
-import Dropdown from '@/components/ui/Dropdown'
-import type { DropdownItem } from '@/components/ui/Dropdown'
-import InputDropdown from '@/components/ui/InputDropdown'
-import FileInput from '@/components/ui/FileInput'
-import LibraryIcon from '@/components/ui/LibraryIcon'
-import MediaIconPicker from '@/components/ui/MediaIconPicker'
-import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
-import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'
-import { useGlobalToast } from '@/contexts/ToastContext'
-import Modal from '@/components/modals/Modal'
-import TwoStageMultiSelect, { TwoStageMultiSelectContent } from '@/components/ui/TwoStageMultiSelect'
+import {
+  BtnExamples,
+  IconBtnExamples,
+  ContextMenuDropdownExamples,
+  DropdownExamples,
+  InputDropdownExamples,
+  MultiSelectExamples,
+  TwoStageMultiSelectExamples,
+  MultiSelectDropdownExamples,
+  ModalExamples,
+  RangeInputExamples,
+  CheckboxExamples,
+  FileInputExamples,
+  LibraryIconExamples,
+  MediaIconPickerExamples,
+  LoadingExamples,
+  AdvancedModalExamples,
+  ToastNotificationExamples
+} from './ComponentExamples'
 
 export default function ComponentsCatalogPage() {
-  const { showToast } = useGlobalToast()
-  const [checkboxValue, setCheckboxValue] = useState(false)
-  const [checkboxValue2, setCheckboxValue2] = useState(true)
-  const [checkboxValue3, setCheckboxValue3] = useState(false)
-
-  // Dropdown sample data
-  const dropdownItems: DropdownItem[] = [
-    { text: 'Option 1', value: 'option1' },
-    { text: 'Option 2', value: 'option2' },
-    { text: 'Option 3', value: 'option3' },
-    { text: 'Option 4', value: 'option4' }
-  ]
-
-  const dropdownItemsWithSubtext: DropdownItem[] = [
-    { text: 'English', value: 'en', subtext: 'US' },
-    { text: 'Spanish', value: 'es', subtext: 'ES' },
-    { text: 'French', value: 'fr', subtext: 'FR' },
-    { text: 'German', value: 'de', subtext: 'DE' }
-  ]
-
-  const [dropdownValue, setDropdownValue] = useState('option1')
-  const [dropdownValue2, setDropdownValue2] = useState('en')
-  const [dropdownValue3, setDropdownValue3] = useState('option1')
-  const [mediaIconValue, setMediaIconValue] = useState('audiobookshelf')
-
-  // InputDropdown sample data
-  const inputDropdownItems = ['Apple', 'Banana', 'Cherry', 'Date', 'Elderberry', 'Fig', 'Grape', 'Honeydew']
-  const [inputDropdownValue, setInputDropdownValue] = useState('')
-  const [inputDropdownValue2, setInputDropdownValue2] = useState('')
-  const [inputDropdownValue3, setInputDropdownValue3] = useState('')
-
-  // MultiSelect sample data
-  const multiSelectItems: MultiSelectItem[] = [
-    { content: 'Apple', value: 'apple' },
-    { content: 'Banana', value: 'banana' },
-    { content: 'Cherry', value: 'cherry' },
-    { content: 'Date', value: 'date' },
-    { content: 'Elderberry', value: 'elderberry' },
-    { content: 'Fig', value: 'fig' },
-    { content: 'Grape', value: 'grape' },
-    { content: 'Honeydew', value: 'honeydew' }
-  ]
-  const [multiSelectValue, setMultiSelectValue] = useState<MultiSelectItem[]>([
-    { content: 'Apple', value: 'apple' },
-    { content: 'Banana', value: 'banana' }
-  ])
-  const multiSelectDropdownItems = [
-    { content: 'Red', value: '#ff0000' },
-    { content: 'Green', value: '#00ff00' },
-    { content: 'Blue', value: '#0000ff' },
-    { content: 'Yellow', value: '#ffff00' },
-    { content: 'Purple', value: '#800080' }
-  ]
-  const [multiSelectDropdownSelectedItems, setMultiSelectDropdownSelectedItems] = useState<MultiSelectItem[]>([
-    { content: 'Red', value: '#ff0000' },
-    { content: 'Blue', value: '#0000ff' }
-  ])
-
-  // Modal state
-  const [isModalOpen, setIsModalOpen] = useState(false)
-  const [isBasicModalOpen, setIsBasicModalOpen] = useState(false)
-  const [isOuterContentModalOpen, setIsOuterContentModalOpen] = useState(false)
-  const [isResponsiveModalOpen, setIsResponsiveModalOpen] = useState(false)
-  const [isProcessingModalOpen, setIsProcessingModalOpen] = useState(false)
-  const [isPersistentModalOpen, setIsPersistentModalOpen] = useState(false)
-  const [isCustomModalOpen, setIsCustomModalOpen] = useState(false)
-  const [isProcessing, setIsProcessing] = useState(false)
-  const [modalMultiSelectValue, setModalMultiSelectValue] = useState<MultiSelectItem[]>([
-    { content: 'Cherry', value: 'cherry' },
-    { content: 'Date', value: 'date' }
-  ])
-
-  const [twoStageMultiSelectValue, setTwoStageMultiSelectValue] = useState<MultiSelectItem<TwoStageMultiSelectContent>[]>([
-    { value: '1', content: { value: 'Harry Potter', modifier: '1' } },
-    { value: '2', content: { value: 'Lord of the Rings', modifier: '3' } }
-  ])
-
-  const twoStageMultiSelectItems = [
-    { value: '1', content: 'Harry Potter' },
-    { value: '2', content: 'Lord of the Rings' },
-    { value: '3', content: 'The Hitchhikers Guide to the Galaxy' },
-    { value: '4', content: 'The Chronicles of Narnia' },
-    { value: '5', content: 'The Hunger Games' },
-    { value: '6', content: 'Foundation' },
-    { value: '7', content: 'A song of ice and fire' },
-    { value: '8', content: 'Robots' }
-  ]
-
-  const handleTwoStageMultiSelectItemAdded = (item: any) => {
-    const newItems = [...twoStageMultiSelectValue, item]
-    setTwoStageMultiSelectValue(newItems)
-    if (item.value.startsWith('new-')) {
-      console.log('new item', item)
-      showToast(`New item created: ${item.content.value}${item.content.modifier ? ` #${item.content.modifier}` : ''}`, {
-        type: 'success',
-        title: 'Item Created'
-      })
-    }
-  }
-
-  const handleTwoStageMultiSelectItemRemoved = (item: any) => {
-    const newItems = twoStageMultiSelectValue.filter((i) => i.value !== item.value)
-    setTwoStageMultiSelectValue(newItems)
-    showToast(`Removed: ${item.content.value}${item.content.modifier ? ` #${item.content.modifier}` : ''}`, { type: 'info', title: 'Item Removed' })
-  }
-
-  const handleTwoStageMultiSelectItemEdited = (item: any, index: number) => {
-    const newItems = [...twoStageMultiSelectValue]
-    newItems[index] = item
-    setTwoStageMultiSelectValue(newItems)
-  }
-
-  // MultiSelect handlers
-  const handleMultiSelectItemAdded = (item: MultiSelectItem) => {
-    const newItems = [...multiSelectValue, item]
-    setMultiSelectValue(newItems)
-    if (item.value.startsWith('new-')) {
-      showToast(`New item created: ${item.content}`, { type: 'success', title: 'Item Created' })
-    }
-  }
-
-  const handleMultiSelectItemRemoved = (item: MultiSelectItem) => {
-    const newItems = multiSelectValue.filter((i) => i.value !== item.value)
-    setMultiSelectValue(newItems)
-    showToast(`Removed: ${item.content}`, { type: 'info', title: 'Item Removed' })
-  }
-
-  const handleMultiSelectItemEdited = (item: MultiSelectItem, index: number) => {
-    const newItems = [...multiSelectValue]
-    newItems[index] = item
-    setMultiSelectValue(newItems)
-    showToast(`Edited: ${item.content}`, { type: 'info', title: 'Item Edited' })
-  }
-
-  const handleModalMultiSelectItemAdded = (item: MultiSelectItem) => {
-    const newItems = [...modalMultiSelectValue, item]
-    setModalMultiSelectValue(newItems)
-    if (item.value.startsWith('new-')) {
-      showToast(`New item created: ${item.content}`, { type: 'success', title: 'Item Created' })
-    }
-  }
-
-  const handleModalMultiSelectItemRemoved = (item: MultiSelectItem) => {
-    const newItems = modalMultiSelectValue.filter((i) => i.value !== item.value)
-    setModalMultiSelectValue(newItems)
-    showToast(`Removed tag: ${item.content}`, { type: 'info', title: 'Tag Removed' })
-  }
-
-  const handleModalMultiSelectItemEdited = (item: MultiSelectItem, index: number) => {
-    const newItems = [...modalMultiSelectValue]
-    newItems[index] = item
-    setModalMultiSelectValue(newItems)
-    showToast(`Edited tag: ${item.content}`, { type: 'info', title: 'Tag Edited' })
-  }
-
-  const handleMultiSelectDropdownItemAdded = (item: MultiSelectItem) => {
-    const newItems = [...multiSelectDropdownSelectedItems, item]
-    setMultiSelectDropdownSelectedItems(newItems)
-    if (item.value.startsWith('new-')) {
-      showToast(`New item created: ${item.content}`, { type: 'success', title: 'Item Created' })
-    }
-  }
-
-  const handleMultiSelectDropdownItemRemoved = (item: MultiSelectItem) => {
-    const newItems = multiSelectDropdownSelectedItems.filter((i) => i.value !== item.value)
-    setMultiSelectDropdownSelectedItems(newItems)
-    showToast(`Removed: ${item.content}`, { type: 'info', title: 'Item Removed' })
-  }
-
-  // Dropdown change handlers
-  const handleDropdownChange = (value: string | number) => {
-    setDropdownValue(String(value))
-  }
-
-  const handleDropdownChange2 = (value: string | number) => {
-    setDropdownValue2(String(value))
-  }
-
-  const handleDropdownChange3 = (value: string | number) => {
-    setDropdownValue3(String(value))
-  }
-
-  // InputDropdown change handlers
-  const handleInputDropdownChange = (value: string | number) => {
-    setInputDropdownValue(String(value))
-  }
-
-  const handleInputDropdownChange2 = (value: string | number) => {
-    setInputDropdownValue2(String(value))
-  }
-
-  const handleInputDropdownChange3 = (value: string | number) => {
-    setInputDropdownValue3(String(value))
-  }
-
-  const handleInputDropdownNewItem = (value: string) => {
-    showToast(`New item created: ${value}`, { type: 'success', title: 'Item Created' })
-  }
-
-  // Helper function to simulate processing
-  const handleProcessingDemo = () => {
-    setIsProcessing(true)
-    setTimeout(() => {
-      setIsProcessing(false)
-      setIsProcessingModalOpen(false)
-      showToast('Processing completed!', { type: 'success', title: 'Success' })
-    }, 3000)
-  }
-
-  // ContextMenuDropdown sample data
-  const contextMenuItems: ContextMenuDropdownItem[] = [
-    { text: 'Edit', action: 'edit' },
-    { text: 'Delete', action: 'delete' },
-    {
-      text: 'More Options',
-      action: 'more',
-      subitems: [
-        { text: 'Copy', action: 'copy' },
-        { text: 'Move', action: 'move' },
-        { text: 'Share', action: 'share' }
-      ]
-    },
-    {
-      text: 'More Options 2',
-      action: 'more2',
-      subitems: [
-        { text: 'Copy 2', action: 'copy2' },
-        { text: 'Move 2', action: 'move2' },
-        { text: 'Share 2', action: 'share2' }
-      ]
-    }
-  ]
-
-  const contextMenuItemsWithData: ContextMenuDropdownItem[] = [
-    { text: 'Edit Item', action: 'edit' },
-    { text: 'Delete Item', action: 'delete' },
-    {
-      text: 'Advanced',
-      action: 'advanced',
-      subitems: [
-        { text: 'Duplicate', action: 'duplicate', data: { id: 1 } },
-        { text: 'Archive', action: 'archive', data: { id: 1 } }
-      ]
-    }
-  ]
-
-  const contextMenuItemsWithEmptySubitems: ContextMenuDropdownItem[] = [
-    { text: 'Edit Item', action: 'edit' },
-    { text: 'Delete Item', action: 'delete' },
-    { text: 'Empty', action: 'empty', subitems: [] }
-  ]
-
-  const seriesItems: MultiSelectItem[] = [
-    { content: 'Lord of the Rings', value: '1' },
-    { content: 'Foundation', value: '2' },
-    { content: 'The Hitchhikers Guide to the Galaxy', value: '3' },
-    { content: 'The Chronicles of Narnia', value: '4' },
-    { content: 'Harry Potter', value: '5' },
-    { content: 'The Hunger Games', value: '6' },
-    { content: 'A very very very very very very very very very very very very long series name', value: '7' }
-  ]
-  const [seriesSelectedItems, setSeriesSelectedItems] = useState<MultiSelectItem[]>([
-    { value: '1', content: 'Lord of the Rings#1' },
-    { value: '3', content: 'The Hitchhikers Guide to the Galaxy#2' }
-  ])
-
   return (
     <div className="p-8 w-full max-w-7xl mx-auto">
       <div className="mb-8">
@@ -294,1181 +28,156 @@ export default function ComponentsCatalogPage() {
         <p className="text-gray-300 mb-6">This page showcases all the available UI components in the audiobookshelf client.</p>
       </div>
 
-      {/* Button Components */}
+      {/* Table of Contents */}
       <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Button Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Primary Button</h3>
-            <Btn>Primary Button</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Small Button</h3>
-            <Btn small>Small Button</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Button</h3>
-            <Btn loading>Loading...</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Small Loading Button</h3>
-            <Btn small loading>
-              Loading...
-            </Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled Button</h3>
-            <Btn disabled>Disabled Button</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Button with Progress</h3>
-            <Btn loading progress="75%">
-              Uploading...
-            </Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Link Button</h3>
-            <Btn to="/settings">Go to Settings</Btn>
-          </div>
-        </div>
-      </section>
-
-      {/* Icon Button Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Icon Button Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Icon Button</h3>
-            <IconBtn icon="&#xe3c9;" ariaLabel="Edit" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Outlined Icon Button</h3>
-            <IconBtn icon="&#xe5ca;" outlined ariaLabel="Close" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Borderless Icon Button</h3>
-            <IconBtn icon="&#xe3c9;" borderless ariaLabel="Edit" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Icon Button</h3>
-            <IconBtn icon="&#xe3c9;" loading ariaLabel="Loading" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled Icon Button</h3>
-            <IconBtn icon="&#xe3c9;" disabled ariaLabel="Edit" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Size Icon Button</h3>
-            <IconBtn icon="&#xe3c9;" size={12} ariaLabel="Large Edit" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Color Icon Button</h3>
-            <IconBtn icon="&#xe5ca;" bgColor="bg-red-500" ariaLabel="Delete" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Font Size Icon Button</h3>
-            <IconBtn icon="&#xe3c9;" iconFontSize="2rem" ariaLabel="Large Edit" />
-          </div>
-        </div>
-      </section>
-
-      {/* Context Menu Dropdown Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Context Menu Dropdown Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Context Menu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItems}
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-              <span className="text-sm text-gray-400">Click to see menu</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Left Aligned Context Menu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItems}
-                menuAlign="left"
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-              <span className="text-sm text-gray-400">Click to see menu</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Context Menu with Data</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItemsWithData}
-                onAction={(action) =>
-                  showToast(`Action: ${action.action} ${action.data ? `, Data: ${JSON.stringify(action.data)}` : ''}`, {
-                    type: 'info',
-                    title: 'Context Menu Action'
-                  })
-                }
-              />
-              <span className="text-sm text-gray-400">Click to see menu with data</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled Context Menu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItems}
-                disabled={true}
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-              <span className="text-sm text-gray-400">Disabled state</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Processing Context Menu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItems}
-                processing={true}
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-              <span className="text-sm text-gray-400">Loading state</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Icon Context Menu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItems}
-                iconClass="text-blue-400"
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-              <span className="text-sm text-gray-400">Custom icon color</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Wide Context Menu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItems}
-                menuWidth={250}
-                menuAlign="left"
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-              <span className="text-sm text-gray-400">Wider menu</span>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Context Menu with Empty Submenu</h3>
-            <div className="flex items-center gap-4">
-              <ContextMenuDropdown
-                items={contextMenuItemsWithEmptySubitems}
-                onAction={(action) => showToast(`Action: ${action.action}`, { type: 'info', title: 'Context Menu Action' })}
-              />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Dropdown Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Dropdown Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Dropdown</h3>
-            <Dropdown value={dropdownValue} onChange={handleDropdownChange} items={dropdownItems} label="Select Option" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Dropdown with Subtext</h3>
-            <Dropdown value={dropdownValue2} onChange={handleDropdownChange2} items={dropdownItemsWithSubtext} label="Language" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Small Dropdown</h3>
-            <Dropdown value={dropdownValue3} onChange={handleDropdownChange3} items={dropdownItems} label="Small Option" small />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled Dropdown</h3>
-            <Dropdown value="option1" items={dropdownItems} label="Disabled Option" disabled />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Dropdown without Label</h3>
-            <Dropdown value={dropdownValue} onChange={handleDropdownChange} items={dropdownItems} />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Height Dropdown</h3>
-            <Dropdown value={dropdownValue} onChange={handleDropdownChange} items={dropdownItems} label="Custom Height" menuMaxHeight="100px" />
-          </div>
-        </div>
-      </section>
-
-      {/* Input Dropdown Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Input Dropdown Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Input Dropdown</h3>
-            <InputDropdown value={inputDropdownValue} onChange={handleInputDropdownChange} items={inputDropdownItems} label="Select Fruit" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Input Dropdown with New Item Creation</h3>
-            <InputDropdown
-              value={inputDropdownValue2}
-              onChange={handleInputDropdownChange2}
-              items={inputDropdownItems}
-              label="Add or Select Fruit"
-              onNewItem={handleInputDropdownNewItem}
-            />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Show All When Empty</h3>
-            <InputDropdown
-              value={inputDropdownValue3}
-              onChange={handleInputDropdownChange3}
-              items={inputDropdownItems}
-              label="Fruit with Show All"
-              showAllWhenEmpty
-            />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled Input Dropdown</h3>
-            <InputDropdown value="Apple" items={inputDropdownItems} label="Disabled Fruit" disabled />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Input Dropdown without Label</h3>
-            <InputDropdown value={inputDropdownValue} onChange={handleInputDropdownChange} items={inputDropdownItems} />
-          </div>
-        </div>
-      </section>
-
-      {/* MultiSelect Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">MultiSelect Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default MultiSelect</h3>
-            <MultiSelect
-              selectedItems={multiSelectValue}
-              onItemAdded={handleMultiSelectItemAdded}
-              onItemRemoved={handleMultiSelectItemRemoved}
-              items={multiSelectItems}
-              label="Select Fruits"
-            />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">MultiSelect with Edit</h3>
-            <MultiSelect
-              selectedItems={multiSelectValue}
-              onItemAdded={handleMultiSelectItemAdded}
-              onItemRemoved={handleMultiSelectItemRemoved}
-              onItemEdited={handleMultiSelectItemEdited}
-              items={multiSelectItems}
-              label="Select Fruits"
-              showEdit
-            />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled MultiSelect</h3>
-            <MultiSelect
-              selectedItems={multiSelectValue}
-              onItemAdded={handleMultiSelectItemAdded}
-              onItemRemoved={handleMultiSelectItemRemoved}
-              items={multiSelectItems}
-              label="Select Fruits"
-              disabled
-            />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">MultiSelect with Validation</h3>
-            <MultiSelect
-              selectedItems={multiSelectValue}
-              onItemAdded={handleMultiSelectItemAdded}
-              onItemRemoved={handleMultiSelectItemRemoved}
-              onItemEdited={handleMultiSelectItemEdited}
-              items={multiSelectItems}
-              label="Select Fruits"
-              showEdit
-              onValidate={(content) => {
-                if (content.includes(' ')) {
-                  return 'A fruit name cannot contain any spaces'
-                }
-                return null
-              }}
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* TwoStageMultiSelect Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">TwoStageMultiSelect Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default TwoStageMultiSelect</h3>
-            <TwoStageMultiSelect
-              selectedItems={twoStageMultiSelectValue}
-              onItemAdded={handleTwoStageMultiSelectItemAdded}
-              onItemRemoved={handleTwoStageMultiSelectItemRemoved}
-              onItemEdited={handleTwoStageMultiSelectItemEdited}
-              items={twoStageMultiSelectItems}
-              label="Select Series and Sequence"
-              onValidate={(content) => {
-                if (content.modifier && content.modifier.includes(' ')) {
-                  return 'A sequence cannot contain any spaces'
-                }
-                return null
-              }}
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* MultiSelectDropdown Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">MultiSelectDropdown Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default MultiSelectDropdown</h3>
-            <MultiSelectDropdown
-              selectedItems={multiSelectDropdownSelectedItems}
-              onItemAdded={handleMultiSelectDropdownItemAdded}
-              onItemRemoved={handleMultiSelectDropdownItemRemoved}
-              items={multiSelectDropdownItems}
-              label="Select Colors"
-            />
-          </div>
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled MultiSelectDropdown</h3>
-            <MultiSelectDropdown
-              selectedItems={multiSelectDropdownSelectedItems}
-              onItemAdded={handleMultiSelectDropdownItemAdded}
-              onItemRemoved={handleMultiSelectDropdownItemRemoved}
-              items={multiSelectDropdownItems}
-              label="Select Colors"
-              disabled
-            />
-          </div>
-        </div>
-      </section>
-
-      {/* Modal Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Modal Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Basic Modal</h3>
-            <p className="text-gray-400 text-sm mb-4">A simple modal with default settings and close functionality.</p>
-            <Btn onClick={() => setIsBasicModalOpen(true)}>Open Basic Modal</Btn>
-
-            <Modal isOpen={isBasicModalOpen} onClose={() => setIsBasicModalOpen(false)}>
-              <div className="bg-gray-800 rounded-lg p-6 max-w-md">
-                <h3 className="text-xl font-semibold text-white mb-4">Basic Modal Example</h3>
-                <p className="text-gray-300 mb-6">
-                  This is a basic modal dialog. You can close it by clicking the close button, pressing Escape, or clicking outside the modal content.
-                </p>
-                <div className="flex justify-end gap-3">
-                  <Btn onClick={() => setIsBasicModalOpen(false)} color="bg-gray-600">
-                    Close
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Processing Modal</h3>
-            <p className="text-gray-400 text-sm mb-4">A modal with a processing overlay that prevents interaction during operations.</p>
-            <Btn onClick={() => setIsProcessingModalOpen(true)}>Open Processing Modal</Btn>
-
-            <Modal isOpen={isProcessingModalOpen} onClose={() => setIsProcessingModalOpen(false)} processing={isProcessing} width={500} height={300}>
-              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
-                <h3 className="text-xl font-semibold text-white mb-4">Processing Example</h3>
-                <p className="text-gray-300 mb-6 flex-1">
-                  Click the "Start Processing" button to see the processing overlay in action. The modal will be disabled during processing.
-                </p>
-                <div className="flex justify-end gap-3">
-                  <Btn onClick={() => setIsProcessingModalOpen(false)} color="bg-gray-600">
-                    Cancel
-                  </Btn>
-                  <Btn onClick={handleProcessingDemo} color="bg-blue-600" disabled={isProcessing}>
-                    {isProcessing ? 'Processing...' : 'Start Processing'}
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Persistent Modal</h3>
-            <p className="text-gray-400 text-sm mb-4">A modal that cannot be closed by clicking outside or pressing Escape.</p>
-            <Btn onClick={() => setIsPersistentModalOpen(true)}>Open Persistent Modal</Btn>
-
-            <Modal
-              isOpen={isPersistentModalOpen}
-              onClose={() => setIsPersistentModalOpen(false)}
-              persistent={true}
-              width={450}
-              height={250}
-              bgOpacityClass="bg-primary/90"
-            >
-              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
-                <h3 className="text-xl font-semibold text-white mb-4">Persistent Modal</h3>
-                <p className="text-gray-300 mb-6 flex-1">
-                  This modal is persistent - you can only close it by clicking the "Close" button. Background clicks and Escape key are disabled.
-                </p>
-                <div className="flex justify-center">
-                  <Btn onClick={() => setIsPersistentModalOpen(false)} color="bg-red-600">
-                    Close Modal
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Styled Modal</h3>
-            <p className="text-gray-400 text-sm mb-4">A modal with custom dimensions and Tailwind z-index/opacity classes.</p>
-            <Btn onClick={() => setIsCustomModalOpen(true)}>Open Custom Modal</Btn>
-
-            <Modal
-              isOpen={isCustomModalOpen}
-              onClose={() => setIsCustomModalOpen(false)}
-              width={800}
-              height={600}
-              zIndexClass="z-[100]"
-              bgOpacityClass="bg-primary/50"
-              contentMarginTop={20}
-            >
-              <div className="bg-gradient-to-br from-blue-900 to-purple-900 rounded-lg p-8 h-full flex flex-col">
-                <h3 className="text-2xl font-bold text-white mb-6">Custom Styled Modal</h3>
-                <div className="flex-1 space-y-4">
-                  <p className="text-blue-100">This modal demonstrates custom styling options:</p>
-                  <ul className="list-disc list-inside text-blue-100 space-y-2">
-                    <li>Custom width (800px) and height (600px)</li>
-                    <li>Higher z-index (z-[100]) using Tailwind classes</li>
-                    <li>Lower background opacity (bg-primary/50) using Tailwind classes</li>
-                    <li>Custom margin top (20px)</li>
-                    <li>Gradient background styling</li>
-                  </ul>
-                  <div className="bg-blue-800/30 rounded p-4 mt-4">
-                    <h4 className="text-lg font-semibold text-white mb-2">Modal Features</h4>
-                    <p className="text-blue-100 text-sm">
-                      The Modal component supports focus management, keyboard navigation, smooth animations, and portal rendering for proper z-index handling.
-                    </p>
-                  </div>
-                </div>
-                <div className="flex justify-end gap-3 pt-6 border-t border-blue-700">
-                  <Btn onClick={() => setIsCustomModalOpen(false)} color="bg-blue-600">
-                    Close Custom Modal
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Modal with Outer Content</h3>
-            <p className="text-gray-400 text-sm mb-4">A modal that can display content outside the main modal area.</p>
-            <Btn onClick={() => setIsOuterContentModalOpen(true)}>Open with Outer Content</Btn>
-
-            <Modal
-              isOpen={isOuterContentModalOpen}
-              onClose={() => setIsOuterContentModalOpen(false)}
-              width={400}
-              height={300}
-              outerContent={<div className="absolute top-10 left-10 bg-yellow-500 text-black px-3 py-1 rounded text-sm font-semibold">Outer Content!</div>}
-            >
-              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
-                <h3 className="text-xl font-semibold text-white mb-4">Modal with Outer Content</h3>
-                <p className="text-gray-300 mb-6 flex-1">
-                  This modal has additional content rendered outside the main modal container. Check the yellow badge in the top-left corner.
-                </p>
-                <div className="flex justify-end">
-                  <Btn onClick={() => setIsOuterContentModalOpen(false)} color="bg-gray-600">
-                    Close
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Responsive Modal</h3>
-            <p className="text-gray-400 text-sm mb-4">A modal that adapts to different screen sizes using string dimensions.</p>
-            <Btn onClick={() => setIsResponsiveModalOpen(true)}>Open Responsive Modal</Btn>
-
-            <Modal isOpen={isResponsiveModalOpen} onClose={() => setIsResponsiveModalOpen(false)} width="90vw" height="80vh">
-              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
-                <h3 className="text-xl font-semibold text-white mb-4">Responsive Modal</h3>
-                <div className="flex-1 space-y-4">
-                  <p className="text-gray-300">This modal uses viewport units for its dimensions:</p>
-                  <ul className="list-disc list-inside text-gray-300 space-y-2">
-                    <li>Width: 90vw (90% of viewport width)</li>
-                    <li>Height: 80vh (80% of viewport height)</li>
-                    <li>Automatically adapts to screen size</li>
-                    <li>Perfect for mobile devices</li>
-                  </ul>
-                  <div className="bg-gray-700 rounded p-4">
-                    <p className="text-sm text-gray-300">Try resizing your browser window to see how the modal adapts to different screen sizes.</p>
-                  </div>
-                </div>
-                <div className="flex justify-end pt-4 border-t border-gray-600">
-                  <Btn onClick={() => setIsResponsiveModalOpen(false)} color="bg-gray-600">
-                    Close
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-        </div>
-      </section>
-
-      {/* MultiSelect in Modal */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Advanced Modal Examples</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">MultiSelect within Modal Dialog</h3>
-            <p className="text-gray-400 text-sm mb-4">This example shows how MultiSelect works inside a modal dialog.</p>
-            <Btn onClick={() => setIsModalOpen(true)}>Open Modal with MultiSelect</Btn>
-
-            <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} width={600}>
-              <div className="bg-gray-800 rounded-lg p-6 h-full flex flex-col">
-                {/* Header */}
-                <div className="flex items-center justify-between mb-6 border-b border-gray-600 pb-4">
-                  <h3 className="text-xl font-semibold text-white">Edit Tags</h3>
-                </div>
-
-                {/* Content */}
-                <div className="space-y-4 flex-1">
-                  <p className="text-gray-300 text-sm">Select or add tags for this item.</p>
-
-                  <MultiSelect
-                    selectedItems={modalMultiSelectValue}
-                    onItemAdded={handleModalMultiSelectItemAdded}
-                    onItemRemoved={handleModalMultiSelectItemRemoved}
-                    onItemEdited={handleModalMultiSelectItemEdited}
-                    items={multiSelectItems}
-                    label="Item Tags"
-                    showEdit
-                  />
-
-                  <div className="text-xs text-gray-400 mt-2">
-                    Current selection: {modalMultiSelectValue.length > 0 ? modalMultiSelectValue.map((i) => i.content).join(', ') : 'None'}
-                  </div>
-                </div>
-
-                {/* Footer */}
-                <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-600">
-                  <Btn onClick={() => setIsModalOpen(false)} color="bg-gray-600">
-                    Cancel
-                  </Btn>
-                  <Btn onClick={() => setIsModalOpen(false)} color="bg-blue-600">
-                    Save Changes
-                  </Btn>
-                </div>
-              </div>
-            </Modal>
-          </div>
-        </div>
-      </section>
-
-      {/* Checkbox Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Checkbox Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Checkbox</h3>
-            <Checkbox value={checkboxValue} onChange={setCheckboxValue} label="Default checkbox" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Checked Checkbox</h3>
-            <Checkbox value={checkboxValue2} onChange={setCheckboxValue2} label="Checked checkbox" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Small Checkbox</h3>
-            <Checkbox value={checkboxValue3} onChange={setCheckboxValue3} label="Small checkbox" small />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Medium Checkbox</h3>
-            <Checkbox value={false} label="Medium checkbox" medium />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled Checkbox</h3>
-            <Checkbox value={true} label="Disabled checkbox" disabled />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Partial Checkbox</h3>
-            <Checkbox value={false} label="Partial checkbox" partial />
-          </div>
-        </div>
-      </section>
-
-      {/* File Input Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">File Input Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default File Input</h3>
-            <FileInput onChange={(file) => showToast(`Selected file: ${file.name}`, { type: 'success', title: 'File Selected' })}>Choose File</FileInput>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Document File Input</h3>
-            <FileInput
-              accept=".pdf, .doc, .docx, .txt"
-              onChange={(file) => showToast(`Selected document: ${file.name}`, { type: 'success', title: 'Document Selected' })}
-              ariaLabel="Upload Document"
-            >
-              Upload Document
-            </FileInput>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">All Files Input</h3>
-            <FileInput
-              accept="*"
-              onChange={(file) => showToast(`Selected file: ${file.name}`, { type: 'success', title: 'File Selected' })}
-              ariaLabel="Upload Any File"
-            >
-              Choose Any File
-            </FileInput>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Styled File Input</h3>
-            <FileInput
-              accept=".png, .jpg, .jpeg"
-              onChange={(file) => showToast(`Selected image: ${file.name}`, { type: 'success', title: 'Image Selected' })}
-              className="border-2 border-dashed border-blue-400 rounded-lg bg-blue-50"
-              ariaLabel="Upload Image"
-            >
-              Drop Image Here
-            </FileInput>
-          </div>
-        </div>
-      </section>
-
-      {/* Library Icon Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Library Icon Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Library Icon</h3>
-            <div className="bg-gray-700 p-2 rounded-lg">
-              <LibraryIcon />
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Large Size</h3>
-            <div className="bg-gray-700 p-2 rounded-lg">
-              <LibraryIcon size={6} />
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Icon</h3>
-            <LibraryIcon icon="books-1" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Font Size</h3>
-            <LibraryIcon fontSize="text-3xl" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Icon with Large Size</h3>
-            <LibraryIcon icon="headphones" size={6} fontSize="text-3xl" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Invalid Icon (Falls Back to Default)</h3>
-            <LibraryIcon icon="invalid-icon" />
-          </div>
-        </div>
-      </section>
-
-      {/* Media Icon Picker Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Media Icon Picker Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Default Media Icon Picker</h3>
-            <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Custom Label & Value</h3>
-            <MediaIconPicker value="books-1" onChange={setMediaIconValue} label="Choose Books Icon" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Disabled State</h3>
-            <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} label="Disabled Picker" disabled />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Menu Alignment (Right)</h3>
-            <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} align="right" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Menu Alignment (Center)</h3>
-            <MediaIconPicker value={mediaIconValue} onChange={setMediaIconValue} align="center" />
-          </div>
-        </div>
-      </section>
-
-      {/* Loading Components */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Loading Components</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Indicator</h3>
-            <LoadingIndicator />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Spinner (Default - Small)</h3>
-            <LoadingSpinner />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Spinner (Large)</h3>
-            <LoadingSpinner size="la-lg" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Spinner (2x)</h3>
-            <LoadingSpinner size="la-2x" />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Spinner (3x)</h3>
-            <LoadingSpinner size="la-3x" />
-          </div>
-
-          <div className="bg-gray-500 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Spinner (Dark - Large)</h3>
-            <LoadingSpinner size="la-lg" dark />
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Loading Spinner (Custom Color - Large)</h3>
-            <LoadingSpinner size="la-lg" color="#ff6b6b" />
-          </div>
-        </div>
-      </section>
-
-      {/* Toast Notification Examples */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Toast Notification Examples</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Success Toast</h3>
-            <Btn onClick={() => showToast('Operation completed successfully!', { type: 'success', title: 'Success' })}>Show Success</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Error Toast</h3>
-            <Btn onClick={() => showToast('Something went wrong!', { type: 'error', title: 'Error' })}>Show Error</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Warning Toast</h3>
-            <Btn onClick={() => showToast('Please be careful!', { type: 'warning', title: 'Warning' })}>Show Warning</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Info Toast</h3>
-            <Btn onClick={() => showToast('Here is some information.', { type: 'info', title: 'Information' })}>Show Info</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Long Duration Toast</h3>
-            <Btn onClick={() => showToast('This toast will stay for 10 seconds.', { type: 'info', title: 'Long Toast', duration: 10000 })}>Show Long Toast</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">No Auto-Dismiss Toast</h3>
-            <Btn onClick={() => showToast('This toast will not auto-dismiss.', { type: 'warning', title: 'Persistent', duration: 0 })}>Show Persistent</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Toast with Title Only</h3>
-            <Btn onClick={() => showToast('Just a simple message.', { type: 'info' })}>Show Simple</Btn>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Multiple Toasts</h3>
-            <Btn
-              onClick={() => {
-                showToast('First notification', { type: 'info', title: 'First' })
-                setTimeout(() => showToast('Second notification', { type: 'success', title: 'Second' }), 500)
-                setTimeout(() => showToast('Third notification', { type: 'warning', title: 'Third' }), 1000)
-              }}
-            >
-              Show Multiple
-            </Btn>
-          </div>
-        </div>
-      </section>
-
-      {/* Interactive Examples */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Interactive Examples</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Button Interactions</h3>
-            <div className="flex items-center gap-4">
-              <Btn onClick={() => showToast('Button clicked!', { type: 'info', title: 'Button Action' })}>Click me!</Btn>
-              <Btn onClick={() => showToast('Form submitted!', { type: 'success', title: 'Form Submitted' })} type="submit">
-                Submit Form
-              </Btn>
-              <Btn to="/settings" color="bg-blue-600">
-                Navigate to Settings
-              </Btn>
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Icon Button Interactions</h3>
-            <div className="flex items-center gap-4">
-              <IconBtn icon="&#xe3c9;" onClick={() => showToast('Edit clicked!', { type: 'info', title: 'Icon Button Action' })} ariaLabel="Edit" />
-              <IconBtn
-                icon="&#xe5ca;"
-                onClick={() => showToast('Close clicked!', { type: 'warning', title: 'Icon Button Action' })}
-                ariaLabel="Close"
-                bgColor="bg-red-500"
-              />
-              <IconBtn icon="&#xe3c9;" onClick={() => showToast('Close clicked!', { type: 'info', title: 'Icon Button Action' })} ariaLabel="Close" />
-              <IconBtn
-                icon="&#xe3c9;"
-                onClick={() => showToast('Loading clicked!', { type: 'info', title: 'Icon Button Action' })}
-                loading
-                ariaLabel="Loading"
-              />
-            </div>
-          </div>
-
-          <div className="bg-gray-800 p-6 rounded-lg">
-            <h3 className="text-lg font-medium mb-4">Checkbox Interactions</h3>
-            <div className="space-y-4">
-              <Checkbox value={checkboxValue} onChange={setCheckboxValue} label="Accept terms and conditions" />
-              <Checkbox value={checkboxValue2} onChange={setCheckboxValue2} label="Subscribe to newsletter" />
-              <Checkbox value={checkboxValue3} onChange={setCheckboxValue3} label="Enable notifications" small />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Component Information */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Available Components</h2>
+        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Table of Contents</h2>
         <div className="bg-gray-800 p-6 rounded-lg">
-          <h3 className="text-lg font-medium mb-4">React Components</h3>
-          <ul className="list-disc list-inside space-y-2 text-gray-300">
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">Btn.tsx</code> - Button component with various states (loading, disabled, small, link)
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">IconBtn.tsx</code> - Icon button component with material symbols, loading states, and
-              customization options
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">Checkbox.tsx</code> - Checkbox component with different sizes and states
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">LoadingIndicator.tsx</code> - Loading spinner component with animated dots
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">LoadingSpinner.tsx</code> - Ball spin loading spinner with multiple sizes and themes
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">ContextMenuDropdown.tsx</code> - Context menu dropdown with submenus, loading states, and custom
-              triggers
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">Dropdown.tsx</code> - Select dropdown component with labels, subtext, and various states
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">FileInput.tsx</code> - File input component with customizable accept types and responsive design
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">LibraryIcon.tsx</code> - Library icon component using absicons font with validation and fallback
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">MediaIconPicker.tsx</code> - Icon picker component for selecting library icons with dropdown menu
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">InputDropdown.tsx</code> - Input dropdown component that allows typing and filtering with optional
-              new item creation
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">MultiSelectDropdown.tsx</code> - A multi-select component that uses a dropdown menu instead of a
-              text input.
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">Toast.tsx</code> - Toast notification component with auto-dismiss, animations, and multiple types
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">ToastContainer.tsx</code> - Container component for managing multiple toast notifications
-            </li>
-            <li>
-              <code className="bg-gray-700 px-2 py-1 rounded">Modal.tsx</code> - Full-featured modal dialog component with portal rendering, animations, focus
-              management, and customizable styling
-            </li>
-          </ul>
-        </div>
-      </section>
-
-      {/* Usage Guidelines */}
-      <section className="mb-12">
-        <h2 className="text-2xl font-semibold mb-6 text-gray-400">Usage Guidelines</h2>
-        <div className="bg-gray-800 p-6 rounded-lg">
-          <h3 className="text-lg font-medium mb-4">React Components</h3>
-          <div className="space-y-4 text-gray-300">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <h4 className="font-medium text-white mb-2">Btn Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import Btn from '@/components/ui/Btn'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">color</code>, <code className="bg-gray-700 px-2 py-1 rounded">small</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">loading</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">to</code> (for navigation)
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">IconBtn Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import IconBtn from '@/components/ui/IconBtn'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">icon</code>, <code className="bg-gray-700 px-2 py-1 rounded">bgColor</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">outlined</code>, <code className="bg-gray-700 px-2 py-1 rounded">borderless</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">loading</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">size</code>, <code className="bg-gray-700 px-2 py-1 rounded">iconFontSize</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">ariaLabel</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">Checkbox Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import Checkbox from '@/components/ui/Checkbox'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">value</code>, <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">label</code>, <code className="bg-gray-700 px-2 py-1 rounded">small</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">medium</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">partial</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">LoadingIndicator Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import LoadingIndicator from '@/components/LoadingIndicator'</code>
-              </p>
-              <p className="mb-2">No props required - displays animated loading dots</p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">LoadingSpinner Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import LoadingSpinner from '@/components/ui/LoadingSpinner'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">size</code> (la-sm, la-lg, la-2x, la-3x),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">dark</code>, <code className="bg-gray-700 px-2 py-1 rounded">color</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">className</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">ContextMenuDropdown Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">items</code> (ContextMenuItem[]),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">processing</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">iconClass</code>, <code className="bg-gray-700 px-2 py-1 rounded">menuWidth</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">onAction</code>, <code className="bg-gray-700 px-2 py-1 rounded">children</code> (ReactNode or
-                function)
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">Dropdown Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import Dropdown from '@/components/ui/Dropdown'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">value</code>, <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">items</code> (DropdownItem[]), <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>, <code className="bg-gray-700 px-2 py-1 rounded">small</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">menuMaxHeight</code>, <code className="bg-gray-700 px-2 py-1 rounded">className</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">FileInput Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import FileInput from '@/components/ui/FileInput'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">accept</code> (file types to accept),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">onChange</code> (callback with selected file),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">children</code> (ReactNode for button content),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">className</code> (custom CSS classes)
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">LibraryIcon Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import LibraryIcon from '@/components/ui/LibraryIcon'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">icon</code> (icon name from absicons, defaults to 'audiobookshelf'),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">fontSize</code> (CSS font size class, defaults to 'text-lg'),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">size</code> (5 or 6 for container size, defaults to 5),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">className</code> (additional CSS classes)
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">MediaIconPicker Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import MediaIconPicker from '@/components/ui/MediaIconPicker'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">value</code> (selected icon name, defaults to 'database'),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">onChange</code> (callback when icon is selected),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">label</code> (label text, defaults to 'Icon'),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">disabled</code> (disables the picker),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">className</code> (additional CSS classes),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">align</code> (menu alignment, defaults to 'left', options: 'left', 'right', 'center')
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">InputDropdown Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import InputDropdown from '@/components/ui/InputDropdown'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">value</code>, <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">items</code> (string[] or number[]),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">label</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">editable</code>, <code className="bg-gray-700 px-2 py-1 rounded">showAllWhenEmpty</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">onNewItem</code>, <code className="bg-gray-700 px-2 py-1 rounded">className</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">MultiSelectDropdown Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import MultiSelectDropdown from '@/components/ui/MultiSelectDropdown'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">value</code>, <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">items</code> (MultiSelectItem[]), <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">Toast Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import Toast from '@/components/widgets/Toast'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">id</code>, <code className="bg-gray-700 px-2 py-1 rounded">type</code> (success, error,
-                warning, info), <code className="bg-gray-700 px-2 py-1 rounded">title</code>, <code className="bg-gray-700 px-2 py-1 rounded">message</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">duration</code>, <code className="bg-gray-700 px-2 py-1 rounded">onClose</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">ToastContainer Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import ToastContainer from '@/components/widgets/ToastContainer'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">toasts</code> (ToastMessage[]),{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">onRemove</code>
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">Global Toast Hook</h4>
-              <p className="mb-2">
-                Import:{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">
-                  import {'{'} useGlobalToast {'}'} from '@/contexts/ToastContext'
-                </code>
-              </p>
-              <p className="mb-2">
-                Returns: <code className="bg-gray-700 px-2 py-1 rounded">toasts</code>, <code className="bg-gray-700 px-2 py-1 rounded">showToast</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">removeToast</code>
-              </p>
-              <p className="mb-2">
-                Usage:{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">
-                  showToast(message, {'{'} type, title, duration {'}'})
-                </code>
-              </p>
-              <p className="mb-2 text-sm text-gray-400">
-                Note: Global toast is automatically available in all pages. No need to include ToastContainer manually.
-              </p>
-            </div>
-            <div>
-              <h4 className="font-medium text-white mb-2">Modal Component</h4>
-              <p className="mb-2">
-                Import: <code className="bg-gray-700 px-2 py-1 rounded">import Modal from '@/components/modals/Modal'</code>
-              </p>
-              <p className="mb-2">
-                Props: <code className="bg-gray-700 px-2 py-1 rounded">isOpen</code>, <code className="bg-gray-700 px-2 py-1 rounded">onClose</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">children</code>, <code className="bg-gray-700 px-2 py-1 rounded">processing</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">persistent</code>, <code className="bg-gray-700 px-2 py-1 rounded">width</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">height</code>, <code className="bg-gray-700 px-2 py-1 rounded">zIndexClass</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">bgOpacityClass</code>, <code className="bg-gray-700 px-2 py-1 rounded">contentMarginTop</code>,{' '}
-                <code className="bg-gray-700 px-2 py-1 rounded">outerContent</code>
-              </p>
-              <p className="mb-2 text-sm text-gray-400">
-                Features: portal rendering, smooth animations, focus management, keyboard navigation (Escape), backdrop click to close, processing overlay,
-                persistent mode, customizable dimensions and styling
-              </p>
+              <h3 className="text-lg font-medium mb-3 text-white">Component Examples</h3>
+              <ul className="space-y-2 text-gray-300">
+                <li>
+                  <a href="#button-components" className="hover:text-blue-400 transition-colors">
+                    Buttons
+                  </a>
+                </li>
+                <li>
+                  <a href="#icon-button-components" className="hover:text-blue-400 transition-colors">
+                    Icon Buttons
+                  </a>
+                </li>
+                <li>
+                  <a href="#context-menu-dropdown-components" className="hover:text-blue-400 transition-colors">
+                    Context Menu Dropdowns
+                  </a>
+                </li>
+                <li>
+                  <a href="#dropdown-components" className="hover:text-blue-400 transition-colors">
+                    Dropdowns
+                  </a>
+                </li>
+                <li>
+                  <a href="#input-dropdown-components" className="hover:text-blue-400 transition-colors">
+                    Input Dropdowns
+                  </a>
+                </li>
+                <li>
+                  <a href="#multi-select-components" className="hover:text-blue-400 transition-colors">
+                    Multi Selects
+                  </a>
+                </li>
+                <li>
+                  <a href="#two-stage-multi-select-components" className="hover:text-blue-400 transition-colors">
+                    Two Stage Multi Selects
+                  </a>
+                </li>
+                <li>
+                  <a href="#multi-select-dropdown-components" className="hover:text-blue-400 transition-colors">
+                    Multi Select Dropdowns
+                  </a>
+                </li>
+                <li>
+                  <a href="#modal-components" className="hover:text-blue-400 transition-colors">
+                    Modals
+                  </a>
+                </li>
+                <li>
+                  <a href="#advanced-modal-examples" className="hover:text-blue-400 transition-colors">
+                    Advanced Modal Examples
+                  </a>
+                </li>
+                <li>
+                  <a href="#range-input-components" className="hover:text-blue-400 transition-colors">
+                    Range Inputs
+                  </a>
+                </li>
+                <li>
+                  <a href="#checkbox-components" className="hover:text-blue-400 transition-colors">
+                    Checkboxes
+                  </a>
+                </li>
+                <li>
+                  <a href="#file-input-components" className="hover:text-blue-400 transition-colors">
+                    File Inputs
+                  </a>
+                </li>
+                <li>
+                  <a href="#library-icon-components" className="hover:text-blue-400 transition-colors">
+                    Library Icons
+                  </a>
+                </li>
+                <li>
+                  <a href="#media-icon-picker-components" className="hover:text-blue-400 transition-colors">
+                    Media Icon Pickers
+                  </a>
+                </li>
+                <li>
+                  <a href="#loading-components" className="hover:text-blue-400 transition-colors">
+                    Loading Indicators
+                  </a>
+                </li>
+                <li>
+                  <a href="#toast-notification-examples" className="hover:text-blue-400 transition-colors">
+                    Toasts
+                  </a>
+                </li>
+              </ul>
             </div>
           </div>
         </div>
       </section>
+
+      <div id="button-components">
+        <BtnExamples />
+      </div>
+      <div id="icon-button-components">
+        <IconBtnExamples />
+      </div>
+      <div id="context-menu-dropdown-components">
+        <ContextMenuDropdownExamples />
+      </div>
+      <div id="dropdown-components">
+        <DropdownExamples />
+      </div>
+      <div id="input-dropdown-components">
+        <InputDropdownExamples />
+      </div>
+      <div id="multi-select-components">
+        <MultiSelectExamples />
+      </div>
+      <div id="two-stage-multi-select-components">
+        <TwoStageMultiSelectExamples />
+      </div>
+      <div id="multi-select-dropdown-components">
+        <MultiSelectDropdownExamples />
+      </div>
+      <div id="modal-components">
+        <ModalExamples />
+      </div>
+      <div id="advanced-modal-examples">
+        <AdvancedModalExamples />
+      </div>
+      <div id="range-input-components">
+        <RangeInputExamples />
+      </div>
+      <div id="checkbox-components">
+        <CheckboxExamples />
+      </div>
+      <div id="file-input-components">
+        <FileInputExamples />
+      </div>
+      <div id="library-icon-components">
+        <LibraryIconExamples />
+      </div>
+      <div id="media-icon-picker-components">
+        <MediaIconPickerExamples />
+      </div>
+      <div id="loading-components">
+        <LoadingExamples />
+      </div>
+      <div id="toast-notification-examples">
+        <ToastNotificationExamples />
+      </div>
     </div>
   )
 }

--- a/src/components/ui/IconBtn.tsx
+++ b/src/components/ui/IconBtn.tsx
@@ -15,6 +15,7 @@ interface IconBtnProps {
   size?: number
   ariaLabel?: string
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
+  'aria-pressed'?: boolean
   className?: string
 }
 
@@ -40,6 +41,7 @@ export default function IconBtn({
   size = 9,
   ariaLabel,
   onClick,
+  'aria-pressed': ariaPressed,
   className = ''
 }: IconBtnProps) {
   const classList = useMemo(() => {
@@ -83,7 +85,15 @@ export default function IconBtn({
   }, [])
 
   return (
-    <button aria-label={ariaLabel} className={classList} disabled={isDisabled} onClick={handleClick} onMouseDown={handleMouseDown}>
+    <button
+      aria-label={ariaLabel}
+      className={classList}
+      disabled={isDisabled}
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      tabIndex={isDisabled ? -1 : 0}
+      aria-pressed={ariaPressed}
+    >
       {loading && <LoadingSpinner />}
       {loading && (
         <span cy-id="icon-btn-loading" className="sr-only">

--- a/src/components/ui/RangeInput.tsx
+++ b/src/components/ui/RangeInput.tsx
@@ -1,0 +1,107 @@
+import React, { useId, useMemo, useCallback } from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+
+interface RangeInputProps {
+  value: number
+  min?: number
+  max?: number
+  step?: number
+  onChange: (value: number) => void
+  label?: string
+  className?: string
+  disabled?: boolean
+  ref?: React.Ref<HTMLInputElement>
+}
+
+const RangeInput = ({ value, min = 0, max = 100, step = 1, onChange, label, className = '', disabled = false, ref, ...props }: RangeInputProps) => {
+  const uniqueId = useId()
+  const inputId = `range-input-${uniqueId}`
+  const labelId = label ? `range-label-${uniqueId}` : undefined
+
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = Number(event.target.value)
+      onChange(newValue)
+    },
+    [onChange]
+  )
+
+  const containerClasses = useMemo(() => mergeClasses('flex flex-col items-start gap-2 w-full', className), [className])
+
+  const rangeInputClasses = useMemo(
+    () =>
+      mergeClasses(
+        // Base styles
+        'appearance-none bg-transparent cursor-pointer focus:outline-none w-full',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+
+        // Webkit slider track
+        '[&::-webkit-slider-runnable-track]:bg-black/25',
+        '[&::-webkit-slider-runnable-track]:rounded-full',
+        '[&::-webkit-slider-runnable-track]:h-3',
+
+        // Webkit slider thumb
+        '[&::-webkit-slider-thumb]:appearance-none',
+        '[&::-webkit-slider-thumb]:-mt-1',
+        '[&::-webkit-slider-thumb]:rounded-full',
+        '[&::-webkit-slider-thumb]:bg-white/70',
+        '[&::-webkit-slider-thumb]:h-5',
+        '[&::-webkit-slider-thumb]:w-5',
+
+        // Mozilla range track
+        '[&::-moz-range-track]:bg-black/25',
+        '[&::-moz-range-track]:rounded-full',
+        '[&::-moz-range-track]:h-3',
+
+        // Mozilla range thumb
+        '[&::-moz-range-thumb]:border-none',
+        '[&::-moz-range-thumb]:rounded-full',
+        '[&::-moz-range-thumb]:-mt-1',
+        '[&::-moz-range-thumb]:bg-white/70',
+        '[&::-moz-range-thumb]:h-5',
+        '[&::-moz-range-thumb]:w-5'
+      ),
+    []
+  )
+
+  return (
+    <div className={containerClasses}>
+      {label && (
+        <label id={labelId} htmlFor={inputId} className={`px-1 text-sm font-semibold ${disabled ? 'text-gray-400' : ''}`}>
+          {label}
+        </label>
+      )}
+      <div
+        className={mergeClasses(
+          'inline-flex items-center w-full rounded-sm px-2 py-1 focus-within:outline',
+          disabled ? 'bg-black-300 text-gray-400 cursor-not-allowed' : 'bg-primary cursor-text'
+        )}
+      >
+        <input
+          ref={ref}
+          id={inputId}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          onChange={handleChange}
+          disabled={disabled}
+          aria-disabled={disabled}
+          aria-labelledby={labelId}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={value}
+          aria-valuetext={`${value}%`}
+          className={rangeInputClasses}
+          {...props}
+        />
+        <span className="text-sm ml-2" aria-hidden="true">
+          {value}%
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default RangeInput

--- a/src/components/ui/RangeInput.tsx
+++ b/src/components/ui/RangeInput.tsx
@@ -13,7 +13,7 @@ interface RangeInputProps {
   ref?: React.Ref<HTMLInputElement>
 }
 
-const RangeInput = ({ value, min = 0, max = 100, step = 1, onChange, label, className = '', disabled = false, ref, ...props }: RangeInputProps) => {
+const RangeInput = ({ value, min = 0, max = 100, step = 1, onChange, label, className = '', disabled = false, ref }: RangeInputProps) => {
   const uniqueId = useId()
   const inputId = `range-input-${uniqueId}`
   const labelId = label ? `range-label-${uniqueId}` : undefined
@@ -94,7 +94,6 @@ const RangeInput = ({ value, min = 0, max = 100, step = 1, onChange, label, clas
           aria-valuenow={value}
           aria-valuetext={`${value}%`}
           className={rangeInputClasses}
-          {...props}
         />
         <span className="text-sm ml-2" aria-hidden="true">
           {value}%

--- a/src/components/ui/ReadIconBtn.tsx
+++ b/src/components/ui/ReadIconBtn.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import IconBtn from './IconBtn'
+import { mergeClasses } from '@/lib/merge-classes'
+
+interface ReadIconBtnProps {
+  isRead: boolean
+  disabled?: boolean
+  borderless?: boolean
+  onClick?: () => void
+  className?: string
+}
+
+export default function ReadIconBtn({ isRead, disabled = false, borderless = false, onClick, className }: ReadIconBtnProps) {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+    if (disabled) {
+      e.preventDefault()
+      return
+    }
+    onClick?.()
+  }
+
+  const ariaLabel = isRead ? 'Mark as not finished' : 'Mark as finished'
+
+  return (
+    <IconBtn
+      icon="&#xe52d;" // BeenHere icon
+      disabled={disabled}
+      borderless={borderless}
+      ariaLabel={ariaLabel}
+      onClick={handleClick}
+      className={mergeClasses(isRead ? 'text-green-400' : 'text-gray-400', className)}
+    />
+  )
+}

--- a/src/components/ui/ReadIconBtn.tsx
+++ b/src/components/ui/ReadIconBtn.tsx
@@ -32,6 +32,7 @@ export default function ReadIconBtn({ isRead, disabled = false, borderless = fal
       icon="&#xe52d;" // BeenHere icon
       disabled={disabled}
       borderless={borderless}
+      outlined={!isRead}
       ariaLabel={ariaLabel}
       onClick={handleClick}
       aria-pressed={isRead}

--- a/src/components/ui/ReadIconBtn.tsx
+++ b/src/components/ui/ReadIconBtn.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback, useMemo } from 'react'
 import IconBtn from './IconBtn'
 import { mergeClasses } from '@/lib/merge-classes'
 
@@ -11,16 +11,21 @@ interface ReadIconBtnProps {
 }
 
 export default function ReadIconBtn({ isRead, disabled = false, borderless = false, onClick, className }: ReadIconBtnProps) {
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-    if (disabled) {
-      e.preventDefault()
-      return
-    }
-    onClick?.()
-  }
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      if (disabled) {
+        e.preventDefault()
+        return
+      }
+      onClick?.()
+    },
+    [disabled, onClick]
+  )
 
-  const ariaLabel = isRead ? 'Mark as not finished' : 'Mark as finished'
+  const ariaLabel = useMemo(() => (isRead ? 'Mark as not finished' : 'Mark as finished'), [isRead])
+
+  const classes = useMemo(() => mergeClasses(isRead ? 'text-green-400' : 'text-gray-400', className), [isRead, className])
 
   return (
     <IconBtn
@@ -29,7 +34,8 @@ export default function ReadIconBtn({ isRead, disabled = false, borderless = fal
       borderless={borderless}
       ariaLabel={ariaLabel}
       onClick={handleClick}
-      className={mergeClasses(isRead ? 'text-green-400' : 'text-gray-400', className)}
+      aria-pressed={isRead}
+      className={classes}
     />
   )
 }


### PR DESCRIPTION
This migrates the RangeInput component.

This departs a bit from the vue implementation, because I wanted to make it more consistent with other input components:
- To make it more consistent with other inputs:
  - Made it full width
  - Added a label
  - Modifed disabled styles
  - Made focus ring appear around the input wrapper instead of the slider thumb
- Replaced the scoped css classes with tailwind scoped classes (seems more consistent with tailwind style)
- Added propr aria attributes 

I think we might need another base component for all input compoenents to make sure some of the basic behaviors like label, focus, and disabled are consistent between them. I'll look into it later.

I also had to refactor the component catalog, because the RangeInput examples were occasionally freezing when moving the slider.  This was due to the catalog being one single giant component holding all of the examples, and it was re-rendered on every RangeInput onChange, which fire very frequently. Now it has a separate examples component for each component.

I have not forgotten about adding component tests for the latest components - just wanted to make a bit more progress and iron out issues before generating those.