### PR TITLE
Migrate TextAreaInput

### DIFF
--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -11,6 +11,7 @@ import type { DropdownItem } from '@/components/ui/Dropdown'
 import FileInput from '@/components/ui/FileInput'
 import IconBtn from '@/components/ui/IconBtn'
 import InputDropdown from '@/components/ui/InputDropdown'
+import TextareaInput from '@/components/ui/TextareaInput'
 import LibraryIcon from '@/components/ui/LibraryIcon'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import LoadingSpinner from '@/components/widgets/LoadingSpinner'
@@ -686,6 +687,54 @@ export function InputDropdownExamples() {
 
         <Example title="Input Dropdown without Label">
           <InputDropdown value={inputDropdownValue} onChange={handleInputDropdownChange} items={inputDropdownItems} />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}
+
+// TextareaInput Examples
+export function TextareaInputExamples() {
+  const [textValue1, setTextValue1] = useState('These are my notes.')
+  const [textValue2, setTextValue2] = useState('Initial content')
+  const [textValue3, setTextValue3] = useState('')
+  const [textValue4] = useState('Read-only content.\nThis is a long text\nto test the textarea input.')
+
+  return (
+    <ComponentExamples title="Textarea Inputs">
+      <ComponentInfo component="TextareaInput" description="Accessible textarea input with disabled and focus styles consistent with InputDropdown">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import TextareaInput from '@/components/ui/TextareaInput'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>, <code className="bg-gray-700 px-2 py-1 rounded">label</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">placeholder</code>, <code className="bg-gray-700 px-2 py-1 rounded">rows</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">readOnly</code>, <code className="bg-gray-700 px-2 py-1 rounded">disabled</code>,{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code>, <code className="bg-gray-700 px-2 py-1 rounded">id</code>
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Default Textarea">
+          <TextareaInput label="Notes" value={textValue1} onChange={setTextValue1} />
+        </Example>
+
+        <Example title="Read-only Textarea">
+          <TextareaInput label="Read-only" value={textValue4} readOnly />
+        </Example>
+
+        <Example title="Disabled Textarea">
+          <TextareaInput label="Disabled" value={'Disabled state. \nThis is a long text\nto test the textarea input.'} disabled />
+        </Example>
+
+        <Example title="Textarea with 4 Rows">
+          <TextareaInput value={textValue2} onChange={setTextValue2} rows={4} />
+        </Example>
+
+        <Example title="Default Textarea with Placeholder">
+          <TextareaInput value={textValue3} onChange={setTextValue3} placeholder="Type your text here..." />
         </Example>
       </ExamplesBlock>
     </ComponentExamples>

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -6,6 +6,7 @@ import {
   ContextMenuDropdownExamples,
   DropdownExamples,
   InputDropdownExamples,
+  TextareaInputExamples,
   MultiSelectExamples,
   TwoStageMultiSelectExamples,
   MultiSelectDropdownExamples,
@@ -65,6 +66,11 @@ export default function ComponentsCatalogPage() {
                 <li>
                   <a href="#input-dropdown-components" className="hover:text-blue-400 transition-colors">
                     Input Dropdowns
+                  </a>
+                </li>
+                <li>
+                  <a href="#textarea-input-components" className="hover:text-blue-400 transition-colors">
+                    Textarea Inputs
                   </a>
                 </li>
                 <li>
@@ -150,6 +156,9 @@ export default function ComponentsCatalogPage() {
       </div>
       <div id="input-dropdown-components">
         <InputDropdownExamples />
+      </div>
+      <div id="textarea-input-components">
+        <TextareaInputExamples />
       </div>
       <div id="multi-select-components">
         <MultiSelectExamples />

--- a/src/components/ui/TextareaInput.tsx
+++ b/src/components/ui/TextareaInput.tsx
@@ -37,7 +37,7 @@ export default function TextareaInput({
     return mergeClasses(
       'relative w-full shadow-xs flex items-stretch rounded-sm px-2 py-2 focus-within:outline',
       'border border-gray-600',
-      disabled ? 'bg-black-300 text-gray-400' : readOnly ? 'bg-black-400 text-gray-400' : 'bg-primary',
+      disabled ? 'bg-black-300' : readOnly ? 'bg-[#444]' : 'bg-primary',
       className
     )
   }, [disabled, readOnly, className])
@@ -69,8 +69,7 @@ export default function TextareaInput({
           dir="auto"
           className={mergeClasses(
             'w-full resize-y bg-transparent px-1 outline-none border-none',
-            disabled ? 'cursor-not-allowed' : '',
-            disabled || readOnly ? 'text-gray-400' : 'text-gray-200'
+            disabled ? 'cursor-not-allowed text-gray-400' : readOnly ? '[&]:text-[#aaa]' : ''
           )}
           aria-disabled={disabled || undefined}
           aria-readonly={readOnly || undefined}

--- a/src/components/ui/TextareaInput.tsx
+++ b/src/components/ui/TextareaInput.tsx
@@ -69,7 +69,7 @@ export default function TextareaInput({
           dir="auto"
           className={mergeClasses(
             'w-full resize-y bg-transparent px-1 outline-none border-none',
-            disabled ? 'cursor-not-allowed text-gray-400' : readOnly ? '[&]:text-[#aaa]' : ''
+            disabled ? 'cursor-not-allowed text-gray-400' : readOnly ? '[&]:text-[#ccc]' : ''
           )}
           aria-disabled={disabled || undefined}
           aria-readonly={readOnly || undefined}

--- a/src/components/ui/TextareaInput.tsx
+++ b/src/components/ui/TextareaInput.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useCallback, useId, useMemo } from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+
+export interface TextareaInputProps {
+  id?: string
+  label?: string
+  value?: string | number
+  placeholder?: string
+  readOnly?: boolean
+  rows?: number
+  disabled?: boolean
+  onChange?: (value: string) => void
+  className?: string
+}
+
+/**
+ * Accessible textarea input with optional transparent style and disabled/focus states
+ * aligned with InputDropdown visual treatment.
+ */
+export default function TextareaInput({
+  id,
+  label,
+  value,
+  placeholder,
+  readOnly = false,
+  rows = 2,
+  disabled = false,
+  onChange,
+  className
+}: TextareaInputProps) {
+  const generatedId = useId()
+  const textareaId = id || generatedId
+
+  const wrapperClass = useMemo(() => {
+    return mergeClasses(
+      'relative w-full shadow-xs flex items-stretch rounded-sm px-2 py-2 focus-within:outline',
+      'border border-gray-600',
+      disabled ? 'bg-black-300 text-gray-400' : readOnly ? 'bg-black-400 text-gray-400' : 'bg-primary',
+      className
+    )
+  }, [disabled, readOnly, className])
+
+  const labelClass = useMemo(() => mergeClasses('px-1 text-sm font-semibold', disabled ? 'text-gray-400' : ''), [disabled])
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange?.(e.target.value)
+    },
+    [onChange]
+  )
+
+  return (
+    <div className="w-full" cy-id="textarea-input">
+      {label ? (
+        <label htmlFor={textareaId} className={labelClass}>
+          {label}
+        </label>
+      ) : null}
+      <div className={wrapperClass} cy-id="textarea-input-wrapper">
+        <textarea
+          id={textareaId}
+          value={value?.toString() ?? ''}
+          placeholder={placeholder}
+          readOnly={readOnly}
+          disabled={disabled}
+          rows={rows}
+          dir="auto"
+          className={mergeClasses(
+            'w-full resize-y bg-transparent px-1 outline-none border-none',
+            disabled ? 'cursor-not-allowed' : '',
+            disabled || readOnly ? 'text-gray-400' : 'text-gray-200'
+          )}
+          aria-disabled={disabled || undefined}
+          aria-readonly={readOnly || undefined}
+          aria-multiline="true"
+          onChange={handleChange}
+          cy-id="textarea-input-textarea"
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This migrates both TextAreaInput and TextAreaWithLabel into a single component TextAreaInput (in the current view code, TextAreaInput is never used directly, just as a component in TextAreaWithLabel).

Notes:
- Accessiblity attributes are properly set
- The `transparent` prop was removed, since it's unused in the vue code and doesn't make a lot of sense.
- The original had an imperative blur() method. I have not implemented it since I'm not sure it's required (it is used once in PodcastDetailsEdit.vue, but I'm not sure if we can't do without it). I prefer not to use imperatives, if not strictly needed.
- I don't dig the `readOnly` styles. They seem similar to `disabled`, but not exactly the same. I (tried to) migrate exactly like in the vue code, but it doesn't make a lot of sense to me.