### PR TITLE
Migrate Alert and inline indicator components

### DIFF
--- a/src/app/(main)/components_catalog/examples/AlertExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/AlertExamples.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import Alert from '@/components/widgets/Alert'
+import { ComponentExamples, ComponentInfo, Example, ExamplesBlock } from '../ComponentExamples'
+
+export function AlertExamples() {
+  return (
+    <ComponentExamples title="Alert Components">
+      <ComponentInfo component="Alert" description="Display contextual feedback messages with different severity levels (error, warning, success, info).">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span> <code className="bg-gray-700 px-2 py-1 rounded">import Alert from '@/components/widgets/Alert'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">type</code> (optional: 'error' | 'warning' | 'success' |
+          'info', defaults to 'error'), <code className="bg-gray-700 px-2 py-1 rounded">children</code> (required),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">className</code> (optional)
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Note:</span> Uses Material Symbols icons and includes cy-id attributes for testing
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Error Alert">
+          <Alert type="error">
+            <div className="pr-4">
+              <p className="font-medium">Something went wrong!</p>
+              <p className="text-sm opacity-80 mt-1">Unable to connect to the server. Please check your internet connection and try again.</p>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Warning Alert">
+          <Alert type="warning">
+            <div className="pr-4">
+              <p className="font-medium">Warning: Low disk space</p>
+              <p className="text-sm opacity-80 mt-1">Your storage is running low. Consider removing some files to free up space.</p>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Success Alert">
+          <Alert type="success">
+            <div className="pr-4">
+              <p className="font-medium">Success!</p>
+              <p className="text-sm opacity-80 mt-1">Your audiobook has been successfully added to the library.</p>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Info Alert">
+          <Alert type="info">
+            <div className="pr-4">
+              <p className="font-medium">Did you know?</p>
+              <p className="text-sm opacity-80 mt-1">You can organize your audiobooks into custom collections for better management.</p>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Simple Error Alert">
+          <Alert type="error">
+            <div className="pr-4">
+              <p>Invalid username or password</p>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Custom Styled Alert">
+          <Alert type="info" className="shadow-lg">
+            <div className="pr-4">
+              <p className="font-medium">Custom styled alert</p>
+              <p className="text-sm opacity-80 mt-1">This alert has additional shadow styling applied via className prop.</p>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Alert with Action Button">
+          <Alert type="warning">
+            <div className="pr-4 flex items-center justify-between w-full">
+              <div>
+                <p className="font-medium">Update available</p>
+                <p className="text-sm opacity-80 mt-1">A new version of the application is available.</p>
+              </div>
+              <button className="ml-4 px-4 py-2 bg-warning text-gray-900 rounded-md text-sm font-medium hover:bg-warning/90 transition-colors">
+                Update Now
+              </button>
+            </div>
+          </Alert>
+        </Example>
+
+        <Example title="Alert with List Content">
+          <Alert type="error">
+            <div className="pr-4">
+              <p className="font-medium mb-2">Validation errors:</p>
+              <ul className="text-sm opacity-80 space-y-1 list-disc list-inside">
+                <li>Title field is required</li>
+                <li>Author field cannot be empty</li>
+                <li>Duration must be greater than 0</li>
+              </ul>
+            </div>
+          </Alert>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}

--- a/src/app/(main)/components_catalog/examples/InlineIndicatorExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/InlineIndicatorExamples.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { ComponentExamples, ComponentInfo, ExamplesBlock, Example } from '../ComponentExamples'
+import AbridgedIndicator from '@/components/widgets/AbridgedIndicator'
+import AlreadyInLibraryIndicator from '@/components/widgets/AlreadyInLibraryIndicator'
+import BonusIndicator from '@/components/widgets/BonusIndicator'
+import ExplicitIndicator from '@/components/widgets/ExplicitIndicator'
+import TrailerIndicator from '@/components/widgets/TrailerIndicator'
+import OnlineIndicator from '@/components/widgets/OnlineIndicator'
+
+export function InlineIndicatorExamples() {
+  return (
+    <ComponentExamples title="Inline Indicators">
+      <ComponentInfo component="AbridgedIndicator" description="A small indicator showing that content is abridged, with a tooltip">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import AbridgedIndicator from '@/components/widgets/AbridgedIndicator'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">className</code> (optional)
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Note:</span> Uses a custom svg icon with a tooltip that says "Abridged"
+        </p>
+      </ComponentInfo>
+
+      <ComponentInfo component="AlreadyInLibraryIndicator" description="A small indicator showing that content is already in your library, with a tooltip">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import AlreadyInLibraryIndicator from '@/components/widgets/AlreadyInLibraryIndicator'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">className</code> (optional)
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Note:</span> Uses a material symbols check_circle icon with a tooltip that says "Already in your library"
+        </p>
+      </ComponentInfo>
+
+      <ComponentInfo component="ExplicitIndicator" description="A small indicator showing that content is explicit, with a tooltip">
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import ExplicitIndicator from '@/components/widgets/ExplicitIndicator'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">className</code> (optional)
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Note:</span> Uses a material symbols explicit icon with a tooltip that says "Explicit"
+        </p>
+      </ComponentInfo>
+
+      <ExamplesBlock>
+        <Example title="Abridged">
+          <div className="space-y-4">
+            <div className="flex items-center gap-1">
+              <span className="text-3xl">Abridged Book</span>
+              <AbridgedIndicator />
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Explicit">
+          <div className="space-y-4">
+            <div className="flex items-center gap-1">
+              <span className="text-3xl">F#?@!! Book</span>
+              <ExplicitIndicator />
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Abridged and Explicit">
+          <div className="space-y-4">
+            <div className="flex items-center gap-1">
+              <span className="text-3xl">Shock and Shortened</span>
+              <AbridgedIndicator />
+              <ExplicitIndicator />
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Already in Library">
+          <div className="space-y-4">
+            <div className="flex items-center gap-1">
+              <span className="text-xl">Podcast Title</span>
+              <AlreadyInLibraryIndicator />
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Bonus">
+          <div className="space-y-4">
+            <div className="flex items-center gap-1">
+              <span className="text-xl">Bonus Episode</span>
+              <BonusIndicator />
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Trailer">
+          <div className="space-y-4">
+            <div className="flex items-center gap-1">
+              <span className="text-xl">Trailer Episode</span>
+              <TrailerIndicator />
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Online">
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <OnlineIndicator value={true} />
+              <span className="text-base">online_user</span>
+            </div>
+          </div>
+        </Example>
+
+        <Example title="Offline">
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <OnlineIndicator value={false} />
+              <span className="text-base">offline_user</span>
+            </div>
+          </div>
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -26,6 +26,8 @@ import { RangeInputExamples } from './examples/RangeInputExamples'
 import { AdvancedModalExamples } from './examples/AdvancedModalExamples'
 import { TooltipExamples } from './examples/TooltipExamples'
 import { SlateEditorExamples } from './examples/SlateEditorExamples'
+import { InlineIndicatorExamples } from './examples/InlineIndicatorExamples'
+import { AlertExamples } from './examples/AlertExamples'
 
 export default function ComponentsCatalogPage() {
   return (
@@ -173,6 +175,16 @@ export default function ComponentsCatalogPage() {
                     Rich Text Editor
                   </a>
                 </li>
+                <li>
+                  <a href="#abridged-indicator-examples" className="hover:text-blue-400 transition-colors">
+                    Abridged Indicator
+                  </a>
+                </li>
+                <li>
+                  <a href="#alert-examples" className="hover:text-blue-400 transition-colors">
+                    Alerts
+                  </a>
+                </li>
               </ul>
             </div>
           </div>
@@ -256,6 +268,12 @@ export default function ComponentsCatalogPage() {
       </div>
       <div id="slate-editor-examples">
         <SlateEditorExamples />
+      </div>
+      <div id="abridged-indicator-examples">
+        <InlineIndicatorExamples />
+      </div>
+      <div id="alert-examples">
+        <AlertExamples />
       </div>
     </div>
   )

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -212,7 +212,7 @@ const Tooltip = ({
   )
 
   const referenceClass = useMemo(() => {
-    return mergeClasses('inline-block', className)
+    return mergeClasses('inline-flex', className)
   }, [className])
 
   const tooltipElement = (

--- a/src/components/widgets/AbridgedIndicator.tsx
+++ b/src/components/widgets/AbridgedIndicator.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import Indicator from './Indicator'
+
+interface AbridgedIndicatorProps {
+  className?: string
+}
+
+const AbridgedIndicator = ({ className }: AbridgedIndicatorProps) => {
+  return (
+    <Indicator tooltipText="Abridged" className={className}>
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 512 512" aria-hidden="true">
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="
+            M40 40 L472 40 L472 472 L40 472 L40 40 Z
+            
+            M246 120 L266 120 L376 380 L314 380 L292 326 L220 326 L198 380 L136 380 L246 120 Z
+            M256 210 L230 278 L282 278 L256 210 Z
+          "
+        />
+      </svg>
+    </Indicator>
+  )
+}
+
+export default AbridgedIndicator

--- a/src/components/widgets/Alert.tsx
+++ b/src/components/widgets/Alert.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import React, { useEffect, useMemo, useRef } from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+
+export interface AlertProps {
+  type?: 'error' | 'warning' | 'success' | 'info'
+  children: React.ReactNode
+  className?: string
+}
+
+export default function Alert({ type = 'error', children, className }: AlertProps) {
+  const alertRef = useRef<HTMLDivElement>(null)
+
+  const isAlert = useMemo(() => {
+    return type === 'error' || type === 'warning'
+  }, [type])
+
+  const icon = useMemo(() => {
+    return isAlert ? 'report' : 'info'
+  }, [isAlert])
+
+  const prefix = useMemo(() => {
+    switch (type) {
+      case 'error':
+        return 'Error'
+      case 'warning':
+        return 'Warning'
+      case 'success':
+        return 'Success'
+      case 'info':
+        return 'Information'
+      default:
+        return 'Alert'
+    }
+  }, [type])
+
+  const alertRole = useMemo(() => {
+    return isAlert ? 'alert' : 'status'
+  }, [type])
+
+  const wrapperClass = useMemo(() => {
+    const baseClasses = 'w-full border rounded-lg flex items-center relative py-4 ps-16'
+
+    const typeClasses = (() => {
+      switch (type) {
+        case 'error':
+          return 'bg-error/5 border-error/60 text-error'
+        case 'warning':
+          return 'bg-warning/5 border-warning/60 text-warning'
+        case 'success':
+          return 'bg-success/5 border-success/60 text-success'
+        case 'info':
+          return 'bg-info/5 border-info/60 text-info'
+        default:
+          return 'bg-primary/5 border-primary/60 text-primary'
+      }
+    })()
+
+    return mergeClasses(baseClasses, typeClasses, className)
+  }, [type, className])
+
+  useEffect(() => {
+    if (isAlert && alertRef.current) {
+      alertRef.current.focus()
+    }
+  }, [isAlert])
+
+  return (
+    <div cy-id="alert" className={wrapperClass} role={alertRole} tabIndex={isAlert ? -1 : undefined} ref={alertRef}>
+      <div className="absolute top-0 start-4 h-full flex items-center">
+        <span cy-id="alert-icon" className="material-symbols text-2xl" aria-hidden="true">
+          {icon}
+        </span>
+      </div>
+      <div>
+        <span className="sr-only">{prefix}: </span>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/AlreadyInLibraryIndicator.tsx
+++ b/src/components/widgets/AlreadyInLibraryIndicator.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+import Indicator from './Indicator'
+
+interface AlreadyInLibraryIndicatorProps {
+  className?: string
+}
+
+const AlreadyInLibraryIndicator = ({ className }: AlreadyInLibraryIndicatorProps) => {
+  return (
+    <Indicator tooltipText="Already in your library" className={mergeClasses('text-success', className)}>
+      check_circle
+    </Indicator>
+  )
+}
+
+export default AlreadyInLibraryIndicator

--- a/src/components/widgets/BonusIndicator.tsx
+++ b/src/components/widgets/BonusIndicator.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Indicator from './Indicator'
+
+interface BonusIndicatorProps {
+  className?: string
+}
+
+const BonusIndicator = ({ className }: BonusIndicatorProps) => {
+  return (
+    <Indicator tooltipText="Bonus" className={className}>
+      local_play
+    </Indicator>
+  )
+}
+
+export default BonusIndicator

--- a/src/components/widgets/ExplicitIndicator.tsx
+++ b/src/components/widgets/ExplicitIndicator.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Indicator from './Indicator'
+
+interface ExplicitIndicatorProps {
+  className?: string
+}
+
+const ExplicitIndicator = ({ className }: ExplicitIndicatorProps) => {
+  return (
+    <Indicator tooltipText="Explicit" className={className}>
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 512 512" aria-hidden="true">
+        <path
+          fill="currentColor"
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="
+            M40 40 L472 40 L472 472 L40 472 L40 40 Z
+
+            M176 120 L336 120 L336 162 L226 162
+            L226 230 L316 230 L316 276 L226 276
+            L226 338 L336 338 L336 380 L176 380 Z
+          "
+        />
+      </svg>
+    </Indicator>
+  )
+}
+
+export default ExplicitIndicator

--- a/src/components/widgets/Indicator.tsx
+++ b/src/components/widgets/Indicator.tsx
@@ -10,7 +10,7 @@ interface IndicatorProps {
   role?: string
 }
 
-const Indicator = ({ tooltipText, children, className, ariaLabel, role = 'img' }: IndicatorProps) => {
+const Indicator = ({ tooltipText, children, className, ariaLabel, role = 'note' }: IndicatorProps) => {
   const effectiveAriaLabel = ariaLabel || tooltipText
 
   return (

--- a/src/components/widgets/Indicator.tsx
+++ b/src/components/widgets/Indicator.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import Tooltip from '@/components/ui/Tooltip'
+import { mergeClasses } from '@/lib/merge-classes'
+
+interface IndicatorProps {
+  tooltipText: string
+  children?: React.ReactNode
+  className?: string
+  ariaLabel?: string
+  role?: string
+}
+
+const Indicator = ({ tooltipText, children, className, ariaLabel, role = 'img' }: IndicatorProps) => {
+  const effectiveAriaLabel = ariaLabel || tooltipText
+
+  return (
+    <Tooltip text={tooltipText} position="top">
+      {typeof children === 'string' ? (
+        <span className={mergeClasses('material-symbols text-sm', className)} role={role} aria-label={effectiveAriaLabel}>
+          {children}
+        </span>
+      ) : (
+        <div className={className} role={role} aria-label={effectiveAriaLabel}>
+          {children}
+        </div>
+      )}
+    </Tooltip>
+  )
+}
+
+export default Indicator

--- a/src/components/widgets/OnlineIndicator.tsx
+++ b/src/components/widgets/OnlineIndicator.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Indicator from './Indicator'
+
+interface OnlineIndicatorProps {
+  value: boolean
+  className?: string
+}
+
+const OnlineIndicator = ({ value, className }: OnlineIndicatorProps) => {
+  const statusText = value ? 'Online' : 'Offline'
+
+  return (
+    <Indicator role="status" tooltipText={statusText} className={className}>
+      {value ? (
+        <div className="w-3 h-3 text-success animate-pulse">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" fill="currentColor" />
+          </svg>
+        </div>
+      ) : (
+        <svg className="w-3 h-3 text-white/20" viewBox="0 0 24 24" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" fill="currentColor" />
+        </svg>
+      )}
+    </Indicator>
+  )
+}
+
+export default OnlineIndicator

--- a/src/components/widgets/TrailerIndicator.tsx
+++ b/src/components/widgets/TrailerIndicator.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import Indicator from './Indicator'
+
+interface TrailerIndicatorProps {
+  className?: string
+}
+
+const TrailerIndicator = ({ className }: TrailerIndicatorProps) => {
+  return (
+    <Indicator tooltipText="Trailer" className={className}>
+      local_movies
+    </Indicator>
+  )
+}
+
+export default TrailerIndicator


### PR DESCRIPTION
This migrates the Alert component, as well as all the inline indicator components defined in `widgets`

Changes from the original:

Alert:
- Added support for a11y and RTL

Indicators:
- Created an Indicator base component, with tooltip
- Added support for a11y and RTL
- AbridgedIndicator: simplified svg
- ExplicitIndicator: switch to svg to make it similar to Abridged indicator.
- Online indicator: simplified svg

See examples in the component catalog.
