### PR TITLE
Split code into two components

### DIFF
--- a/src/components/widgets/CronExpressionBuilder.tsx
+++ b/src/components/widgets/CronExpressionBuilder.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState, useEffect, useMemo } from 'react'
+import { validateCron } from '@/lib/cron'
+import CronExpressionControls from './CronExpressionControls'
+import CronExpressionPreview from './CronExpressionPreview'
+
+interface CronExpressionBuilderProps {
+  currentCronValue: string
+  onChange?: (value: string, isInvalid?: boolean) => void
+}
+
+export default function CronExpressionBuilder({ currentCronValue, onChange }: CronExpressionBuilderProps) {
+  const [isValid, setIsValid] = useState<boolean>(true)
+
+  // Validate cron expression whenever it changes
+  useEffect(() => {
+    const validationResult = validateCron(currentCronValue)
+    setIsValid(validationResult.isValid)
+  }, [currentCronValue])
+
+  // Determine if we should show the preview (hide when in advanced mode with invalid cron)
+  const showPreview = useMemo(() => {
+    if (!isValid) {
+      // Only hide preview if the cron is invalid
+      return false
+    }
+    return true
+  }, [isValid])
+
+  return (
+    <div className="w-full py-2" cy-id="cron-expression-builder">
+      <CronExpressionControls 
+        currentCronValue={currentCronValue} 
+        onChange={onChange} 
+      />
+      
+      <CronExpressionPreview 
+        cronExpression={currentCronValue}
+        isValid={isValid}
+        showPreview={showPreview}
+      />
+    </div>
+  )
+}

--- a/src/components/widgets/CronExpressionControls.tsx
+++ b/src/components/widgets/CronExpressionControls.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { validateCron } from '@/lib/cron'
+import Dropdown from '@/components/ui/Dropdown'
+import { MultiSelect } from '@/components/ui/MultiSelect'
+import TextInput from '@/components/ui/TextInput'
+import type { MultiSelectItem } from '@/components/ui/MultiSelect'
+
+interface CronExpressionControlsProps {
+  currentCronValue: string
+  onChange?: (value: string, isInvalid?: boolean) => void
+}
+
+export default function CronExpressionControls({ currentCronValue, onChange }: CronExpressionControlsProps) {
+  const [selectedInterval, setSelectedInterval] = useState<string>('daily')
+  const [customCronError, setCustomCronError] = useState<string>('')
+
+  const customExpressionInputRef = useRef<HTMLInputElement>(null)
+
+  // Memoize interval options to prevent re-creation on every render.
+  const intervalOptions = useMemo(
+    () => [
+      { text: 'Daily', value: 'daily', canExpress: (expr: string) => /^\d+ \d+ \* \* \*$/.test(expr) },
+      { text: 'Weekly', value: 'weekly', canExpress: (expr: string) => /^\d+ \d+ \* \* (\*|(\d+(,\d+)*))$/.test(expr) },
+      { text: 'Every 12 Hours', value: '0 */12 * * *', canExpress: (expr: string) => expr === '0 */12 * * *' },
+      { text: 'Every 6 Hours', value: '0 */6 * * *', canExpress: (expr: string) => expr === '0 */6 * * *' },
+      { text: 'Every 2 Hours', value: '0 */2 * * *', canExpress: (expr: string) => expr === '0 */2 * * *' },
+      { text: 'Every Hour', value: '0 * * * *', canExpress: (expr: string) => expr === '0 * * * *' },
+      { text: 'Every 30 Minutes', value: '*/30 * * * *', canExpress: (expr: string) => expr === '*/30 * * * *' },
+      { text: 'Every 15 Minutes', value: '*/15 * * * *', canExpress: (expr: string) => expr === '*/15 * * * *' },
+      { text: 'Custom', value: 'advanced', canExpress: () => true }
+    ],
+    []
+  )
+
+  const weekdays = useMemo<MultiSelectItem<string>[]>(() => {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    return days.map((day, index) => ({ value: index.toString(), content: day }))
+  }, [])
+
+  const parsedValues = useMemo(() => {
+    const pieces = currentCronValue.split(' ').filter(Boolean)
+    if (pieces.length < 5) {
+      // Return a default state for invalid or incomplete cron strings.
+      return { hour: 0, minute: 0, selectedWeekdays: [] }
+    }
+
+    const hour = parseInt(pieces[1]) || 0
+    const minute = parseInt(pieces[0]) || 0
+    let selectedWeekdays: MultiSelectItem<string>[] = []
+
+    if (pieces[4] && pieces[4] !== '*') {
+      const weekdayValues = pieces[4].split(',')
+      selectedWeekdays = weekdays.filter((w) => weekdayValues.includes(w.value))
+    }
+
+    return { hour, minute, selectedWeekdays }
+  }, [currentCronValue, weekdays])
+
+  // Effect to parse the incoming cron value and set the correct UI view.
+  useEffect(() => {
+    const validationResult = validateCron(currentCronValue)
+    setCustomCronError(validationResult.error || '')
+
+    if (!validationResult.isValid) {
+      setSelectedInterval('advanced')
+      return
+    }
+
+    // Find all interval types that can express this cron expression
+    const matchingTypes = intervalOptions.filter((config) => config.canExpress(currentCronValue))
+    setSelectedInterval((currentInterval) => {
+      const matchesCurrent = matchingTypes.some((config) => config.value === currentInterval)
+      return matchesCurrent ? currentInterval : matchingTypes[0].value
+    })
+  }, [currentCronValue, intervalOptions])
+
+  const handleIntervalChange = useCallback((newInterval: string) => {
+    setSelectedInterval(newInterval)
+
+    if (newInterval === 'daily') {
+      onChange?.(`${parsedValues.minute} ${parsedValues.hour} * * *`)
+    } else if (newInterval === 'weekly') {
+      const daysOfWeek =
+        parsedValues.selectedWeekdays.length > 0
+          ? parsedValues.selectedWeekdays
+              .map((w) => w.value)
+              .sort()
+              .join(',')
+          : '*'
+      onChange?.(`${parsedValues.minute} ${parsedValues.hour} * * ${daysOfWeek}`)
+    } else if (newInterval !== 'advanced') {
+      onChange?.(newInterval)
+    }
+  }, [parsedValues.minute, parsedValues.hour, parsedValues.selectedWeekdays, onChange])
+
+  const handleTimeChange = useCallback((value: string) => {
+    if (!value) return
+
+    const [hourStr, minuteStr] = value.split(':')
+    const newHour = Math.max(0, Math.min(23, parseInt(hourStr) || 0))
+    const newMinute = Math.max(0, Math.min(59, parseInt(minuteStr) || 0))
+
+    const pieces = currentCronValue.split(' ')
+    pieces[0] = String(newMinute)
+    pieces[1] = String(newHour)
+    onChange?.(pieces.join(' '))
+  }, [currentCronValue, onChange])
+
+  const handleWeekdayChange = useCallback((items: MultiSelectItem<string>[]) => {
+    const sortedItems = [...items].sort((a, b) => parseInt(a.value) - parseInt(b.value))
+    const daysOfWeek = sortedItems.length === 0 || sortedItems.length === 7 ? '*' : sortedItems.map((w) => w.value).join(',')
+
+    const pieces = currentCronValue.split(' ')
+    pieces[4] = daysOfWeek
+    onChange?.(pieces.join(' '))
+  }, [currentCronValue, onChange])
+
+  const handleCustomCronChange = useCallback((newValue: string) => {
+    const validationResult = validateCron(newValue)
+    setCustomCronError(validationResult.error || '')
+    onChange?.(newValue, !validationResult.isValid)
+  }, [onChange])
+
+  const formatTimeValue = useMemo(() => {
+    const hour = String(parsedValues.hour).padStart(2, '0')
+    const minute = String(parsedValues.minute).padStart(2, '0')
+    return `${hour}:${minute}`
+  }, [parsedValues.hour, parsedValues.minute])
+
+  return (
+    <div className="w-full" cy-id="cron-expression-controls">
+      <div style={{ minHeight: '160px' }}>
+        <Dropdown
+          value={selectedInterval}
+          onChange={(value) => handleIntervalChange(String(value))}
+          label="Interval"
+          items={intervalOptions}
+          className="mb-2"
+          cy-id="interval-dropdown"
+        />
+
+        <div className="flex items-center gap-2 mb-2">
+          {(selectedInterval === 'weekly' || selectedInterval === 'daily') && (
+            <TextInput
+              value={formatTimeValue}
+              onChange={handleTimeChange}
+              type="time"
+              label="Time"
+              customInputClass="[&::-webkit-calendar-picker-indicator]:hidden"
+              className="w-fit"
+              cy-id="time-input"
+            />
+          )}
+
+          {selectedInterval === 'weekly' && (
+            <MultiSelect
+              selectedItems={parsedValues.selectedWeekdays}
+              items={weekdays}
+              label="Weekdays to Run"
+              onItemAdded={(item) => handleWeekdayChange([...parsedValues.selectedWeekdays, item])}
+              onItemRemoved={(item) => handleWeekdayChange(parsedValues.selectedWeekdays.filter((w) => w.value !== item.value))}
+              allowNew={false}
+              cy-id="weekdays-multiselect"
+            />
+          )}
+
+          {selectedInterval === 'advanced' && (
+            <div className="w-full">
+              <TextInput
+                ref={customExpressionInputRef}
+                label="Cron Expression"
+                value={currentCronValue}
+                onChange={handleCustomCronChange}
+                customInputClass={'text-2xl md:text-3xl font-mono text-center'}
+                className="w-full mb-2"
+                error={customCronError}
+                cy-id="cron-expression-input"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/CronExpressionPreview.tsx
+++ b/src/components/widgets/CronExpressionPreview.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useMemo } from 'react'
+import { getHumanReadableCronExpression, calculateNextRunDate } from '@/lib/cron'
+
+interface CronExpressionPreviewProps {
+  cronExpression: string
+  isValid: boolean
+  showPreview?: boolean
+}
+
+export default function CronExpressionPreview({
+  cronExpression,
+  isValid,
+  showPreview = true
+}: CronExpressionPreviewProps) {
+  const verbalDescription = useMemo(() => 
+    getHumanReadableCronExpression(cronExpression), 
+    [cronExpression]
+  )
+
+  const nextRunDate = useMemo(() => 
+    cronExpression && isValid ? calculateNextRunDate(cronExpression) : '',
+    [cronExpression, isValid]
+  )
+
+  if (!showPreview || !isValid) {
+    return null
+  }
+
+  return (
+    <div>
+      <div className="mb-4 p-3 bg-primary/30 rounded-lg border border-primary/50">
+        <div className="flex items-center">
+          <span className="material-symbols mr-2 text-blue-400">schedule</span>
+          <p className="text-sm font-medium text-gray-300">Schedule:</p>
+        </div>
+        <p className="text-base font-semibold text-white mt-1" cy-id="cron-description">
+          {verbalDescription}
+        </p>
+        {cronExpression && <p className="text-xs text-gray-400 mt-1 font-mono">{cronExpression}</p>}
+      </div>
+
+      {cronExpression && isValid && nextRunDate && (
+        <div className="flex items-center justify-center text-yellow-400 mt-2">
+          <span className="material-symbols mr-2 text-xl">event</span>
+          <p>Next Scheduled Run: {nextRunDate}</p>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Refactor `CronExpressionBuilder` into `CronExpressionControls` and `CronExpressionPreview` to separate input logic from display logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-33a61108-4325-4864-bad0-1e38f28614f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33a61108-4325-4864-bad0-1e38f28614f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

