### PR TITLE
CronExpressionBuilder & CronExpressionPreview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.6",
         "clsx": "^2.1.1",
+        "cronstrue": "^3.3.0",
         "next": "15.3.3",
         "next-intl": "^4.3.4",
         "react": "^19.0.0",
@@ -1778,6 +1779,15 @@
       "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cronstrue": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-3.3.0.tgz",
+      "integrity": "sha512-iwJytzJph1hosXC09zY8F5ACDJKerr0h3/2mOxg9+5uuFObYlgK0m35uUPk4GCvhHc2abK7NfnR9oMqY0qZFAg==",
+      "license": "MIT",
+      "bin": {
+        "cronstrue": "bin/cli.js"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.6",
     "clsx": "^2.1.1",
+    "cronstrue": "^3.3.0",
     "next": "15.3.3",
     "next-intl": "^4.3.4",
     "react": "^19.0.0",

--- a/src/app/(main)/components_catalog/ComponentExamples.tsx
+++ b/src/app/(main)/components_catalog/ComponentExamples.tsx
@@ -61,6 +61,6 @@ export function Example({ title, children, className }: ExampleProps) {
   )
 }
 
-export function ExamplesBlock({ children }: { children: React.ReactNode }) {
-  return <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">{children}</div>
+export function ExamplesBlock({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={mergeClasses('grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6', className)}>{children}</div>
 }

--- a/src/app/(main)/components_catalog/examples/AlertExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/AlertExamples.tsx
@@ -13,16 +13,21 @@ export function AlertExamples() {
         <p className="mb-2">
           <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">type</code> (optional: 'error' | 'warning' | 'success' |
           'info', defaults to 'error'), <code className="bg-gray-700 px-2 py-1 rounded">children</code> (required),{' '}
-          <code className="bg-gray-700 px-2 py-1 rounded">className</code> (optional)
+          <code className="bg-gray-700 px-2 py-1 rounded">autoFocus</code> (optional: boolean, defaults to true. If true and type is 'error' or 'warning', the
+          alert will be focused when rendered), <code className="bg-gray-700 px-2 py-1 rounded">className</code> (optional)
         </p>
         <p className="mb-2">
-          <span className="font-bold">Note:</span> Uses Material Symbols icons and includes cy-id attributes for testing
+          <span className="font-bold">Note:</span> Uses Material Symbols icons.
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Note:</span> <code className="bg-gray-700 px-2 py-1 rounded">autoFocus</code> is always set to false in the examples, so
+          as not to steal focus.
         </p>
       </ComponentInfo>
 
       <ExamplesBlock>
         <Example title="Error Alert">
-          <Alert type="error">
+          <Alert type="error" autoFocus={false}>
             <div className="pr-4">
               <p className="font-medium">Something went wrong!</p>
               <p className="text-sm opacity-80 mt-1">Unable to connect to the server. Please check your internet connection and try again.</p>
@@ -31,7 +36,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Warning Alert">
-          <Alert type="warning">
+          <Alert type="warning" autoFocus={false}>
             <div className="pr-4">
               <p className="font-medium">Warning: Low disk space</p>
               <p className="text-sm opacity-80 mt-1">Your storage is running low. Consider removing some files to free up space.</p>
@@ -40,7 +45,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Success Alert">
-          <Alert type="success">
+          <Alert type="success" autoFocus={false}>
             <div className="pr-4">
               <p className="font-medium">Success!</p>
               <p className="text-sm opacity-80 mt-1">Your audiobook has been successfully added to the library.</p>
@@ -49,7 +54,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Info Alert">
-          <Alert type="info">
+          <Alert type="info" autoFocus={false}>
             <div className="pr-4">
               <p className="font-medium">Did you know?</p>
               <p className="text-sm opacity-80 mt-1">You can organize your audiobooks into custom collections for better management.</p>
@@ -58,7 +63,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Simple Error Alert">
-          <Alert type="error">
+          <Alert type="error" autoFocus={false}>
             <div className="pr-4">
               <p>Invalid username or password</p>
             </div>
@@ -66,7 +71,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Custom Styled Alert">
-          <Alert type="info" className="shadow-lg">
+          <Alert type="info" className="shadow-lg" autoFocus={false}>
             <div className="pr-4">
               <p className="font-medium">Custom styled alert</p>
               <p className="text-sm opacity-80 mt-1">This alert has additional shadow styling applied via className prop.</p>
@@ -75,7 +80,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Alert with Action Button">
-          <Alert type="warning">
+          <Alert type="warning" autoFocus={false}>
             <div className="pr-4 flex items-center justify-between w-full">
               <div>
                 <p className="font-medium">Update available</p>
@@ -89,7 +94,7 @@ export function AlertExamples() {
         </Example>
 
         <Example title="Alert with List Content">
-          <Alert type="error">
+          <Alert type="error" autoFocus={false}>
             <div className="pr-4">
               <p className="font-medium mb-2">Validation errors:</p>
               <ul className="text-sm opacity-80 space-y-1 list-disc list-inside">

--- a/src/app/(main)/components_catalog/examples/CronExpressionBuilderExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/CronExpressionBuilderExamples.tsx
@@ -3,34 +3,74 @@ import CronExpressionBuilder from '@/components/widgets/CronExpressionBuilder'
 import { useState, useCallback } from 'react'
 import { ComponentExamples, ComponentInfo, ExamplesBlock, Example } from '../ComponentExamples'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import CronExpressionPreview from '@/components/widgets/CronExpressionPreview'
 
 // CronExpressionBuilder Examples
 export function CronExpressionBuilderExamples() {
   const { showToast } = useGlobalToast()
 
+  // Example server settings for demonstration
+  const exampleServerSettings = {
+    language: 'en-us',
+    dateFormat: 'EEEE, MM/dd/yyyy',
+    timeFormat: 'HH:mm',
+    timeZone: 'America/New_York'
+  }
+
+  // Example with different languages for testing
+  const spanishSettings = {
+    language: 'es',
+    dateFormat: 'EEEE, dd/MM/yyyy',
+    timeFormat: 'HH:mm',
+    timeZone: 'America/New_York'
+  }
+
+  const frenchSettings = {
+    language: 'fr',
+    dateFormat: 'EEEE dd/MM/yyyy',
+    timeFormat: 'HH:mm',
+    timeZone: 'America/New_York'
+  }
+
   const [cronValue1, setCronValue1] = useState<string>('0 0 * * *')
+  const [cronValue1IsValid, setCronValue1IsValid] = useState<boolean>(true)
   const [cronValue2, setCronValue2] = useState<string>('0 9 * * 1,3,5')
+  const [cronValue2IsValid, setCronValue2IsValid] = useState<boolean>(true)
   const [cronValue3, setCronValue3] = useState<string>('*/15 * * * *')
-  const [cronValue4, setCronValue4] = useState<string>('')
+  const [cronValue3IsValid, setCronValue3IsValid] = useState<boolean>(true)
+  const [cronValue4, setCronValue4] = useState<string>('15 */3 * * *')
+  const [cronValue4IsValid, setCronValue4IsValid] = useState<boolean>(true)
+  const [cronValue5, setCronValue5] = useState<string>('0 10 * * 0,2,4,6')
+  const [cronValue5IsValid, setCronValue5IsValid] = useState<boolean>(true)
 
-  const handleCronChange1 = useCallback((value: string, isInvalid?: boolean) => {
+  const handleCronChange1 = useCallback((value: string, isValid: boolean) => {
     setCronValue1(value)
-    console.log('Cron expression 1 updated: ', value, ' isInvalid: ', isInvalid)
+    setCronValue1IsValid(isValid)
+    console.log('Cron expression 1 updated: ', value, ' isValid: ', isValid)
   }, [])
 
-  const handleCronChange2 = useCallback((value: string, isInvalid?: boolean) => {
+  const handleCronChange2 = useCallback((value: string, isValid: boolean = false) => {
     setCronValue2(value)
-    console.log('Cron expression 2 updated: ', value, ' isInvalid: ', isInvalid)
+    setCronValue2IsValid(isValid)
+    console.log('Cron expression 2 updated: ', value, ' isValid: ', isValid)
   }, [])
 
-  const handleCronChange3 = useCallback((value: string, isInvalid?: boolean) => {
+  const handleCronChange3 = useCallback((value: string, isValid: boolean) => {
     setCronValue3(value)
-    console.log('Cron expression 3 updated: ', value, ' isInvalid: ', isInvalid)
+    setCronValue3IsValid(isValid)
+    console.log('Cron expression 3 updated: ', value, ' isValid: ', isValid)
   }, [])
 
-  const handleCronChange4 = useCallback((value: string, isInvalid?: boolean) => {
+  const handleCronChange4 = useCallback((value: string, isValid: boolean) => {
     setCronValue4(value)
-    console.log('Cron expression 4 updated: ', value, ' isInvalid: ', isInvalid)
+    setCronValue4IsValid(isValid)
+    console.log('Cron expression 4 updated: ', value, ' isValid: ', isValid)
+  }, [])
+
+  const handleCronChange5 = useCallback((value: string, isValid: boolean) => {
+    setCronValue5(value)
+    setCronValue5IsValid(isValid)
+    console.log('Cron expression 5 updated: ', value, ' isValid: ', isValid)
   }, [])
 
   return (
@@ -43,38 +83,76 @@ export function CronExpressionBuilderExamples() {
           <span className="font-bold">Import:</span>{' '}
           <code className="bg-gray-700 px-2 py-1 rounded">import CronExpressionBuilder from '@/components/widgets/CronExpressionBuilder'</code>
         </p>
+        <div className="mb-2">
+          <span className="font-bold">Props:</span>
+          <div className="grid grid-cols-[auto_1fr] gap-2">
+            <code className="bg-gray-700 px-1 rounded">value</code>
+            <span>a cron expression</span>
+            <code className="bg-gray-700 px-1 rounded">options? </code>
+            <span>
+              <code>
+                {'{'} language?, timeZone? {'}'}
+              </code>{' '}
+              - server language and time zone settings
+            </span>
+            <code className="bg-gray-700 px-1 rounded">onChange?</code>
+            <code>function (value: string, isValid?: boolean): void</code>
+          </div>
+        </div>
+      </ComponentInfo>
+
+      <ComponentInfo component="CronExpressionPreview" description="A preview of the cron expression with a verbal description of the schedule, next run date">
         <p className="mb-2">
-          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code> (string | null),{' '}
-          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code> (function)
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import CronExpressionPreview from '@/components/widgets/CronExpressionPreview'</code>
         </p>
-        <p className="mb-2">
-          <span className="font-bold">Features:</span>
-        </p>
-        <ul className="list-disc list-inside mb-2 text-sm text-gray-300 ml-4">
-          <li>Visual schedule builder with predefined intervals</li>
-          <li>Custom daily/weekly scheduling with time picker</li>
-          <li>Advanced option for direct cron expression editing</li>
-          <li>Real-time validation with server-side verification</li>
-          <li>Next run date calculation and display</li>
-          <li>Simplified single-interface design</li>
-        </ul>
+        <div className="mb-2">
+          <span className="font-bold">Props:</span>
+          <div className="grid grid-cols-[auto_1fr] gap-2">
+            <code className="bg-gray-700 px-1 rounded">cronExpression</code>
+            <span>a cron expression</span>
+            <code className="bg-gray-700 px-1 rounded">isValid?</code>
+            <span>the validity of the cron expression. Will validate the cron expression internally if not provided</span>
+            <code className="bg-gray-700 px-1 rounded">options?</code>
+            <span>
+              <code>
+                {'{'} language?, dateFormat?, timeFormat?, timeZone? {'}'}
+              </code>{' '}
+              - the server language, date, and time settings
+            </span>
+            <code className="bg-gray-700 px-1 rounded">className?</code>
+            <span>classes to merge with the default classes</span>
+          </div>
+        </div>
       </ComponentInfo>
 
       <ExamplesBlock className="lg:grid-cols-2">
-        <Example title="Daily Schedule (Default)">
-          <CronExpressionBuilder currentCronValue={cronValue1} onChange={handleCronChange1} />
+        <Example title="Daily">
+          <CronExpressionBuilder value={cronValue1} onChange={handleCronChange1} options={exampleServerSettings} />
+          <CronExpressionPreview cronExpression={cronValue1} isValid={cronValue1IsValid} options={exampleServerSettings} />
         </Example>
 
-        <Example title="Weekly Schedule (Monday, Wednesday, Friday at 9:00 AM)">
-          <CronExpressionBuilder currentCronValue={cronValue2} onChange={handleCronChange2} />
+        <Example title="Weekly">
+          <CronExpressionBuilder value={cronValue2} onChange={handleCronChange2} options={exampleServerSettings} />
+          <CronExpressionPreview cronExpression={cronValue2} isValid={cronValue2IsValid} options={exampleServerSettings} />
         </Example>
 
-        <Example title="Advanced Schedule (Every 15 minutes)">
-          <CronExpressionBuilder currentCronValue={cronValue3} onChange={handleCronChange3} />
+        <Example title="Every 15 Minutes">
+          <CronExpressionBuilder value={cronValue3} onChange={handleCronChange3} options={exampleServerSettings} />
+          <CronExpressionPreview cronExpression={cronValue3} isValid={cronValue3IsValid} options={exampleServerSettings} />
         </Example>
 
-        <Example title="Empty Schedule Builder">
-          <CronExpressionBuilder currentCronValue={cronValue4} onChange={handleCronChange4} />
+        <Example title="Custom Cron Expression">
+          <CronExpressionBuilder value={cronValue4} onChange={handleCronChange4} options={exampleServerSettings} />
+          <CronExpressionPreview cronExpression={cronValue4} isValid={cronValue4IsValid} options={exampleServerSettings} />
+        </Example>
+
+        <Example title="i18n">
+          <CronExpressionBuilder value={cronValue5} onChange={handleCronChange5} options={exampleServerSettings} />
+          <p>Spanish</p>
+          <CronExpressionPreview cronExpression={cronValue5} isValid={cronValue5IsValid} options={spanishSettings} />
+          <p>French</p>
+          <CronExpressionPreview cronExpression={cronValue5} isValid={cronValue5IsValid} options={frenchSettings} />
         </Example>
       </ExamplesBlock>
     </ComponentExamples>

--- a/src/app/(main)/components_catalog/examples/CronExpressionBuilderExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/CronExpressionBuilderExamples.tsx
@@ -1,0 +1,82 @@
+'use client'
+import CronExpressionBuilder from '@/components/widgets/CronExpressionBuilder'
+import { useState, useCallback } from 'react'
+import { ComponentExamples, ComponentInfo, ExamplesBlock, Example } from '../ComponentExamples'
+import { useGlobalToast } from '@/contexts/ToastContext'
+
+// CronExpressionBuilder Examples
+export function CronExpressionBuilderExamples() {
+  const { showToast } = useGlobalToast()
+
+  const [cronValue1, setCronValue1] = useState<string>('0 0 * * *')
+  const [cronValue2, setCronValue2] = useState<string>('0 9 * * 1,3,5')
+  const [cronValue3, setCronValue3] = useState<string>('*/15 * * * *')
+  const [cronValue4, setCronValue4] = useState<string>('')
+
+  const handleCronChange1 = useCallback((value: string, isInvalid?: boolean) => {
+    setCronValue1(value)
+    console.log('Cron expression 1 updated: ', value, ' isInvalid: ', isInvalid)
+  }, [])
+
+  const handleCronChange2 = useCallback((value: string, isInvalid?: boolean) => {
+    setCronValue2(value)
+    console.log('Cron expression 2 updated: ', value, ' isInvalid: ', isInvalid)
+  }, [])
+
+  const handleCronChange3 = useCallback((value: string, isInvalid?: boolean) => {
+    setCronValue3(value)
+    console.log('Cron expression 3 updated: ', value, ' isInvalid: ', isInvalid)
+  }, [])
+
+  const handleCronChange4 = useCallback((value: string, isInvalid?: boolean) => {
+    setCronValue4(value)
+    console.log('Cron expression 4 updated: ', value, ' isInvalid: ', isInvalid)
+  }, [])
+
+  return (
+    <ComponentExamples title="Cron Expression Builder">
+      <ComponentInfo
+        component="CronExpressionBuilder"
+        description="A comprehensive cron expression builder with visual schedule builder and advanced cron expression input option"
+      >
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import CronExpressionBuilder from '@/components/widgets/CronExpressionBuilder'</code>
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Props:</span> <code className="bg-gray-700 px-2 py-1 rounded">value</code> (string | null),{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">onChange</code> (function)
+        </p>
+        <p className="mb-2">
+          <span className="font-bold">Features:</span>
+        </p>
+        <ul className="list-disc list-inside mb-2 text-sm text-gray-300 ml-4">
+          <li>Visual schedule builder with predefined intervals</li>
+          <li>Custom daily/weekly scheduling with time picker</li>
+          <li>Advanced option for direct cron expression editing</li>
+          <li>Real-time validation with server-side verification</li>
+          <li>Next run date calculation and display</li>
+          <li>Simplified single-interface design</li>
+        </ul>
+      </ComponentInfo>
+
+      <ExamplesBlock className="lg:grid-cols-2">
+        <Example title="Daily Schedule (Default)">
+          <CronExpressionBuilder currentCronValue={cronValue1} onChange={handleCronChange1} />
+        </Example>
+
+        <Example title="Weekly Schedule (Monday, Wednesday, Friday at 9:00 AM)">
+          <CronExpressionBuilder currentCronValue={cronValue2} onChange={handleCronChange2} />
+        </Example>
+
+        <Example title="Advanced Schedule (Every 15 minutes)">
+          <CronExpressionBuilder currentCronValue={cronValue3} onChange={handleCronChange3} />
+        </Example>
+
+        <Example title="Empty Schedule Builder">
+          <CronExpressionBuilder currentCronValue={cronValue4} onChange={handleCronChange4} />
+        </Example>
+      </ExamplesBlock>
+    </ComponentExamples>
+  )
+}

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -29,6 +29,7 @@ import { SlateEditorExamples } from './examples/SlateEditorExamples'
 import { InlineIndicatorExamples } from './examples/InlineIndicatorExamples'
 import { AlertExamples } from './examples/AlertExamples'
 import { CoverSizeWidgetExamples } from './examples/CoverSizeWidgetExamples'
+import { CronExpressionBuilderExamples } from './examples/CronExpressionBuilderExamples'
 
 export default function ComponentsCatalogPage() {
   return (
@@ -191,6 +192,11 @@ export default function ComponentsCatalogPage() {
                     Cover Size Widget
                   </a>
                 </li>
+                <li>
+                  <a href="#cron-expression-builder-examples" className="hover:text-blue-400 transition-colors">
+                    Cron Expression Builder
+                  </a>
+                </li>
               </ul>
             </div>
           </div>
@@ -283,6 +289,9 @@ export default function ComponentsCatalogPage() {
       </div>
       <div id="cover-size-widget-examples">
         <CoverSizeWidgetExamples />
+      </div>
+      <div id="cron-expression-builder-examples">
+        <CronExpressionBuilderExamples />
       </div>
     </div>
   )

--- a/src/components/widgets/Alert.tsx
+++ b/src/components/widgets/Alert.tsx
@@ -65,7 +65,7 @@ export default function Alert({ type = 'error', autoFocus = true, children, clas
     if (isAlert && alertRef.current && autoFocus) {
       alertRef.current.focus()
     }
-  }, [isAlert])
+  }, [isAlert, autoFocus])
 
   return (
     <div cy-id="alert" className={wrapperClass} role={alertRole} tabIndex={isAlert ? -1 : undefined} ref={alertRef}>

--- a/src/components/widgets/Alert.tsx
+++ b/src/components/widgets/Alert.tsx
@@ -5,11 +5,12 @@ import { mergeClasses } from '@/lib/merge-classes'
 
 export interface AlertProps {
   type?: 'error' | 'warning' | 'success' | 'info'
+  autoFocus?: boolean
   children: React.ReactNode
   className?: string
 }
 
-export default function Alert({ type = 'error', children, className }: AlertProps) {
+export default function Alert({ type = 'error', autoFocus = true, children, className }: AlertProps) {
   const alertRef = useRef<HTMLDivElement>(null)
 
   const isAlert = useMemo(() => {
@@ -61,7 +62,7 @@ export default function Alert({ type = 'error', children, className }: AlertProp
   }, [type, className])
 
   useEffect(() => {
-    if (isAlert && alertRef.current) {
+    if (isAlert && alertRef.current && autoFocus) {
       alertRef.current.focus()
     }
   }, [isAlert])

--- a/src/components/widgets/CronExpressionBuilder.tsx
+++ b/src/components/widgets/CronExpressionBuilder.tsx
@@ -1,364 +1,218 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { mergeClasses } from '@/lib/merge-classes'
-import { validateCron, getHumanReadableCronExpression, calculateNextRunDate, type ValidationResult } from '@/lib/cron'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
+import { getLocalizedServerTimeZone, validateCron, type FormatDateOptions, type ValidationResult } from '@/lib/cron'
 import Dropdown from '@/components/ui/Dropdown'
 import { MultiSelect } from '@/components/ui/MultiSelect'
 import TextInput from '@/components/ui/TextInput'
 import type { MultiSelectItem } from '@/components/ui/MultiSelect'
 
 interface CronExpressionBuilderProps {
-  currentCronValue: string
-  onChange?: (value: string, isInvalid?: boolean) => void
+  value: string
+  onChange?: (value: string, isValid: boolean) => void
+  options?: FormatDateOptions
 }
 
-export default function CronExpressionBuilder({ currentCronValue, onChange }: CronExpressionBuilderProps) {
-  // State management
-  const [selectedInterval, setSelectedInterval] = useState<string | null>(null)
-  const [selectedHour, setSelectedHour] = useState<number>(0)
-  const [selectedMinute, setSelectedMinute] = useState<number>(0)
-  const [selectedWeekdays, setSelectedWeekdays] = useState<MultiSelectItem<string>[]>([])
-
-  // Derive these from the value prop
+export default function CronExpressionBuilder({ value, onChange, options: { language, timeZone } = {} }: CronExpressionBuilderProps) {
+  const [selectedInterval, setSelectedInterval] = useState<string>('daily')
   const [customCronError, setCustomCronError] = useState<string>('')
-  const [isValid, setIsValid] = useState<boolean>(true)
-  const [nextRunDate, setNextRunDate] = useState<string>('')
 
-  const customExpressionInputRef = useRef<HTMLInputElement>(null)
-
-  // Calculate next run date on client side only
-  useEffect(() => {
-    if (!currentCronValue) {
-      setNextRunDate('')
-      return
-    }
-
-    const nextRun = calculateNextRunDate(currentCronValue)
-    setNextRunDate(nextRun)
-  }, [currentCronValue])
-
-  const verbalDescription = useMemo(() => getHumanReadableCronExpression(currentCronValue), [currentCronValue])
-
-  // Combined interval configuration with both display and matching logic
+  // Memoize interval options to prevent re-creation on every render.
   const intervalOptions = useMemo(
     () => [
-      // Daily - can express: M H * * * where M and H are specific numbers
-      {
-        text: 'Daily',
-        value: 'daily',
-        canExpress: (expr: string) => /^\d+ \d+ \* \* \*$/.test(expr)
-      },
-      // Weekly - can express: M H * * D where M and H are specific numbers, D is * or comma-separated weekdays
-      {
-        text: 'Weekly',
-        value: 'weekly',
-        canExpress: (expr: string) => /^\d+ \d+ \* \* (\*|(\d+(,\d+)*))$/.test(expr)
-      },
-      // Predefined intervals (exact matches) - most specific first
-      {
-        text: 'Every 12 Hours',
-        value: '0 */12 * * *',
-        canExpress: (expr: string) => expr === '0 */12 * * *'
-      },
-      {
-        text: 'Every 6 Hours',
-        value: '0 */6 * * *',
-        canExpress: (expr: string) => expr === '0 */6 * * *'
-      },
-      {
-        text: 'Every 2 Hours',
-        value: '0 */2 * * *',
-        canExpress: (expr: string) => expr === '0 */2 * * *'
-      },
-      {
-        text: 'Every Hour',
-        value: '0 * * * *',
-        canExpress: (expr: string) => expr === '0 * * * *'
-      },
-      {
-        text: 'Every 30 Minutes',
-        value: '*/30 * * * *',
-        canExpress: (expr: string) => expr === '*/30 * * * *'
-      },
-      {
-        text: 'Every 15 Minutes',
-        value: '*/15 * * * *',
-        canExpress: (expr: string) => expr === '*/15 * * * *'
-      },
-      // Advanced - matches everything
-      {
-        text: 'Custom',
-        value: 'advanced',
-        canExpress: () => true
-      }
+      { text: 'Daily', value: 'daily', canExpress: (expr: string) => /^\d+ \d+ \* \* \*$/.test(expr) },
+      { text: 'Weekly', value: 'weekly', canExpress: (expr: string) => /^\d+ \d+ \* \* (\*|(\d+(,\d+)*))$/.test(expr) },
+      { text: 'Every 12 Hours', value: '0 */12 * * *', canExpress: (expr: string) => expr === '0 */12 * * *' },
+      { text: 'Every 6 Hours', value: '0 */6 * * *', canExpress: (expr: string) => expr === '0 */6 * * *' },
+      { text: 'Every 2 Hours', value: '0 */2 * * *', canExpress: (expr: string) => expr === '0 */2 * * *' },
+      { text: 'Every Hour', value: '0 * * * *', canExpress: (expr: string) => expr === '0 * * * *' },
+      { text: 'Every 30 Minutes', value: '*/30 * * * *', canExpress: (expr: string) => expr === '*/30 * * * *' },
+      { text: 'Every 15 Minutes', value: '*/15 * * * *', canExpress: (expr: string) => expr === '*/15 * * * *' },
+      { text: 'Custom Cron Expression (advanced)', value: 'advanced', canExpress: () => true }
     ],
     []
   )
 
-  const weekdays: MultiSelectItem<string>[] = useMemo(() => {
-    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-    return days.map((day, index) => ({
-      value: index.toString(),
-      content: day
+  const weekdays = useMemo<MultiSelectItem<string>[]>(() => {
+    const formatter = new Intl.DateTimeFormat(language, { weekday: 'long' })
+
+    // Generate localized day names (Sunday = 0, Monday = 1, etc.)
+    // Using Jan 7-13, 2024 which is a complete Sun-Sat week
+    return Array.from({ length: 7 }, (_, i) => ({
+      value: i.toString(),
+      content: formatter.format(new Date(2024, 0, 7 + i))
     }))
-  }, [])
+  }, [language])
 
-  const updateCron = useCallback(() => {
-    let newCronExpression = ''
+  const validation = useMemo<ValidationResult>(() => {
+    return validateCron(value)
+  }, [value])
 
-    if (selectedInterval === 'weekly') {
-      const sortedWeekdays = selectedWeekdays.map((w) => parseInt(w.value)).sort()
-      const daysOfWeekPiece = sortedWeekdays.length === 7 || sortedWeekdays.length === 0 ? '*' : sortedWeekdays.join(',')
-      newCronExpression = `${selectedMinute} ${selectedHour} * * ${daysOfWeekPiece}`
-    } else if (selectedInterval === 'daily') {
-      newCronExpression = `${selectedMinute} ${selectedHour} * * *`
-    } else if (selectedInterval === 'advanced') {
-      // For advanced mode, don't auto-generate - let the user input the cron expression manually
+  const parsedValues = useMemo<{ hour: number; minute: number; selectedWeekdays: MultiSelectItem<string>[] }>(() => {
+    if (!validation.isValid) {
+      return { hour: 0, minute: 0, selectedWeekdays: [] }
+    }
+
+    const pieces = value.split(' ').filter(Boolean)
+
+    const hour = parseInt(pieces[1]) || 0
+    const minute = parseInt(pieces[0]) || 0
+    let selectedWeekdays: MultiSelectItem<string>[] = []
+
+    if (pieces[4] && pieces[4] !== '*') {
+      const weekdayValues = pieces[4].split(',')
+      selectedWeekdays = weekdays.filter((w) => weekdayValues.includes(w.value))
+    }
+
+    return { hour, minute, selectedWeekdays }
+  }, [value, weekdays, validation])
+
+  // Parse the incoming cron value and set the correct interval type.
+  useEffect(() => {
+    setCustomCronError(validation.error || '')
+
+    if (!validation.isValid) {
+      onChange?.(value, false)
+      setSelectedInterval('advanced')
       return
-    } else {
-      newCronExpression = selectedInterval || ''
     }
 
-    // Only notify parent if the expression actually changed
-    if (newCronExpression !== currentCronValue) {
-      onChange?.(newCronExpression)
-    }
-  }, [selectedInterval, selectedWeekdays, selectedMinute, selectedHour, onChange, currentCronValue])
+    // Find all interval types that can express this cron expression
+    const matchingTypes = intervalOptions.filter((config) => config.canExpress(value))
+    setSelectedInterval((currentInterval) => {
+      // prefer current interval if it matches
+      const matchesCurrent = matchingTypes.some((config) => config.value === currentInterval)
+      return matchesCurrent ? currentInterval : matchingTypes[0].value
+    })
+  }, [value, intervalOptions, validation, onChange])
 
-  // Helper to format time from hour/minute values
-  const formatTimeValue = useCallback(() => {
-    const hour = selectedHour.toString().padStart(2, '0')
-    const minute = selectedMinute.toString().padStart(2, '0')
-    return `${hour}:${minute}`
-  }, [selectedHour, selectedMinute])
+  const handleIntervalChange = useCallback(
+    (newInterval: string) => {
+      setSelectedInterval(newInterval)
 
-  // Handler for time input changes
-  const handleTimeChange = useCallback((value: string) => {
-    if (!value) return
-
-    const [hourStr, minuteStr] = value.split(':')
-    const hour = parseInt(hourStr) || 0
-    const minute = parseInt(minuteStr) || 0
-
-    setSelectedHour(Math.max(0, Math.min(23, hour)))
-    setSelectedMinute(Math.max(0, Math.min(59, minute)))
-  }, [])
-
-  const parseAndUpdateStates = useCallback(
-    (cronExpr: string) => {
-      const validationResult = validateCron(cronExpr)
-      if (!validationResult.isValid) {
-        setSelectedInterval('advanced')
-        setCustomCronError(validationResult.error || '')
-        setIsValid(false)
-        onChange?.(cronExpr, false)
-        return
+      if (newInterval === 'daily') {
+        onChange?.(`${parsedValues.minute} ${parsedValues.hour} * * *`, true)
+      } else if (newInterval === 'weekly') {
+        const daysOfWeek =
+          parsedValues.selectedWeekdays.length > 0
+            ? parsedValues.selectedWeekdays
+                .map((w) => w.value)
+                .sort()
+                .join(',')
+            : '*'
+        onChange?.(`${parsedValues.minute} ${parsedValues.hour} * * ${daysOfWeek}`, true)
+      } else if (newInterval !== 'advanced') {
+        onChange?.(newInterval, true)
       }
-
-      const pieces = cronExpr.split(' ')
-
-      // Find all interval types that can express this cron expression
-      const matchingTypes = intervalOptions.filter((config) => config.canExpress(cronExpr))
-
-      // If no matches found, default to advanced (this is just defensive programming - should never happen)
-      if (matchingTypes.length === 0) {
-        setSelectedInterval('advanced')
-        return
-      }
-
-      // Determine which interval type to use
-      setSelectedInterval((currentInterval) => {
-        // If current interval is in the matching types, prefer it
-        const currentMatch = matchingTypes.find((config) => config.value === currentInterval)
-        if (currentMatch) {
-          // Parse and set the appropriate state values for the current interval
-          if (currentInterval === 'daily') {
-            setSelectedHour(Number(pieces[1]))
-            setSelectedMinute(Number(pieces[0]))
-            setSelectedWeekdays([])
-          } else if (currentInterval === 'weekly') {
-            setSelectedHour(Number(pieces[1]))
-            setSelectedMinute(Number(pieces[0]))
-
-            if (pieces[4] === '*') {
-              setSelectedWeekdays([])
-            } else {
-              const weekdayValues = pieces[4].split(',')
-              const weekdayItems = weekdayValues
-                .map((val) => ({
-                  value: val.trim(),
-                  content: weekdays.find((w) => w.value === val.trim())?.content || ''
-                }))
-                .filter((item) => item.content) // Filter out invalid weekdays
-              setSelectedWeekdays(weekdayItems)
-            }
-          }
-          return currentInterval
-        }
-
-        // Otherwise, use the first (most specific) match
-        const selectedType = matchingTypes[0].value
-
-        // Parse and set the appropriate state values based on the selected type
-        if (selectedType === 'daily') {
-          setSelectedHour(Number(pieces[1]))
-          setSelectedMinute(Number(pieces[0]))
-          setSelectedWeekdays([])
-        } else if (selectedType === 'weekly') {
-          setSelectedHour(Number(pieces[1]))
-          setSelectedMinute(Number(pieces[0]))
-
-          if (pieces[4] === '*') {
-            setSelectedWeekdays([])
-          } else {
-            const weekdayValues = pieces[4].split(',')
-            const weekdayItems = weekdayValues
-              .map((val) => ({
-                value: val.trim(),
-                content: weekdays.find((w) => w.value === val.trim())?.content || ''
-              }))
-              .filter((item) => item.content) // Filter out invalid weekdays
-            setSelectedWeekdays(weekdayItems)
-          }
-        }
-        // For predefined intervals and advanced mode, no additional state parsing needed
-
-        return selectedType
-      })
     },
-    [intervalOptions, weekdays]
+    [parsedValues, onChange]
   )
 
-  const handleCronExpressionChange = useCallback(
-    (newValue: string) => {
-      // Real-time validation for immediate feedback
-      const validationResult = validateCron(newValue)
-      setIsValid(validationResult.isValid)
-      setCustomCronError(validationResult.error || '')
+  const handleTimeChange = useCallback(
+    (newTime: string) => {
+      if (!newTime) return
 
-      onChange?.(newValue, !validationResult.isValid)
+      const [hourStr, minuteStr] = newTime.split(':')
+      const newHour = Math.max(0, Math.min(23, parseInt(hourStr) || 0))
+      const newMinute = Math.max(0, Math.min(59, parseInt(minuteStr) || 0))
+
+      const pieces = value.split(' ')
+      pieces[0] = String(newMinute)
+      pieces[1] = String(newHour)
+      onChange?.(pieces.join(' '), true)
+    },
+    [value, onChange]
+  )
+
+  const handleWeekdayChange = useCallback(
+    (newItems: MultiSelectItem<string>[]) => {
+      const sortedItems = [...newItems].sort((a, b) => parseInt(a.value) - parseInt(b.value))
+      const daysOfWeek = sortedItems.length === 0 || sortedItems.length === 7 ? '*' : sortedItems.map((w) => w.value).join(',')
+
+      const pieces = value.split(' ')
+      pieces[4] = daysOfWeek
+      onChange?.(pieces.join(' '), true)
+    },
+    [value, onChange]
+  )
+
+  const handleCustomCronChange = useCallback(
+    (newCronExpression: string) => {
+      const validationResult = validateCron(newCronExpression)
+      onChange?.(newCronExpression, validationResult.isValid)
     },
     [onChange]
   )
 
-  const handleCronExpressionBlur = useCallback(() => {
-    if (!currentCronValue) {
-      setCustomCronError('Cron expression is required')
-      setIsValid(false)
-      return
-    }
+  const formatTimeValue = useMemo(() => {
+    const hour = String(parsedValues.hour).padStart(2, '0')
+    const minute = String(parsedValues.minute).padStart(2, '0')
+    return `${hour}:${minute}`
+  }, [parsedValues.hour, parsedValues.minute])
 
-    // Final validation on blur
-    const validationResult = validateCron(currentCronValue)
-    setIsValid(validationResult.isValid)
-    setCustomCronError(validationResult.error || '')
+  const [clientTimeZone, setClientTimeZone] = useState<string | null>(null)
 
-    // The onChange was already called during typing, so we don't need to call it again
-    // The parent will update the value prop, which will trigger re-parsing if needed
-  }, [currentCronValue])
-
-  // Handle weekday selection changes
-  const handleWeekdayChange = useCallback((items: MultiSelectItem<string>[]) => {
-    setSelectedWeekdays(items)
+  useEffect(() => {
+    setClientTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
   }, [])
 
-  // Initialize component when value changes
-  useEffect(() => {
-    parseAndUpdateStates(currentCronValue)
-  }, [currentCronValue, parseAndUpdateStates])
-
-  // Track if we're in initialization phase to prevent unnecessary updates
-  const isInitializingRef = useRef(false)
-
-  // Update cron when user makes changes (but not during initialization)
-  useEffect(() => {
-    if (selectedInterval !== null) updateCron()
-  }, [selectedInterval, selectedHour, selectedMinute, selectedWeekdays, updateCron])
+  const serverTimeZone = useMemo(() => {
+    return getLocalizedServerTimeZone(clientTimeZone, timeZone || 'UTC', language || 'en')
+  }, [clientTimeZone, timeZone, language])
 
   return (
     <div className="w-full py-2" cy-id="cron-expression-builder">
-      {selectedInterval !== null && (
-        <div style={{ minHeight: '160px' }}>
-          <Dropdown
-            value={selectedInterval}
-            onChange={(value) => setSelectedInterval(String(value))}
-            label="Interval"
-            items={intervalOptions}
-            className="mb-2"
-            cy-id="interval-dropdown"
-          />
+      <div style={{ minHeight: '172px' }}>
+        <Dropdown
+          value={selectedInterval}
+          onChange={(value) => handleIntervalChange(String(value))}
+          label="Interval"
+          items={intervalOptions}
+          className="mb-2"
+          cy-id="interval-dropdown"
+        />
 
-          <div className="flex items-center gap-2 mb-2">
-            {(selectedInterval === 'weekly' || selectedInterval === 'daily') && (
-              <div>
-                <TextInput
-                  value={formatTimeValue()}
-                  onChange={handleTimeChange}
-                  type="time"
-                  label="Time"
-                  customInputClass="[&::-webkit-calendar-picker-indicator]:hidden"
-                  className="w-fit"
-                  cy-id="time-input"
-                />
-              </div>
-            )}
+        <div className="flex items-center gap-2 mb-2" cy-id="cron-expression-builder-inputs">
+          {(selectedInterval === 'weekly' || selectedInterval === 'daily') && (
+            <TextInput
+              value={formatTimeValue}
+              onChange={handleTimeChange}
+              type="time"
+              label="Time"
+              customInputClass="[&::-webkit-calendar-picker-indicator]:hidden"
+              className="w-fit"
+              cy-id="time-input"
+            />
+          )}
 
-            {selectedInterval === 'weekly' && (
-              <MultiSelect
-                selectedItems={selectedWeekdays}
-                items={weekdays}
-                label="Weekdays to Run"
-                onItemAdded={(item) => {
-                  const newItems = [...selectedWeekdays, item]
-                  handleWeekdayChange(newItems)
-                }}
-                onItemRemoved={(item) => {
-                  const newItems = selectedWeekdays.filter((w) => w.value !== item.value)
-                  handleWeekdayChange(newItems)
-                }}
-                cy-id="weekdays-multiselect"
+          {selectedInterval === 'weekly' && (
+            <MultiSelect
+              selectedItems={parsedValues.selectedWeekdays}
+              items={weekdays}
+              label="Weekdays to Run"
+              onItemAdded={(item) => handleWeekdayChange([...parsedValues.selectedWeekdays, item])}
+              onItemRemoved={(item) => handleWeekdayChange(parsedValues.selectedWeekdays.filter((w) => w.value !== item.value))}
+              allowNew={false}
+              cy-id="weekdays-multiselect"
+            />
+          )}
+
+          {selectedInterval === 'advanced' && (
+            <div className="w-full">
+              <TextInput
+                label="Cron Expression"
+                value={value}
+                onChange={handleCustomCronChange}
+                customInputClass={'text-2xl md:text-3xl font-mono text-center'}
+                className="w-full mb-2"
+                error={customCronError}
+                cy-id="cron-expression-input"
               />
-            )}
-
-            {selectedInterval === 'advanced' && (
-              <div className="w-full">
-                <TextInput
-                  ref={customExpressionInputRef}
-                  label="Cron Expression"
-                  value={currentCronValue}
-                  onChange={handleCronExpressionChange}
-                  onBlur={handleCronExpressionBlur}
-                  customInputClass={'text-2xl md:text-3xl font-mono text-center'}
-                  className="w-full mb-2"
-                  error={customCronError}
-                  cy-id="cron-expression-input"
-                />
-              </div>
-            )}
-          </div>
-        </div>
-      )}
-      <div>
-        {/* Verbal Description - hide in advanced mode if there's a validation error */}
-        {!(selectedInterval === 'advanced' && !isValid) && (
-          <div className="mb-4 p-3 bg-primary/30 rounded-lg border border-primary/50">
-            <div className="flex items-center">
-              <span className="material-symbols mr-2 text-blue-400">schedule</span>
-              <p className="text-sm font-medium text-gray-300">Schedule:</p>
             </div>
-            <p className="text-base font-semibold text-white mt-1" cy-id="cron-description">
-              {verbalDescription}
-            </p>
-            {currentCronValue && <p className="text-xs text-gray-400 mt-1 font-mono">{currentCronValue}</p>}
-          </div>
-        )}
-
-        {currentCronValue && isValid && nextRunDate && !(selectedInterval === 'advanced' && !isValid) && (
-          <div className="flex items-center justify-center text-yellow-400 mt-2">
-            <span className="material-symbols mr-2 text-xl">event</span>
-            <p>Next Scheduled Run: {nextRunDate}</p>
-          </div>
+          )}
+        </div>
+        {serverTimeZone && (selectedInterval === 'daily' || selectedInterval === 'weekly' || selectedInterval === 'advanced') && (
+          <p className="text-sm text-yellow-500">Note: Time should be specified in the server's time zone ({serverTimeZone})</p>
         )}
       </div>
     </div>

--- a/src/components/widgets/CronExpressionBuilder.tsx
+++ b/src/components/widgets/CronExpressionBuilder.tsx
@@ -1,0 +1,366 @@
+'use client'
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+import { validateCron, getHumanReadableCronExpression, calculateNextRunDate, type ValidationResult } from '@/lib/cron'
+import Dropdown from '@/components/ui/Dropdown'
+import { MultiSelect } from '@/components/ui/MultiSelect'
+import TextInput from '@/components/ui/TextInput'
+import type { MultiSelectItem } from '@/components/ui/MultiSelect'
+
+interface CronExpressionBuilderProps {
+  currentCronValue: string
+  onChange?: (value: string, isInvalid?: boolean) => void
+}
+
+export default function CronExpressionBuilder({ currentCronValue, onChange }: CronExpressionBuilderProps) {
+  // State management
+  const [selectedInterval, setSelectedInterval] = useState<string | null>(null)
+  const [selectedHour, setSelectedHour] = useState<number>(0)
+  const [selectedMinute, setSelectedMinute] = useState<number>(0)
+  const [selectedWeekdays, setSelectedWeekdays] = useState<MultiSelectItem<string>[]>([])
+
+  // Derive these from the value prop
+  const [customCronError, setCustomCronError] = useState<string>('')
+  const [isValid, setIsValid] = useState<boolean>(true)
+  const [nextRunDate, setNextRunDate] = useState<string>('')
+
+  const customExpressionInputRef = useRef<HTMLInputElement>(null)
+
+  // Calculate next run date on client side only
+  useEffect(() => {
+    if (!currentCronValue) {
+      setNextRunDate('')
+      return
+    }
+
+    const nextRun = calculateNextRunDate(currentCronValue)
+    setNextRunDate(nextRun)
+  }, [currentCronValue])
+
+  const verbalDescription = useMemo(() => getHumanReadableCronExpression(currentCronValue), [currentCronValue])
+
+  // Combined interval configuration with both display and matching logic
+  const intervalOptions = useMemo(
+    () => [
+      // Daily - can express: M H * * * where M and H are specific numbers
+      {
+        text: 'Daily',
+        value: 'daily',
+        canExpress: (expr: string) => /^\d+ \d+ \* \* \*$/.test(expr)
+      },
+      // Weekly - can express: M H * * D where M and H are specific numbers, D is * or comma-separated weekdays
+      {
+        text: 'Weekly',
+        value: 'weekly',
+        canExpress: (expr: string) => /^\d+ \d+ \* \* (\*|(\d+(,\d+)*))$/.test(expr)
+      },
+      // Predefined intervals (exact matches) - most specific first
+      {
+        text: 'Every 12 Hours',
+        value: '0 */12 * * *',
+        canExpress: (expr: string) => expr === '0 */12 * * *'
+      },
+      {
+        text: 'Every 6 Hours',
+        value: '0 */6 * * *',
+        canExpress: (expr: string) => expr === '0 */6 * * *'
+      },
+      {
+        text: 'Every 2 Hours',
+        value: '0 */2 * * *',
+        canExpress: (expr: string) => expr === '0 */2 * * *'
+      },
+      {
+        text: 'Every Hour',
+        value: '0 * * * *',
+        canExpress: (expr: string) => expr === '0 * * * *'
+      },
+      {
+        text: 'Every 30 Minutes',
+        value: '*/30 * * * *',
+        canExpress: (expr: string) => expr === '*/30 * * * *'
+      },
+      {
+        text: 'Every 15 Minutes',
+        value: '*/15 * * * *',
+        canExpress: (expr: string) => expr === '*/15 * * * *'
+      },
+      // Advanced - matches everything
+      {
+        text: 'Custom',
+        value: 'advanced',
+        canExpress: () => true
+      }
+    ],
+    []
+  )
+
+  const weekdays: MultiSelectItem<string>[] = useMemo(() => {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+    return days.map((day, index) => ({
+      value: index.toString(),
+      content: day
+    }))
+  }, [])
+
+  const updateCron = useCallback(() => {
+    let newCronExpression = ''
+
+    if (selectedInterval === 'weekly') {
+      const sortedWeekdays = selectedWeekdays.map((w) => parseInt(w.value)).sort()
+      const daysOfWeekPiece = sortedWeekdays.length === 7 || sortedWeekdays.length === 0 ? '*' : sortedWeekdays.join(',')
+      newCronExpression = `${selectedMinute} ${selectedHour} * * ${daysOfWeekPiece}`
+    } else if (selectedInterval === 'daily') {
+      newCronExpression = `${selectedMinute} ${selectedHour} * * *`
+    } else if (selectedInterval === 'advanced') {
+      // For advanced mode, don't auto-generate - let the user input the cron expression manually
+      return
+    } else {
+      newCronExpression = selectedInterval || ''
+    }
+
+    // Only notify parent if the expression actually changed
+    if (newCronExpression !== currentCronValue) {
+      onChange?.(newCronExpression)
+    }
+  }, [selectedInterval, selectedWeekdays, selectedMinute, selectedHour, onChange, currentCronValue])
+
+  // Helper to format time from hour/minute values
+  const formatTimeValue = useCallback(() => {
+    const hour = selectedHour.toString().padStart(2, '0')
+    const minute = selectedMinute.toString().padStart(2, '0')
+    return `${hour}:${minute}`
+  }, [selectedHour, selectedMinute])
+
+  // Handler for time input changes
+  const handleTimeChange = useCallback((value: string) => {
+    if (!value) return
+
+    const [hourStr, minuteStr] = value.split(':')
+    const hour = parseInt(hourStr) || 0
+    const minute = parseInt(minuteStr) || 0
+
+    setSelectedHour(Math.max(0, Math.min(23, hour)))
+    setSelectedMinute(Math.max(0, Math.min(59, minute)))
+  }, [])
+
+  const parseAndUpdateStates = useCallback(
+    (cronExpr: string) => {
+      const validationResult = validateCron(cronExpr)
+      if (!validationResult.isValid) {
+        setSelectedInterval('advanced')
+        setCustomCronError(validationResult.error || '')
+        setIsValid(false)
+        onChange?.(cronExpr, false)
+        return
+      }
+
+      const pieces = cronExpr.split(' ')
+
+      // Find all interval types that can express this cron expression
+      const matchingTypes = intervalOptions.filter((config) => config.canExpress(cronExpr))
+
+      // If no matches found, default to advanced (this is just defensive programming - should never happen)
+      if (matchingTypes.length === 0) {
+        setSelectedInterval('advanced')
+        return
+      }
+
+      // Determine which interval type to use
+      setSelectedInterval((currentInterval) => {
+        // If current interval is in the matching types, prefer it
+        const currentMatch = matchingTypes.find((config) => config.value === currentInterval)
+        if (currentMatch) {
+          // Parse and set the appropriate state values for the current interval
+          if (currentInterval === 'daily') {
+            setSelectedHour(Number(pieces[1]))
+            setSelectedMinute(Number(pieces[0]))
+            setSelectedWeekdays([])
+          } else if (currentInterval === 'weekly') {
+            setSelectedHour(Number(pieces[1]))
+            setSelectedMinute(Number(pieces[0]))
+
+            if (pieces[4] === '*') {
+              setSelectedWeekdays([])
+            } else {
+              const weekdayValues = pieces[4].split(',')
+              const weekdayItems = weekdayValues
+                .map((val) => ({
+                  value: val.trim(),
+                  content: weekdays.find((w) => w.value === val.trim())?.content || ''
+                }))
+                .filter((item) => item.content) // Filter out invalid weekdays
+              setSelectedWeekdays(weekdayItems)
+            }
+          }
+          return currentInterval
+        }
+
+        // Otherwise, use the first (most specific) match
+        const selectedType = matchingTypes[0].value
+
+        // Parse and set the appropriate state values based on the selected type
+        if (selectedType === 'daily') {
+          setSelectedHour(Number(pieces[1]))
+          setSelectedMinute(Number(pieces[0]))
+          setSelectedWeekdays([])
+        } else if (selectedType === 'weekly') {
+          setSelectedHour(Number(pieces[1]))
+          setSelectedMinute(Number(pieces[0]))
+
+          if (pieces[4] === '*') {
+            setSelectedWeekdays([])
+          } else {
+            const weekdayValues = pieces[4].split(',')
+            const weekdayItems = weekdayValues
+              .map((val) => ({
+                value: val.trim(),
+                content: weekdays.find((w) => w.value === val.trim())?.content || ''
+              }))
+              .filter((item) => item.content) // Filter out invalid weekdays
+            setSelectedWeekdays(weekdayItems)
+          }
+        }
+        // For predefined intervals and advanced mode, no additional state parsing needed
+
+        return selectedType
+      })
+    },
+    [intervalOptions, weekdays]
+  )
+
+  const handleCronExpressionChange = useCallback(
+    (newValue: string) => {
+      // Real-time validation for immediate feedback
+      const validationResult = validateCron(newValue)
+      setIsValid(validationResult.isValid)
+      setCustomCronError(validationResult.error || '')
+
+      onChange?.(newValue, !validationResult.isValid)
+    },
+    [onChange]
+  )
+
+  const handleCronExpressionBlur = useCallback(() => {
+    if (!currentCronValue) {
+      setCustomCronError('Cron expression is required')
+      setIsValid(false)
+      return
+    }
+
+    // Final validation on blur
+    const validationResult = validateCron(currentCronValue)
+    setIsValid(validationResult.isValid)
+    setCustomCronError(validationResult.error || '')
+
+    // The onChange was already called during typing, so we don't need to call it again
+    // The parent will update the value prop, which will trigger re-parsing if needed
+  }, [currentCronValue])
+
+  // Handle weekday selection changes
+  const handleWeekdayChange = useCallback((items: MultiSelectItem<string>[]) => {
+    setSelectedWeekdays(items)
+  }, [])
+
+  // Initialize component when value changes
+  useEffect(() => {
+    parseAndUpdateStates(currentCronValue)
+  }, [currentCronValue, parseAndUpdateStates])
+
+  // Track if we're in initialization phase to prevent unnecessary updates
+  const isInitializingRef = useRef(false)
+
+  // Update cron when user makes changes (but not during initialization)
+  useEffect(() => {
+    if (selectedInterval !== null) updateCron()
+  }, [selectedInterval, selectedHour, selectedMinute, selectedWeekdays, updateCron])
+
+  return (
+    <div className="w-full py-2" cy-id="cron-expression-builder">
+      {selectedInterval !== null && (
+        <div style={{ minHeight: '160px' }}>
+          <Dropdown
+            value={selectedInterval}
+            onChange={(value) => setSelectedInterval(String(value))}
+            label="Interval"
+            items={intervalOptions}
+            className="mb-2"
+            cy-id="interval-dropdown"
+          />
+
+          <div className="flex items-center gap-2 mb-2">
+            {(selectedInterval === 'weekly' || selectedInterval === 'daily') && (
+              <div>
+                <TextInput
+                  value={formatTimeValue()}
+                  onChange={handleTimeChange}
+                  type="time"
+                  label="Time"
+                  customInputClass="[&::-webkit-calendar-picker-indicator]:hidden"
+                  className="w-fit"
+                  cy-id="time-input"
+                />
+              </div>
+            )}
+
+            {selectedInterval === 'weekly' && (
+              <MultiSelect
+                selectedItems={selectedWeekdays}
+                items={weekdays}
+                label="Weekdays to Run"
+                onItemAdded={(item) => {
+                  const newItems = [...selectedWeekdays, item]
+                  handleWeekdayChange(newItems)
+                }}
+                onItemRemoved={(item) => {
+                  const newItems = selectedWeekdays.filter((w) => w.value !== item.value)
+                  handleWeekdayChange(newItems)
+                }}
+                cy-id="weekdays-multiselect"
+              />
+            )}
+
+            {selectedInterval === 'advanced' && (
+              <div className="w-full">
+                <TextInput
+                  ref={customExpressionInputRef}
+                  label="Cron Expression"
+                  value={currentCronValue}
+                  onChange={handleCronExpressionChange}
+                  onBlur={handleCronExpressionBlur}
+                  customInputClass={'text-2xl md:text-3xl font-mono text-center'}
+                  className="w-full mb-2"
+                  error={customCronError}
+                  cy-id="cron-expression-input"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+      <div>
+        {/* Verbal Description - hide in advanced mode if there's a validation error */}
+        {!(selectedInterval === 'advanced' && !isValid) && (
+          <div className="mb-4 p-3 bg-primary/30 rounded-lg border border-primary/50">
+            <div className="flex items-center">
+              <span className="material-symbols mr-2 text-blue-400">schedule</span>
+              <p className="text-sm font-medium text-gray-300">Schedule:</p>
+            </div>
+            <p className="text-base font-semibold text-white mt-1" cy-id="cron-description">
+              {verbalDescription}
+            </p>
+            {currentCronValue && <p className="text-xs text-gray-400 mt-1 font-mono">{currentCronValue}</p>}
+          </div>
+        )}
+
+        {currentCronValue && isValid && nextRunDate && !(selectedInterval === 'advanced' && !isValid) && (
+          <div className="flex items-center justify-center text-yellow-400 mt-2">
+            <span className="material-symbols mr-2 text-xl">event</span>
+            <p>Next Scheduled Run: {nextRunDate}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/CronExpressionPreview.tsx
+++ b/src/components/widgets/CronExpressionPreview.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useMemo, useEffect, useState } from 'react'
+import { mergeClasses } from '@/lib/merge-classes'
+import { validateCron, getHumanReadableCronExpression, calculateNextRunDate } from '@/lib/cron'
+import { capitalizeFirstLetter } from '@/lib/string'
+
+interface CronExpressionPreviewProps {
+  cronExpression: string
+  className?: string
+  isValid?: boolean
+  options?: {
+    language?: string
+    dateFormat?: string
+    timeFormat?: string
+    timeZone?: string
+  }
+}
+
+export default function CronExpressionPreview({ cronExpression, className, isValid: isValidProp, options }: CronExpressionPreviewProps) {
+  const [clientTimeZone, setClientTimeZone] = useState<string | null>(null)
+
+  useEffect(() => {
+    setClientTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
+  }, [])
+
+  const { isValid, verbalDescription, nextRunDate } = useMemo(() => {
+    const isValid = isValidProp !== undefined ? isValidProp : validateCron(cronExpression).isValid
+    const verbalDescription = isValid ? getHumanReadableCronExpression(cronExpression, options?.language || 'en') : ''
+    const nextRunDate = isValid ? capitalizeFirstLetter(calculateNextRunDate(cronExpression, options, clientTimeZone)) : ''
+
+    return { isValid, verbalDescription, nextRunDate }
+  }, [cronExpression, isValidProp, options, clientTimeZone])
+
+  if (!isValid || !cronExpression) {
+    return null
+  }
+
+  return (
+    <div className={mergeClasses('p-1', className)}>
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-2">
+        <div className="flex items-center">
+          <span className="material-symbols mr-2 text-white">schedule</span>
+          <p className="font-medium text-white">Schedule:</p>
+        </div>
+        <p className="text-white" cy-id="cron-description">
+          {verbalDescription}
+        </p>
+
+        <div className="flex items-center">
+          <span className="material-symbols mr-2 text-white">event</span>
+          <p className="font-medium text-white">Next Run:</p>
+        </div>
+        <p className="text-white">{nextRunDate || 'Not available'}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -1,0 +1,198 @@
+import cronstrue from 'cronstrue'
+
+interface ValidationResult {
+  isValid: boolean
+  error?: string
+}
+
+// Helper function to validate individual cron fields
+const isValidCronField = (field: string, min: number, max: number): boolean => {
+  // Handle wildcard
+  if (field === '*') return true
+
+  // Helper to check if a string is a valid integer
+  const isValidInteger = (str: string): boolean => {
+    const trimmed = str.trim()
+    return /^\d+$/.test(trimmed) && !isNaN(parseInt(trimmed))
+  }
+
+  // Handle step values (*/n)
+  if (field.startsWith('*/')) {
+    const stepStr = field.substring(2)
+    if (!isValidInteger(stepStr)) return false
+    const step = parseInt(stepStr)
+    return step > 0 && step <= max
+  }
+
+  // Handle ranges (n-m)
+  if (field.includes('-')) {
+    const parts = field.split('-')
+    if (parts.length !== 2) return false
+    const [startStr, endStr] = parts
+    if (!isValidInteger(startStr) || !isValidInteger(endStr)) return false
+    const start = parseInt(startStr)
+    const end = parseInt(endStr)
+    return start >= min && end <= max && start <= end
+  }
+
+  // Handle comma-separated values (n,m,o)
+  if (field.includes(',')) {
+    const parts = field.split(',')
+    if (parts.length === 0) return false
+    return parts.every((part) => {
+      if (!isValidInteger(part)) return false
+      const val = parseInt(part.trim())
+      return val >= min && val <= max
+    })
+  }
+
+  // Handle single number
+  if (!isValidInteger(field)) return false
+  const num = parseInt(field)
+  return num >= min && num <= max
+}
+
+// Client-side cron validation
+export const validateCron = (expression: string): ValidationResult => {
+  try {
+    const parts = expression.trim().split(/\s+/)
+
+    if (parts.length !== 5) {
+      return { isValid: false, error: 'Cron expression must have exactly 5 parts (minute hour day month weekday)' }
+    }
+
+    const [minute, hour, day, month, weekday] = parts
+
+    // Validate minute (0-59)
+    if (!isValidCronField(minute, 0, 59)) {
+      return { isValid: false, error: 'Invalid minute field. Must be 0-59, *, */n, or comma-separated values' }
+    }
+
+    // Validate hour (0-23)
+    if (!isValidCronField(hour, 0, 23)) {
+      return { isValid: false, error: 'Invalid hour field. Must be 0-23, *, */n, or comma-separated values' }
+    }
+
+    // Validate day (1-31)
+    if (!isValidCronField(day, 1, 31)) {
+      return { isValid: false, error: 'Invalid day field. Must be 1-31, *, */n, or comma-separated values' }
+    }
+
+    // Validate month (1-12)
+    if (!isValidCronField(month, 1, 12)) {
+      return { isValid: false, error: 'Invalid month field. Must be 1-12, *, */n, or comma-separated values' }
+    }
+
+    // Validate weekday (0-7, where 0 and 7 are Sunday)
+    if (!isValidCronField(weekday, 0, 7)) {
+      return { isValid: false, error: 'Invalid weekday field. Must be 0-7 (0=Sunday), *, */n, or comma-separated values' }
+    }
+
+    return { isValid: true }
+  } catch (error) {
+    return { isValid: false, error: 'Invalid cron expression format' }
+  }
+}
+
+// Convert cron expression to human-readable description
+export const getHumanReadableCronExpression = (cronExpr: string): string => {
+  if (!cronExpr) return 'No schedule set'
+
+  try {
+    return cronstrue.toString(cronExpr, {
+      verbose: false,
+      throwExceptionOnParseError: true,
+      use24HourTimeFormat: false
+    })
+  } catch {
+    return 'Invalid cron expression'
+  }
+}
+
+// Helper function to check if a value matches a cron field
+const matchesCronField = (value: number, field: string, min: number, max: number): boolean => {
+  // Handle wildcard
+  if (field === '*') return true
+
+  // Handle step values (*/n)
+  if (field.startsWith('*/')) {
+    const step = parseInt(field.substring(2))
+    return value % step === 0
+  }
+
+  // Handle ranges (n-m)
+  if (field.includes('-')) {
+    const [start, end] = field.split('-').map(Number)
+    return value >= start && value <= end
+  }
+
+  // Handle comma-separated values (n,m,o)
+  if (field.includes(',')) {
+    const values = field.split(',').map(Number)
+    // Handle special case for weekday where 7 = Sunday = 0
+    if (max === 7 && values.includes(7)) {
+      values.push(0)
+    }
+    return values.includes(value)
+  }
+
+  // Handle single number
+  const fieldValue = parseInt(field)
+  // Handle special case for weekday where 7 = Sunday = 0
+  if (max === 7 && fieldValue === 7) {
+    return value === 0
+  }
+  return value === fieldValue
+}
+
+// Helper function to check if a date matches a cron expression
+const matchesCronExpression = (date: Date, minute: string, hour: string, day: string, month: string, weekday: string): boolean => {
+  const dateMinute = date.getMinutes()
+  const dateHour = date.getHours()
+  const dateDay = date.getDate()
+  const dateMonth = date.getMonth() + 1 // JavaScript months are 0-indexed
+  const dateWeekday = date.getDay() // 0 = Sunday, 1 = Monday, etc.
+
+  return (
+    matchesCronField(dateMinute, minute, 0, 59) &&
+    matchesCronField(dateHour, hour, 0, 23) &&
+    matchesCronField(dateDay, day, 1, 31) &&
+    matchesCronField(dateMonth, month, 1, 12) &&
+    matchesCronField(dateWeekday, weekday, 0, 7) // 0 and 7 both represent Sunday
+  )
+}
+
+// Calculate next run date based on cron expression
+export const calculateNextRunDate = (cronExpr: string): string => {
+  if (!cronExpr) return ''
+
+  try {
+    const parts = cronExpr.trim().split(/\s+/)
+    if (parts.length !== 5) return ''
+
+    const [minute, hour, day, month, weekday] = parts
+    const now = new Date()
+
+    // Start from the next minute to avoid returning current time
+    const nextMinute = new Date(now)
+    nextMinute.setSeconds(0, 0)
+    nextMinute.setMinutes(nextMinute.getMinutes() + 1)
+
+    // Find the next valid date/time (check up to 4 years in the future to handle edge cases)
+    const maxIterations = 366 * 4 // 4 years worth of days
+    let candidate = new Date(nextMinute)
+
+    for (let i = 0; i < maxIterations; i++) {
+      if (matchesCronExpression(candidate, minute, hour, day, month, weekday)) {
+        return candidate.toLocaleString()
+      }
+      candidate.setMinutes(candidate.getMinutes() + 1)
+    }
+
+    return 'Unable to calculate next run'
+  } catch {
+    return ''
+  }
+}
+
+export type { ValidationResult }

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,0 +1,3 @@
+export const capitalizeFirstLetter = (string: string): string => {
+  return string.charAt(0).toUpperCase() + string.slice(1)
+}


### PR DESCRIPTION
This migrates CronExpressionBuilder.vue, and add a CronExpressionPreview component that shows a localized verbal description of the schedule, and a localized next run time.

**CronExpressionBuilder**
The migrated builder is almost a complete re-write of the old one, with the following main differences:
- A fully controlled component
  - Parent sets value and onChange is called on input change
  - All display elements are derived from the value
- No Schedule/Advanced tabs.
  - Instead, "Custom Cron Expression" is just another interval option (appearing last)
- Using the native`type="time"` input for specifying time instead of `Hours` and `Minutes`
- No server API call for validation
  - Validation now happens on every change in the input
  - If value is not valid, border goes red, and error is displayed below
- If client and server time zones disagree, a message is displyed to notify the user that time is specified in the server's time zone.
- No external package dependency for the builder
- Weekday names in the weekdays multi-select are localized using standard Javascript (`Intl`)

**CronExpressionPreview**
- Uses `cronstrue` a small external package for generating and localizing a verbal description of the cron expression
- Next Run is calculated locally (current vue code is using `cron-parser`  for that), and is localized using standard Javascript (`Intl`)

_Note:_ the new components are not fully localized yet - labels and messages are still English. I will handle this for all components in a (near-) future PR.
