### PR TITLE
Migrate PodcastDetailsEdit

### DIFF
--- a/src/app/(main)/components_catalog/examples/PodcastDetailsEditExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/PodcastDetailsEditExamples.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import Btn from '@/components/ui/Btn'
+import PodcastDetailsEdit, { PodcastDetailsEditRef, UpdatePayload } from '@/components/widgets/PodcastDetailsEdit'
+import { PodcastLibraryItem } from '@/types/api'
+import { useCallback, useRef, useState } from 'react'
+import { ComponentExamples, ComponentInfo, Example } from '../ComponentExamples'
+
+const mockLibraryItem: PodcastLibraryItem = {
+  id: 'cltjyl123000108l437q67p8o',
+  ino: '13631488-1679503385065',
+  libraryId: 'cltjx6i95000008jp5e2p3j4c',
+  folderId: 'cltjx6i95000008jp5e2p3j4c-root',
+  path: '/data/podcasts/My Favorite Podcast',
+  relPath: 'My Favorite Podcast',
+  isFile: false,
+  mtimeMs: 1679503385065,
+  ctimeMs: 1679503385065,
+  birthtimeMs: 1679503385065,
+  addedAt: 1679503385065,
+  updatedAt: 1679503385065,
+  isMissing: false,
+  isInvalid: false,
+  mediaType: 'podcast',
+  media: {
+    id: 'cltjyl123000208l46y4d3g4h',
+    libraryItemId: 'cltjyl123000108l437q67p8o',
+    metadata: {
+      title: 'My Favorite Podcast',
+      author: 'Jane Doe',
+      description: '<p>An amazing podcast about technology and culture.</p>',
+      releaseDate: '2023-01-15',
+      genres: ['Technology', 'Culture'],
+      feedURL: 'https://example.com/feed.xml',
+      itunesId: '123456789',
+      language: 'English',
+      explicit: false,
+      podcastType: 'episodic'
+    },
+    coverPath: '/data/podcasts/My Favorite Podcast/cover.jpg',
+    tags: ['Tech', 'Weekly'],
+    episodes: []
+  },
+  libraryFiles: []
+}
+
+const mockGenres = [
+  { value: 'Technology', content: 'Technology' },
+  { value: 'Culture', content: 'Culture' },
+  { value: 'News', content: 'News' },
+  { value: 'Comedy', content: 'Comedy' }
+]
+const mockTags = [
+  { value: 'Tech', content: 'Tech' },
+  { value: 'Weekly', content: 'Weekly' },
+  { value: 'Daily', content: 'Daily' }
+]
+
+export function PodcastDetailsEditExamples() {
+  const podcastDetailsEditRef = useRef<PodcastDetailsEditRef>(null)
+  const [libraryItem, setLibraryItem] = useState(mockLibraryItem)
+  const [hasChanges, setHasChanges] = useState(false)
+
+  const handleChange = useCallback((details: { libraryItemId: string; hasChanges: boolean }) => {
+    console.log('onChange', details)
+    setHasChanges(details.hasChanges)
+  }, [])
+
+  const handleSubmit = useCallback((details: { updatePayload: UpdatePayload; hasChanges: boolean }) => {
+    console.log('onSubmit', details)
+    if (details.hasChanges) {
+      setLibraryItem((prev) => ({
+        ...prev,
+        media: {
+          ...prev.media,
+          metadata: {
+            ...prev.media.metadata,
+            ...details.updatePayload.metadata
+          },
+          tags: details.updatePayload.tags ?? prev.media.tags
+        }
+      }))
+      setHasChanges(false)
+    }
+  }, [])
+
+  return (
+    <ComponentExamples title="Podcast Details Edit">
+      <ComponentInfo
+        component="PodcastDetailsEdit"
+        description="A form for editing the metadata of a podcast library item. It includes fields for title, author, RSS feed URL, description, and more."
+      >
+        <p className="mb-2">
+          <span className="font-bold">Import:</span>{' '}
+          <code className="bg-gray-700 px-2 py-1 rounded">import PodcastDetailsEdit from &apos;@/components/widgets/PodcastDetailsEdit&apos;</code>
+        </p>
+        <div>
+          <span className="font-bold">Props:</span>
+          <ul className="list-disc list-inside">
+            <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">libraryItem</code>: The podcast library item to edit.
+            </li>
+            <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">availableGenres</code>: A list of available genres.
+            </li>
+            <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">availableTags</code>: A list of available tags.
+            </li>
+            <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">onChange</code>: Callback fired when form data changes.
+            </li>
+            <li>
+              <code className="bg-gray-700 px-2 py-1 rounded">onSubmit</code>: Callback fired when form is submitted.
+            </li>
+          </ul>
+        </div>
+      </ComponentInfo>
+
+      <Example title="Default">
+        <PodcastDetailsEdit
+          ref={podcastDetailsEditRef}
+          libraryItem={libraryItem}
+          availableGenres={mockGenres}
+          availableTags={mockTags}
+          onChange={handleChange}
+          onSubmit={handleSubmit}
+        />
+        <div className="flex justify-end px-2 md:px-4">
+          <Btn onClick={() => podcastDetailsEditRef.current?.submit()} disabled={!hasChanges}>
+            Save
+          </Btn>
+        </div>
+      </Example>
+    </ComponentExamples>
+  )
+}

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -20,6 +20,7 @@ import { MediaIconPickerExamples } from './examples/MediaIconPickerExamples'
 import { ModalExamples } from './examples/ModalExamples'
 import { MultiSelectDropdownExamples } from './examples/MultiSelectDropdownExamples'
 import { MultiSelectExamples } from './examples/MultiSelectExamples'
+import { PodcastDetailsEditExamples } from './examples/PodcastDetailsEditExamples'
 import { RangeInputExamples } from './examples/RangeInputExamples'
 import { ReadIconBtnExamples } from './examples/ReadIconBtnExamples'
 import { SideBySideControlsExamples } from './examples/SideBySideControlsExamples'
@@ -194,6 +195,11 @@ export default function ComponentsCatalogPage() {
                   </a>
                 </li>
                 <li>
+                  <a href="#podcast-details-edit-examples" className="hover:text-blue-400 transition-colors">
+                    Podcast Details Edit
+                  </a>
+                </li>
+                <li>
                   <a href="#cover-size-widget-examples" className="hover:text-blue-400 transition-colors">
                     Cover Size Widget
                   </a>
@@ -295,6 +301,9 @@ export default function ComponentsCatalogPage() {
       </div>
       <div id="book-details-edit-examples">
         <BookDetailsEditExamples />
+      </div>
+      <div id="podcast-details-edit-examples">
+        <PodcastDetailsEditExamples />
       </div>
       <div id="cover-size-widget-examples">
         <CoverSizeWidgetExamples />

--- a/src/components/widgets/PodcastDetailsEdit.tsx
+++ b/src/components/widgets/PodcastDetailsEdit.tsx
@@ -181,7 +181,6 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
               label={t('LabelPodcastType')}
               value={details.podcastType || 'episodic'}
               items={podcastTypeItems}
-              size="small"
               onChange={handlePodcastTypeChange}
               className="max-w-52"
             />

--- a/src/components/widgets/PodcastDetailsEdit.tsx
+++ b/src/components/widgets/PodcastDetailsEdit.tsx
@@ -1,0 +1,321 @@
+'use client'
+
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { PodcastLibraryItem, PodcastMetadata } from '@/types/api'
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useReducer } from 'react'
+import Checkbox from '../ui/Checkbox'
+import Dropdown, { DropdownItem } from '../ui/Dropdown'
+import MultiSelect, { MultiSelectItem } from '../ui/MultiSelect'
+import SlateEditor from '../ui/SlateEditor'
+import TextInput from '../ui/TextInput'
+
+type Details = Omit<PodcastMetadata, 'titleIgnorePrefix' | 'descriptionPlain' | 'imageURL' | 'itunesPageURL' | 'itunesArtistId'>
+
+// Reducer state and actions
+interface EditState {
+  details: Details
+  tags: string[]
+  initialDetails: Details
+  initialTags: string[]
+}
+
+type Action =
+  | { type: 'RESET_STATE'; payload: { details: Details; tags: string[] } }
+  | { type: 'UPDATE_FIELD'; payload: { field: keyof Details; value: Details[keyof Details] } }
+  | { type: 'UPDATE_TAGS'; payload: { tags: string[] } }
+  | { type: 'BATCH_UPDATE'; payload: { batchDetails: Partial<Details & { tags: string[] }>; mapType: 'overwrite' | 'append' } }
+
+const podcastDetailsReducer = (state: EditState, action: Action): EditState => {
+  switch (action.type) {
+    case 'RESET_STATE':
+      return {
+        ...state,
+        details: action.payload.details,
+        tags: action.payload.tags,
+        initialDetails: action.payload.details,
+        initialTags: action.payload.tags
+      }
+    case 'UPDATE_FIELD':
+      return {
+        ...state,
+        details: {
+          ...state.details,
+          [action.payload.field]: action.payload.value
+        }
+      }
+    case 'UPDATE_TAGS':
+      return {
+        ...state,
+        tags: action.payload.tags
+      }
+    case 'BATCH_UPDATE': {
+      const { batchDetails, mapType } = action.payload
+      const { tags: newTags, ...detailsToUpdate } = batchDetails
+
+      const finalTags = newTags ? (mapType === 'append' ? [...new Set([...state.tags, ...newTags])] : [...newTags]) : state.tags
+
+      if (mapType === 'overwrite') {
+        return {
+          ...state,
+          details: { ...state.details, ...detailsToUpdate },
+          tags: finalTags
+        }
+      } else {
+        // Append logic
+        return {
+          ...state,
+          details: {
+            ...state.details,
+            genres: detailsToUpdate.genres ? [...new Set([...(state.details.genres || []), ...detailsToUpdate.genres])] : state.details.genres
+          },
+          tags: finalTags
+        }
+      }
+    }
+    default:
+      return state
+  }
+}
+
+export interface UpdatePayload {
+  metadata?: Partial<Details>
+  tags?: string[]
+}
+
+export interface PodcastDetailsEditRef {
+  submit: () => void
+  getTitleAndAuthorName: () => { title: string | null; author: string }
+  mapBatchDetails: (batchDetails: Partial<Details & { tags: string[] }>, mapType?: 'overwrite' | 'append') => void
+}
+
+interface PodcastDetailsEditProps {
+  libraryItem: PodcastLibraryItem
+  availableGenres: MultiSelectItem<string>[]
+  availableTags: MultiSelectItem<string>[]
+  onChange?: (details: { libraryItemId: string; hasChanges: boolean }) => void
+  onSubmit?: (details: { updatePayload: UpdatePayload; hasChanges: boolean }) => void
+  ref?: React.Ref<PodcastDetailsEditRef>
+}
+
+const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags = [], onChange, onSubmit, ref }: PodcastDetailsEditProps) => {
+  const t = useTypeSafeTranslations()
+
+  const media = useMemo(() => libraryItem.media || {}, [libraryItem.media])
+
+  const [state, dispatch] = useReducer(podcastDetailsReducer, {
+    details: (media.metadata as Details) || {},
+    tags: [...(media.tags || [])],
+    initialDetails: (media.metadata as Details) || {},
+    initialTags: [...(media.tags || [])]
+  })
+
+  const { details, tags, initialDetails, initialTags } = state
+
+  useEffect(() => {
+    dispatch({
+      type: 'RESET_STATE',
+      payload: {
+        details: (media.metadata as Details) || {},
+        tags: [...(media.tags || [])]
+      }
+    })
+  }, [media])
+
+  const podcastTypeItems = useMemo<DropdownItem[]>(
+    () => [
+      { text: t('LabelEpisodic'), value: 'episodic' },
+      { text: t('LabelSerial'), value: 'serial' }
+    ],
+    [t]
+  )
+
+  const genreItems = useMemo(() => (details.genres || []).map((g) => ({ value: g, content: g })), [details.genres])
+  const handleAddGenre = useCallback(
+    (item: MultiSelectItem<string>) => {
+      dispatch({ type: 'UPDATE_FIELD', payload: { field: 'genres', value: [...(details.genres || []), item.content] } })
+    },
+    [details.genres]
+  )
+  const handleRemoveGenre = useCallback(
+    (item: MultiSelectItem<string>) => {
+      dispatch({ type: 'UPDATE_FIELD', payload: { field: 'genres', value: (details.genres || []).filter((g) => g !== item.value) } })
+    },
+    [details.genres]
+  )
+
+  const tagItems = useMemo(() => tags.map((t) => ({ value: t, content: t })), [tags])
+  const handleAddTag = useCallback(
+    (item: MultiSelectItem<string>) => {
+      dispatch({ type: 'UPDATE_TAGS', payload: { tags: [...tags, item.content] } })
+    },
+    [tags]
+  )
+  const handleRemoveTag = useCallback(
+    (item: MultiSelectItem<string>) => {
+      dispatch({ type: 'UPDATE_TAGS', payload: { tags: tags.filter((t) => t !== item.value) } })
+    },
+    [tags]
+  )
+
+  const handleFieldUpdate = useCallback(
+    <K extends keyof Details>(field: K) =>
+      (value: Details[K] | string | number) => {
+        dispatch({ type: 'UPDATE_FIELD', payload: { field, value: value as Details[K] } })
+      },
+    []
+  )
+
+  const changes = useMemo(() => {
+    const changedEntries = (Object.keys(details) as Array<keyof Details>)
+      .filter((key) => {
+        const initialValue = initialDetails[key]
+        const currentValue = details[key]
+
+        if (Array.isArray(currentValue) && Array.isArray(initialValue)) {
+          return JSON.stringify(currentValue) !== JSON.stringify(initialValue)
+        }
+
+        // Intentional != to match Vue component behavior
+        return currentValue != initialValue
+      })
+      .map((key) => [key, details[key]])
+
+    const metadataUpdate = Object.fromEntries(changedEntries) as Partial<Details>
+
+    const updatePayload: UpdatePayload = {}
+    if (changedEntries.length > 0) {
+      updatePayload.metadata = metadataUpdate
+    }
+
+    if (JSON.stringify(tags) !== JSON.stringify(initialTags)) {
+      updatePayload.tags = tags
+    }
+
+    return {
+      updatePayload,
+      hasChanges: Object.keys(updatePayload).length > 0
+    }
+  }, [details, initialDetails, tags, initialTags])
+
+  const handleInputChange = useCallback(() => {
+    onChange?.({
+      libraryItemId: libraryItem.id,
+      hasChanges: changes.hasChanges
+    })
+  }, [libraryItem.id, onChange, changes.hasChanges])
+
+  useEffect(() => {
+    handleInputChange()
+  }, [handleInputChange])
+
+  const submitForm = useCallback(
+    (e?: React.FormEvent) => {
+      e?.preventDefault()
+      onSubmit?.(changes)
+    },
+    [changes, onSubmit]
+  )
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      submit: () => submitForm(),
+      getTitleAndAuthorName: () => {
+        return {
+          title: details.title,
+          author: details.author || ''
+        }
+      },
+      mapBatchDetails: (batchDetails: Partial<Details & { tags: string[] }>, mapType = 'overwrite') => {
+        dispatch({ type: 'BATCH_UPDATE', payload: { batchDetails, mapType } })
+      }
+    }),
+    [submitForm, details.title, details.author]
+  )
+
+  return (
+    <div className="w-full h-full relative">
+      <form
+        className="w-full h-full px-2 md:px-4 py-6"
+        onSubmit={(e) => {
+          e.preventDefault()
+          submitForm()
+        }}
+      >
+        <div className="flex -mx-1">
+          <div className="w-full md:w-1/2 px-1">
+            <TextInput value={details.title || ''} onChange={handleFieldUpdate('title')} label={t('LabelTitle')} />
+          </div>
+          <div className="grow px-1 mt-2 md:mt-0">
+            <TextInput value={details.author || ''} onChange={handleFieldUpdate('author')} label={t('LabelAuthor')} />
+          </div>
+        </div>
+
+        <TextInput value={details.feedURL || ''} onChange={handleFieldUpdate('feedURL')} label={t('LabelRSSFeedURL')} className="mt-2" />
+
+        <SlateEditor srcContent={initialDetails.description || ''} onUpdate={handleFieldUpdate('description')} label={t('LabelDescription')} className="mt-2" />
+
+        <div className="flex mt-2 -mx-1">
+          <div className="w-full md:w-1/2 px-1">
+            <MultiSelect
+              selectedItems={genreItems}
+              onItemAdded={handleAddGenre}
+              onItemRemoved={handleRemoveGenre}
+              label={t('LabelGenres')}
+              items={availableGenres}
+              allowNew
+            />
+          </div>
+          <div className="grow px-1 mt-2 md:mt-0">
+            <MultiSelect
+              selectedItems={tagItems}
+              onItemAdded={handleAddTag}
+              onItemRemoved={handleRemoveTag}
+              label={t('LabelTags')}
+              items={availableTags}
+              allowNew
+            />
+          </div>
+        </div>
+
+        <div className="flex mt-2 -mx-1">
+          <div className="w-full md:w-1/4 px-1">
+            <TextInput value={details.releaseDate || ''} onChange={handleFieldUpdate('releaseDate')} label={t('LabelReleaseDate')} />
+          </div>
+          <div className="w-full md:w-1/4 px-1 mt-2 md:mt-0">
+            <TextInput value={details.itunesId || ''} onChange={handleFieldUpdate('itunesId')} label="iTunes ID" />
+          </div>
+          <div className="w-full md:w-1/4 px-1 mt-2 md:mt-0">
+            <TextInput value={details.language || ''} onChange={handleFieldUpdate('language')} label={t('LabelLanguage')} />
+          </div>
+          <div className="grow px-1 pt-6 mt-2 md:mt-0">
+            <div className="flex justify-center">
+              <Checkbox
+                value={details.explicit}
+                onChange={handleFieldUpdate('explicit')}
+                label={t('LabelExplicit')}
+                checkboxBgClass="bg-primary"
+                borderColorClass="border-gray-600"
+                labelClass="ps-2 text-base font-semibold"
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex mt-2 -mx-1">
+          <div className="w-full md:w-1/4 px-1">
+            <Dropdown
+              label={t('LabelPodcastType')}
+              value={details.podcastType || 'episodic'}
+              items={podcastTypeItems}
+              size="small"
+              onChange={handleFieldUpdate('podcastType')}
+              className="max-w-52"
+            />
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default PodcastDetailsEdit

--- a/src/components/widgets/PodcastDetailsEdit.tsx
+++ b/src/components/widgets/PodcastDetailsEdit.tsx
@@ -111,7 +111,7 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
           submitForm()
         }}
       >
-        <div className="flex -mx-1">
+        <div className="flex flex-wrap -mx-1">
           <div className="w-full md:w-1/2 px-1">
             <TextInput value={details.title || ''} onChange={handleFieldUpdate('title') as (value: string) => void} label={t('LabelTitle')} />
           </div>
@@ -129,7 +129,7 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
 
         <SlateEditor srcContent={initialDetails.description || ''} onUpdate={handleFieldUpdate('description')} label={t('LabelDescription')} className="mt-2" />
 
-        <div className="flex mt-2 -mx-1">
+        <div className="flex flex-wrap mt-2 -mx-1">
           <div className="w-full md:w-1/2 px-1">
             <MultiSelect
               selectedItems={genreItems}
@@ -152,7 +152,7 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
           </div>
         </div>
 
-        <div className="flex mt-2 -mx-1">
+        <div className="flex flex-wrap mt-2 -mx-1">
           <div className="w-full md:w-1/4 px-1">
             <TextInput value={details.releaseDate || ''} onChange={handleFieldUpdate('releaseDate') as (value: string) => void} label={t('LabelReleaseDate')} />
           </div>
@@ -182,7 +182,7 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
               value={details.podcastType || 'episodic'}
               items={podcastTypeItems}
               onChange={handlePodcastTypeChange}
-              className="max-w-52"
+              className="md:max-w-52"
             />
           </div>
         </div>

--- a/src/hooks/useDetailsEdit.ts
+++ b/src/hooks/useDetailsEdit.ts
@@ -1,0 +1,235 @@
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useReducer } from 'react'
+
+// Generic state interface
+interface EditState<TDetails> {
+  details: TDetails
+  tags: string[]
+  initialDetails: TDetails
+  initialTags: string[]
+}
+
+// Generic action types
+type Action<TDetails> =
+  | { type: 'RESET_STATE'; payload: { details: TDetails; tags: string[] } }
+  | { type: 'UPDATE_FIELD'; payload: { field: keyof TDetails; value: TDetails[keyof TDetails] } }
+  | { type: 'UPDATE_TAGS'; payload: { tags: string[] } }
+  | { type: 'BATCH_UPDATE'; payload: { batchDetails: Partial<TDetails & { tags: string[] }>; mapType: 'overwrite' | 'append' } }
+
+// Generic reducer factory
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createDetailsReducer<TDetails extends Record<string, any>>(
+  batchAppendLogic?: (state: EditState<TDetails>, detailsToUpdate: Partial<TDetails>) => TDetails
+) {
+  return (state: EditState<TDetails>, action: Action<TDetails>): EditState<TDetails> => {
+    switch (action.type) {
+      case 'RESET_STATE':
+        return {
+          ...state,
+          details: action.payload.details,
+          tags: action.payload.tags,
+          initialDetails: action.payload.details,
+          initialTags: action.payload.tags
+        }
+      case 'UPDATE_FIELD':
+        return {
+          ...state,
+          details: {
+            ...state.details,
+            [action.payload.field]: action.payload.value
+          }
+        }
+      case 'UPDATE_TAGS':
+        return {
+          ...state,
+          tags: action.payload.tags
+        }
+      case 'BATCH_UPDATE': {
+        const { batchDetails, mapType } = action.payload
+        const { tags: newTags, ...detailsToUpdate } = batchDetails
+
+        const finalTags = newTags ? (mapType === 'append' ? [...new Set([...state.tags, ...newTags])] : [...newTags]) : state.tags
+
+        if (mapType === 'overwrite') {
+          return {
+            ...state,
+            details: { ...state.details, ...detailsToUpdate },
+            tags: finalTags
+          }
+        } else {
+          // Append logic - use custom logic if provided
+          const appendedDetails = batchAppendLogic ? batchAppendLogic(state, detailsToUpdate as Partial<TDetails>) : { ...state.details, ...detailsToUpdate }
+
+          return {
+            ...state,
+            details: appendedDetails,
+            tags: finalTags
+          }
+        }
+      }
+      default:
+        return state
+    }
+  }
+}
+
+export interface UpdatePayload<TDetails> {
+  metadata?: Partial<TDetails>
+  tags?: string[]
+}
+
+export interface DetailsEditRef<TDetails> {
+  submit: () => void
+  getTitleAndAuthorName: () => { title: string | null; author: string }
+  mapBatchDetails: (batchDetails: Partial<TDetails & { tags: string[] }>, mapType?: 'overwrite' | 'append') => void
+}
+
+interface UseDetailsEditOptions<TDetails> {
+  metadata: TDetails
+  tags: string[]
+  libraryItemId: string
+  ref?: React.Ref<DetailsEditRef<TDetails>>
+  extractAuthor: (details: TDetails) => string
+  onChange?: (details: { libraryItemId: string; hasChanges: boolean }) => void
+  onSubmit?: (details: { updatePayload: UpdatePayload<TDetails>; hasChanges: boolean }) => void
+  batchAppendLogic?: (state: EditState<TDetails>, detailsToUpdate: Partial<TDetails>) => TDetails
+  /** Use loose equality (!=) instead of strict equality (!==) for change detection */
+  useLooseEquality?: boolean
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useDetailsEdit<TDetails extends Record<string, any>>({
+  metadata,
+  tags,
+  libraryItemId,
+  ref,
+  extractAuthor,
+  onChange,
+  onSubmit,
+  batchAppendLogic,
+  useLooseEquality = false
+}: UseDetailsEditOptions<TDetails>) {
+  const reducer = useMemo(() => createDetailsReducer<TDetails>(batchAppendLogic), [batchAppendLogic])
+
+  const [state, dispatch] = useReducer(reducer, {
+    details: metadata || ({} as TDetails),
+    tags: [...(tags || [])],
+    initialDetails: metadata || ({} as TDetails),
+    initialTags: [...(tags || [])]
+  })
+
+  const { details, tags: currentTags, initialDetails, initialTags } = state
+
+  // Reset state when metadata or tags change
+  useEffect(() => {
+    dispatch({
+      type: 'RESET_STATE',
+      payload: {
+        details: metadata || ({} as TDetails),
+        tags: [...(tags || [])]
+      }
+    })
+  }, [metadata, tags])
+
+  const updateField = useCallback(
+    <K extends keyof TDetails>(field: K) =>
+      (value: TDetails[K]) => {
+        dispatch({ type: 'UPDATE_FIELD', payload: { field, value } })
+      },
+    []
+  )
+
+  const updateTags = useCallback((newTags: string[]) => {
+    dispatch({ type: 'UPDATE_TAGS', payload: { tags: newTags } })
+  }, [])
+
+  const mapBatchDetails = useCallback((batchDetails: Partial<TDetails & { tags: string[] }>, mapType: 'overwrite' | 'append' = 'overwrite') => {
+    dispatch({ type: 'BATCH_UPDATE', payload: { batchDetails, mapType } })
+  }, [])
+
+  // Calculate changes
+  const changes = useMemo(() => {
+    const changedEntries = (Object.keys(details) as Array<keyof TDetails>)
+      .filter((key) => {
+        const initialValue = initialDetails[key]
+        const currentValue = details[key]
+
+        if (Array.isArray(currentValue) && Array.isArray(initialValue)) {
+          return JSON.stringify(currentValue) !== JSON.stringify(initialValue)
+        }
+
+        // Use loose or strict equality based on option
+        return useLooseEquality ? currentValue != initialValue : currentValue !== initialValue
+      })
+      .map((key) => [key, details[key]])
+
+    const metadataUpdate = Object.fromEntries(changedEntries) as Partial<TDetails>
+
+    const updatePayload: UpdatePayload<TDetails> = {}
+    if (changedEntries.length > 0) {
+      updatePayload.metadata = metadataUpdate
+    }
+
+    if (JSON.stringify(currentTags) !== JSON.stringify(initialTags)) {
+      updatePayload.tags = currentTags
+    }
+
+    return {
+      updatePayload,
+      hasChanges: Object.keys(updatePayload).length > 0
+    }
+  }, [details, initialDetails, currentTags, initialTags, useLooseEquality])
+
+  // Notify parent of changes
+  const handleInputChange = useCallback(() => {
+    onChange?.({
+      libraryItemId,
+      hasChanges: changes.hasChanges
+    })
+  }, [libraryItemId, onChange, changes.hasChanges])
+
+  useEffect(() => {
+    handleInputChange()
+  }, [handleInputChange])
+
+  // Submit handler
+  const submitForm = useCallback(
+    (e?: React.FormEvent) => {
+      e?.preventDefault()
+      onSubmit?.(changes)
+    },
+    [changes, onSubmit]
+  )
+
+  // Extract title from details (assuming it has a title property)
+  const title = useMemo(() => {
+    const detailsWithTitle = details as TDetails & { title?: string | null }
+    return detailsWithTitle.title ?? null
+  }, [details])
+
+  const author = useMemo(() => extractAuthor(details), [details, extractAuthor])
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      submit: () => submitForm(),
+      getTitleAndAuthorName: () => ({
+        title,
+        author
+      }),
+      mapBatchDetails
+    }),
+    [submitForm, title, author, mapBatchDetails]
+  )
+
+  return {
+    details,
+    tags: currentTags,
+    initialDetails,
+    updateField,
+    updateTags,
+    mapBatchDetails,
+    changes,
+    submitForm,
+    dispatch
+  }
+}


### PR DESCRIPTION
This migrates PodcaastDetailsEdit from Vue. This was much easier with `BookDetailsEdit.tsx` as blueprint.

Also, since much code is shared between the two components, it was refactored into a custom hook, useDetailsEdit (which is templated on the `Details` of each of the components).

Please play with both examples.