### PR TITLE
Add dateFormat and timeFormat settings w/ date-fns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@formkit/drag-and-drop": "^0.5.3",
         "clsx": "^2.1.1",
         "cronstrue": "^3.3.0",
+        "date-fns": "^4.1.0",
         "next": "^15.5.4",
         "next-intl": "^4.3.4",
         "react": "^19.0.0",
@@ -3200,6 +3201,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@formkit/drag-and-drop": "^0.5.3",
     "clsx": "^2.1.1",
     "cronstrue": "^3.3.0",
+    "date-fns": "^4.1.0",
     "next": "^15.5.4",
     "next-intl": "^4.3.4",
     "react": "^19.0.0",

--- a/src/app/(main)/settings/SettingsClient.tsx
+++ b/src/app/(main)/settings/SettingsClient.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import Dropdown from '@/components/ui/Dropdown'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { formatJsDate } from '@/lib/datefns'
 import { BookshelfView, ServerSettings } from '@/types/api'
-import { useState, useTransition } from 'react'
+import { useMemo, useState, useTransition } from 'react'
+import { dateFormats, timeFormats } from './settingsConstants'
 import SettingsToggleSwitch from './SettingsToggleSwitch'
 
 interface SettingsClientProps {
@@ -16,13 +19,21 @@ export default function SettingsClient(props: SettingsClientProps) {
   const [isPending, startTransition] = useTransition()
   const [serverSettings, setServerSettings] = useState(initialServerSettings)
 
-  const handleToggleChange = (key: keyof ServerSettings, value: boolean) => {
-    let newValue: boolean | BookshelfView = value
-    if (key === 'homeBookshelfView' || key === 'bookshelfView') {
-      newValue = value ? BookshelfView.STANDARD : BookshelfView.DETAIL
+  const exampleDateFormat = useMemo(() => {
+    if (!serverSettings?.dateFormat) {
+      return ''
     }
-    const updatedSettings = { ...serverSettings, [key]: newValue } as ServerSettings
+    return formatJsDate(new Date(2025, 9, 25), serverSettings.dateFormat)
+  }, [serverSettings?.dateFormat])
 
+  const exampleTimeFormat = useMemo(() => {
+    if (!serverSettings?.timeFormat) {
+      return ''
+    }
+    return formatJsDate(new Date(2025, 9, 25, 17, 30, 0), serverSettings.timeFormat)
+  }, [serverSettings?.timeFormat])
+
+  const handleSaveSettings = (updatedSettings: ServerSettings) => {
     // Optimistically update the UI
     setServerSettings(updatedSettings)
 
@@ -42,6 +53,15 @@ export default function SettingsClient(props: SettingsClientProps) {
     })
   }
 
+  const handleSettingChanged = (key: keyof ServerSettings, value: boolean | string) => {
+    let newValue: boolean | BookshelfView | string = value
+    if (key === 'homeBookshelfView' || key === 'bookshelfView') {
+      newValue = value ? BookshelfView.STANDARD : BookshelfView.DETAIL
+    }
+    const updatedSettings = { ...serverSettings, [key]: newValue } as ServerSettings
+    handleSaveSettings(updatedSettings)
+  }
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div className="flex flex-col gap-4 py-4">
@@ -50,14 +70,14 @@ export default function SettingsClient(props: SettingsClientProps) {
           <SettingsToggleSwitch
             label={t('LabelSettingsStoreCoversWithItem')}
             value={serverSettings?.storeCoverWithItem}
-            onChange={(value) => handleToggleChange('storeCoverWithItem', value)}
+            onChange={(value) => handleSettingChanged('storeCoverWithItem', value)}
             disabled={isPending}
             tooltip={t('LabelSettingsStoreCoversWithItemHelp')}
           />
           <SettingsToggleSwitch
             label={t('LabelSettingsStoreMetadataWithItem')}
             value={serverSettings?.storeMetadataWithItem}
-            onChange={(value) => handleToggleChange('storeMetadataWithItem', value)}
+            onChange={(value) => handleSettingChanged('storeMetadataWithItem', value)}
             disabled={isPending}
             tooltip={t('LabelSettingsStoreMetadataWithItemHelp')}
           />
@@ -67,7 +87,7 @@ export default function SettingsClient(props: SettingsClientProps) {
           <SettingsToggleSwitch
             label={t('LabelSettingsParseSubtitles')}
             value={serverSettings?.scannerParseSubtitle}
-            onChange={(value) => handleToggleChange('scannerParseSubtitle', value)}
+            onChange={(value) => handleSettingChanged('scannerParseSubtitle', value)}
             disabled={isPending}
             tooltip={t.rich('LabelSettingsParseSubtitlesHelp', {
               br: () => <br />
@@ -76,7 +96,7 @@ export default function SettingsClient(props: SettingsClientProps) {
           <SettingsToggleSwitch
             label={t('LabelSettingsFindCovers')}
             value={serverSettings?.scannerFindCovers}
-            onChange={(value) => handleToggleChange('scannerFindCovers', value)}
+            onChange={(value) => handleSettingChanged('scannerFindCovers', value)}
             disabled={isPending}
             tooltip={t.rich('LabelSettingsFindCoversHelp', {
               br: () => <br />
@@ -85,14 +105,14 @@ export default function SettingsClient(props: SettingsClientProps) {
           <SettingsToggleSwitch
             label={t('LabelSettingsPreferMatchedMetadata')}
             value={serverSettings?.scannerPreferMatchedMetadata}
-            onChange={(value) => handleToggleChange('scannerPreferMatchedMetadata', value)}
+            onChange={(value) => handleSettingChanged('scannerPreferMatchedMetadata', value)}
             disabled={isPending}
             tooltip={t('LabelSettingsPreferMatchedMetadataHelp')}
           />
           <SettingsToggleSwitch
             label={t('LabelSettingsEnableWatcher')}
             value={!serverSettings?.scannerDisableWatcher}
-            onChange={(value) => handleToggleChange('scannerDisableWatcher', !value)}
+            onChange={(value) => handleSettingChanged('scannerDisableWatcher', !value)}
             disabled={isPending}
             tooltip={t('LabelSettingsEnableWatcherHelp')}
           />
@@ -103,14 +123,14 @@ export default function SettingsClient(props: SettingsClientProps) {
           <SettingsToggleSwitch
             label={t('LabelSettingsChromecastSupport')}
             value={serverSettings?.chromecastEnabled}
-            onChange={(value) => handleToggleChange('chromecastEnabled', value)}
+            onChange={(value) => handleSettingChanged('chromecastEnabled', value)}
             disabled={isPending}
           />
 
           <SettingsToggleSwitch
             label={t('LabelSettingsAllowIframe')}
             value={serverSettings?.allowIframe}
-            onChange={(value) => handleToggleChange('allowIframe', value)}
+            onChange={(value) => handleSettingChanged('allowIframe', value)}
             disabled={isPending}
           />
         </div>
@@ -121,17 +141,39 @@ export default function SettingsClient(props: SettingsClientProps) {
           <SettingsToggleSwitch
             label={t('LabelSettingsHomePageBookshelfView')}
             value={serverSettings?.homeBookshelfView === BookshelfView.STANDARD}
-            onChange={(value) => handleToggleChange('homeBookshelfView', value)}
+            onChange={(value) => handleSettingChanged('homeBookshelfView', value)}
             disabled={isPending}
             tooltip={t('LabelSettingsBookshelfViewHelp')}
           />
           <SettingsToggleSwitch
             label={t('LabelSettingsLibraryBookshelfView')}
             value={serverSettings?.bookshelfView === BookshelfView.STANDARD}
-            onChange={(value) => handleToggleChange('bookshelfView', value)}
+            onChange={(value) => handleSettingChanged('bookshelfView', value)}
             disabled={isPending}
             tooltip={t('LabelSettingsBookshelfViewHelp')}
           />
+          <div className="w-full max-w-72">
+            <Dropdown
+              items={dateFormats}
+              label={t('LabelSettingsDateFormat')}
+              value={serverSettings?.dateFormat}
+              onChange={(value) => handleSettingChanged('dateFormat', value as string)}
+            />
+            <p className="text-xs text-gray-300 px-1 mb-2">
+              {t('LabelExample')}: {exampleDateFormat}
+            </p>
+          </div>
+          <div className="w-full max-w-72">
+            <Dropdown
+              items={timeFormats}
+              label={t('LabelSettingsTimeFormat')}
+              value={serverSettings?.timeFormat}
+              onChange={(value) => handleSettingChanged('timeFormat', value as string)}
+            />
+            <p className="text-xs text-gray-300 px-1 mb-2">
+              {t('LabelExample')}: {exampleTimeFormat}
+            </p>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(main)/settings/settingsConstants.ts
+++ b/src/app/(main)/settings/settingsConstants.ts
@@ -1,0 +1,45 @@
+export const dateFormats = [
+  {
+    text: 'MM/DD/YYYY',
+    value: 'MM/dd/yyyy'
+  },
+  {
+    text: 'DD/MM/YYYY',
+    value: 'dd/MM/yyyy'
+  },
+  {
+    text: 'DD.MM.YYYY',
+    value: 'dd.MM.yyyy'
+  },
+  {
+    text: 'YYYY-MM-DD',
+    value: 'yyyy-MM-dd'
+  },
+  {
+    text: 'MMM do, yyyy',
+    value: 'MMM do, yyyy'
+  },
+  {
+    text: 'MMMM do, yyyy',
+    value: 'MMMM do, yyyy'
+  },
+  {
+    text: 'dd MMM yyyy',
+    value: 'dd MMM yyyy'
+  },
+  {
+    text: 'dd MMMM yyyy',
+    value: 'dd MMMM yyyy'
+  }
+]
+
+export const timeFormats = [
+  {
+    text: 'h:mma (am/pm)',
+    value: 'h:mma'
+  },
+  {
+    text: 'HH:mm (24-hour)',
+    value: 'HH:mm'
+  }
+]

--- a/src/lib/datefns.ts
+++ b/src/lib/datefns.ts
@@ -1,0 +1,8 @@
+import { format } from 'date-fns'
+
+export function formatJsDate(date: Date, fnsFormat: string = 'MM/dd/yyyy HH:mm') {
+  if (!date || !(date instanceof Date)) {
+    return ''
+  }
+  return format(date, fnsFormat)
+}


### PR DESCRIPTION
This adds date format and time format server settings

Added [date-fns](https://www.npmjs.com/package/date-fns) package to handle formatting. The `dateFormat` and `timeFormat` server settings use datefns format strings.

<img width="507" height="325" alt="image" src="https://github.com/user-attachments/assets/e5669bc0-4e07-48b6-995d-c6aaa57e80cc" />

Started a `datefns.ts` file that will include all date helpers.