### PR TITLE
Migrate GlobalSearch.vue

### DIFF
--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -66,10 +66,10 @@ export default function AppBar({ libraries, currentLibraryId, user }: AppBarProp
       {/* Search Input mobile and desktop */}
       <div className="flex-1 min-w-0 max-w-70">
         {isSearchMode ? (
-          <GlobalSearchInput autoFocus onSubmit={handleSearchSubmit} />
+          <GlobalSearchInput autoFocus onSubmit={handleSearchSubmit} libraryId={currentLibraryId} />
         ) : (
           <div className="hidden md:block">
-            <GlobalSearchInput onSubmit={handleSearchSubmit} />
+            <GlobalSearchInput onSubmit={handleSearchSubmit} libraryId={currentLibraryId} />
           </div>
         )}
       </div>

--- a/src/app/(main)/GlobalSearchInput.tsx
+++ b/src/app/(main)/GlobalSearchInput.tsx
@@ -115,16 +115,6 @@ export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit }: Gl
     }
   }
 
-  // Scroll focused item into view
-  useEffect(() => {
-    if (focusedIndex >= 0 && menuRef.current) {
-      const el = menuRef.current.querySelector(`[data-index="${focusedIndex}"]`)
-      if (el) {
-        el.scrollIntoView({ block: 'nearest' })
-      }
-    }
-  }, [focusedIndex])
-
   const handleClear = () => {
     setSearchQuery('')
     setFocusedIndex(-1)

--- a/src/app/(main)/GlobalSearchInput.tsx
+++ b/src/app/(main)/GlobalSearchInput.tsx
@@ -11,8 +11,6 @@ import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import GlobalSearchMenu from './GlobalSearchMenu'
 
-
-
 interface GlobalSearchInputProps {
   libraryId?: string
   autoFocus?: boolean
@@ -167,7 +165,7 @@ export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit }: Gl
       {/* Search Icon, Spinner or Clear Button */}
       <div className="absolute end-0 top-0 h-full flex items-center pe-2">
         {isSearching || isTyping ? (
-           <LoadingSpinner size="la-sm" className="scale-50 text-gray-400" />
+          <LoadingSpinner size="la-sm" className="scale-50 text-gray-400" />
         ) : searchQuery ? (
           <button onClick={handleClear} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer" aria-label="Clear search">
             <span className="material-symbols text-lg">close</span>
@@ -179,13 +177,7 @@ export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit }: Gl
 
       {/* Dropdown Menu */}
       {showMenu && (searchQuery || isSearching || isTyping) && (
-        <GlobalSearchMenu
-          results={flatResults}
-          focusedIndex={focusedIndex}
-          onItemClick={handleResultClick}
-          menuRef={menuRef}
-          searchQuery={searchQuery}
-        />
+        <GlobalSearchMenu results={flatResults} focusedIndex={focusedIndex} onItemClick={handleResultClick} menuRef={menuRef} searchQuery={searchQuery} />
       )}
     </div>
   )

--- a/src/app/(main)/GlobalSearchInput.tsx
+++ b/src/app/(main)/GlobalSearchInput.tsx
@@ -1,47 +1,192 @@
 'use client'
 
-import InputDropdown from '@/components/ui/InputDropdown'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import InputWrapper from '@/components/ui/InputWrapper'
+import LoadingSpinner from '@/components/widgets/LoadingSpinner'
+import { useClickOutside } from '@/hooks/useClickOutside'
+import { useLibrarySearch } from '@/hooks/useLibrarySearch'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+
+import { useGlobalSearchTransformer } from '@/hooks/useGlobalSearchTransformer'
+import { useRouter } from 'next/navigation'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import GlobalSearchMenu from './GlobalSearchMenu'
+
+
 
 interface GlobalSearchInputProps {
-  onSubmit?: () => void
+  libraryId?: string
   autoFocus?: boolean
+  onSubmit?: () => void
 }
 
-export default function GlobalSearchInput({ onSubmit, autoFocus = false }: GlobalSearchInputProps) {
-  const [searchValue, setSearchValue] = useState('')
-  const inputRef = useRef<{ focus: () => void }>(null)
-  const [shouldFocus, setShouldFocus] = useState(false)
+export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit }: GlobalSearchInputProps = {}) {
+  const searchOptions = useMemo(() => ({ autoSelectFirst: false, libraryId }), [libraryId])
+  const { searchQuery, setSearchQuery, isSearching, searchResults, selectedLibraryId, handleSearch, searchError } = useLibrarySearch(searchOptions)
+  const t = useTypeSafeTranslations()
+  const router = useRouter()
 
-  // Focus the input when shouldFocus becomes true
+  // Local state for UI
+  const [showMenu, setShowMenu] = useState(false)
+  const [focusedIndex, setFocusedIndex] = useState(-1)
+  const [isTyping, setIsTyping] = useState(false) // Local typing state for "Thinking..."
+
+  // Debounce search
   useEffect(() => {
-    if (shouldFocus && inputRef.current) {
-      inputRef.current.focus()
-      setShouldFocus(false)
+    if (!searchQuery) {
+      setIsTyping(false)
+      return
     }
-  }, [shouldFocus])
 
-  // Auto-focus when autoFocus prop is true
+    setIsTyping(true)
+    const timeoutId = setTimeout(() => {
+      setIsTyping(false)
+      handleSearch()
+    }, 500) // 500ms debounce
+
+    return () => clearTimeout(timeoutId)
+  }, [searchQuery, handleSearch])
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  // Close menu when clicking outside
+  useClickOutside(containerRef, containerRef, () => {
+    setShowMenu(false)
+  })
+
+  const handleInputFocus = () => {
+    setShowMenu(true)
+  }
+
+  const handleInputBlur = () => {
+    setShowMenu(false)
+  }
+
+  const flatResults = useGlobalSearchTransformer({
+    searchResults,
+    searchQuery,
+    isSearching,
+    isTyping,
+    searchError,
+    selectedLibraryId
+  })
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      // Skip headers
+      let nextIndex = focusedIndex + 1
+      while (nextIndex < flatResults.length && (flatResults[nextIndex].type === 'header' || flatResults[nextIndex].isPlaceholder)) {
+        nextIndex++
+      }
+      if (nextIndex < flatResults.length) {
+        setFocusedIndex(nextIndex)
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      let prevIndex = focusedIndex - 1
+      while (prevIndex >= 0 && (flatResults[prevIndex].type === 'header' || flatResults[prevIndex].isPlaceholder)) {
+        prevIndex--
+      }
+      if (prevIndex >= 0) {
+        setFocusedIndex(prevIndex)
+      } else if (prevIndex < 0) {
+        setFocusedIndex(-1) // Allow going back to input
+      }
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (focusedIndex >= 0 && flatResults[focusedIndex]) {
+        const item = flatResults[focusedIndex]
+        if (item.link) {
+          router.push(item.link)
+          setShowMenu(false)
+          inputRef.current?.blur()
+          onSubmit?.()
+        }
+      } else if (searchQuery.trim()) {
+        router.push(`/library/${selectedLibraryId}/search?q=${encodeURIComponent(searchQuery.trim())}`)
+        setShowMenu(false)
+        inputRef.current?.blur()
+        onSubmit?.()
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setShowMenu(false)
+      inputRef.current?.blur()
+    }
+  }
+
+  // Scroll focused item into view
   useEffect(() => {
-    if (autoFocus) {
-      setShouldFocus(true)
+    if (focusedIndex >= 0 && menuRef.current) {
+      const el = menuRef.current.querySelector(`[data-index="${focusedIndex}"]`)
+      if (el) {
+        el.scrollIntoView({ block: 'nearest' })
+      }
     }
-  }, [autoFocus])
+  }, [focusedIndex])
 
-  const handleSearchSelect = useCallback(
-    (value: string | number) => {
-      setSearchValue(String(value))
-      onSubmit?.()
-    },
-    [onSubmit]
-  )
+  const handleClear = () => {
+    setSearchQuery('')
+    setFocusedIndex(-1)
+    inputRef.current?.focus()
+  }
+
+  const handleResultClick = () => {
+    setShowMenu(false)
+    onSubmit?.()
+  }
 
   return (
-    <div className="relative">
-      <InputDropdown ref={inputRef} items={[]} size="small" placeholder="Search..." value={searchValue} onChange={handleSearchSelect} />
-      <div className="absolute end-0 top-0 h-full w-10 flex items-center justify-center">
-        <span className="material-symbols text-gray-400 text-lg">search</span>
+    <div className="w-full relative sm:w-80" ref={containerRef}>
+      <InputWrapper size="small" borderless className="w-full" inputRef={inputRef}>
+        <input
+          ref={inputRef}
+          type="text"
+          className="w-full h-full bg-transparent outline-none text-sm placeholder:text-gray-400"
+          placeholder={t('PlaceholderSearch')}
+          value={searchQuery}
+          onInput={(e) => setSearchQuery(e.currentTarget.value)}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          onKeyDown={handleKeyDown}
+          role="combobox"
+          aria-expanded={showMenu}
+          aria-haspopup="listbox"
+          aria-controls="global-search-menu"
+          aria-activedescendant={focusedIndex >= 0 ? `result-item-${focusedIndex}` : undefined}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
+          autoFocus={autoFocus}
+        />
+      </InputWrapper>
+
+      {/* Search Icon, Spinner or Clear Button */}
+      <div className="absolute end-0 top-0 h-full flex items-center pe-2">
+        {isSearching || isTyping ? (
+           <LoadingSpinner size="la-sm" className="scale-50 text-gray-400" />
+        ) : searchQuery ? (
+          <button onClick={handleClear} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer" aria-label="Clear search">
+            <span className="material-symbols text-lg">close</span>
+          </button>
+        ) : (
+          <span className="material-symbols text-gray-400 text-lg pointer-events-none">search</span>
+        )}
       </div>
+
+      {/* Dropdown Menu */}
+      {showMenu && (searchQuery || isSearching || isTyping) && (
+        <GlobalSearchMenu
+          results={flatResults}
+          focusedIndex={focusedIndex}
+          onItemClick={handleResultClick}
+          menuRef={menuRef}
+          searchQuery={searchQuery}
+        />
+      )}
     </div>
   )
 }

--- a/src/app/(main)/GlobalSearchMenu.tsx
+++ b/src/app/(main)/GlobalSearchMenu.tsx
@@ -1,0 +1,148 @@
+import AuthorImage from '@/components/covers/AuthorImage'
+import { FlatResultItem } from '@/hooks/useGlobalSearchTransformer'
+import { mergeClasses } from '@/lib/merge-classes'
+import Link from 'next/link'
+import React, { useEffect, useMemo } from 'react'
+
+const HighlightMatch = ({ text, query }: { text: string; query: string }) => {
+  const parts = useMemo(() => {
+    if (!query) return [{ text, isMatch: false }]
+    const escapedQuery = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`(${escapedQuery})`, 'gi')
+    return text.split(regex).map((part) => ({
+      text: part,
+      isMatch: part.toLowerCase() === query.toLowerCase()
+    }))
+  }, [text, query])
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.isMatch ? (
+          <span key={i} className="font-bold text-amber-600 dark:text-amber-500">
+            {part.text}
+          </span>
+        ) : (
+          <span key={i}>{part.text}</span>
+        )
+      )}
+    </>
+  )
+}
+
+interface GlobalSearchMenuProps {
+  results: FlatResultItem[]
+  focusedIndex: number
+  onItemClick: () => void
+  menuRef: React.RefObject<HTMLDivElement | null>
+  searchQuery: string
+}
+
+export default function GlobalSearchMenu({ results, focusedIndex, onItemClick, menuRef, searchQuery }: GlobalSearchMenuProps) {
+  // Scroll focused item into view
+  useEffect(() => {
+    if (focusedIndex >= 0 && menuRef.current) {
+      const el = menuRef.current.querySelector(`[data-index="${focusedIndex}"]`)
+      if (el) {
+        el.scrollIntoView({ block: 'nearest' })
+      }
+    }
+  }, [focusedIndex, menuRef])
+
+  return (
+    <div
+      ref={menuRef}
+      id="global-search-menu"
+      role="listbox"
+      tabIndex={-1}
+      className="absolute z-50 mt-1 w-full max-h-[calc(100vh-100px)] overflow-y-auto bg-primary border border-dropdown-menu-border shadow-lg rounded-md py-1 ring-1 ring-black/5 globalSearchMenu"
+      onMouseDown={(e) => e.preventDefault()} // Prevent blur on scroll click
+    >
+      {results.map((result, index) => {
+        if (result.isPlaceholder) {
+          return (
+            <div key={result.id} className="py-2 px-3 text-sm text-gray-500">
+              {result.placeholderText}
+            </div>
+          )
+        }
+
+        if (result.type === 'header') {
+          return (
+            <div key={result.id} className="px-3 py-1 mt-2 mb-1 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+              {result.title}
+            </div>
+          )
+        }
+
+        const isSelected = focusedIndex === index
+        const isAuthor = result.type === 'author'
+        const usePortrait = isAuthor // Authors keep the portrait ratio
+        // Books, Series, Podcasts, etc use square
+        const containerClass = usePortrait
+          ? 'w-8 h-12' // Portrait
+          : 'w-12 h-12' // Square
+
+        const hasImage = !!result.imageSrc || isAuthor
+
+        return (
+          <Link
+            key={`${result.type}-${result.id}`}
+            href={result.link || '#'}
+            id={`result-item-${index}`}
+            data-index={index}
+            tabIndex={-1}
+            className={mergeClasses(
+              'block px-3 py-2 cursor-pointer no-underline select-none',
+              'hover:bg-dropdown-item-hover',
+              isSelected ? 'bg-dropdown-item-selected' : ''
+            )}
+            onClick={onItemClick}
+            role="option"
+            aria-selected={isSelected}
+          >
+            <div className="flex items-center gap-3">
+              {/* Image / Icon */}
+              {hasImage ? (
+                <div className={mergeClasses('flex-shrink-0 relative bg-bg-secondary rounded-sm overflow-hidden flex items-center justify-center shadow-sm', containerClass)}>
+                  {result.type === 'author' && result.originalItem ? (
+                    <AuthorImage author={result.originalItem} className="w-full h-full" />
+                  ) : (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={result.imageSrc} alt="" className="w-full h-full object-cover" loading="lazy" />
+                  )}
+                </div>
+              ) : (
+                // Placeholder or Icon for items without images (Tags/Genres)
+                <div className="flex-shrink-0 w-8 h-8 rounded-full bg-bg-secondary flex items-center justify-center">
+                  <span className="material-symbols text-gray-400 text-lg">
+                    {result.type === 'tag' ? 'label' : result.type === 'genre' ? 'category' : result.type === 'collection' ? 'collections_bookmark' : result.type === 'playlist' ? 'library_music' : 'record_voice_over'}
+                  </span>
+                </div>
+              )}
+
+              {/* Text */}
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-foreground truncate">
+                  <HighlightMatch text={result.title} query={searchQuery} />
+                </div>
+                {/* Only show subtitle if it exists */}
+                {result.subtitle && (
+                  <div className="text-xxs text-foreground-subdued truncate">
+                    <HighlightMatch text={result.subtitle} query={searchQuery} />
+                  </div>
+                )}
+                {/* Show author if it exists */}
+                {result.author && (
+                  <div className="text-xs text-foreground truncate">
+                    <HighlightMatch text={result.author} query={searchQuery} />
+                  </div>
+                )}
+              </div>
+            </div>
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/(main)/GlobalSearchMenu.tsx
+++ b/src/app/(main)/GlobalSearchMenu.tsx
@@ -1,5 +1,5 @@
 import AuthorImage from '@/components/covers/AuthorImage'
-import { FlatResultItem } from '@/hooks/useGlobalSearchTransformer'
+import { FlatResultItem, SearchResultType } from '@/hooks/useGlobalSearchTransformer'
 import { mergeClasses } from '@/lib/merge-classes'
 import Link from 'next/link'
 import React, { useEffect, useMemo } from 'react'
@@ -28,6 +28,21 @@ const HighlightMatch = ({ text, query }: { text: string; query: string }) => {
       )}
     </>
   )
+}
+
+const getMaterialSymbolIcon = (type: SearchResultType): string => {
+  switch (type) {
+    case 'tag':
+      return 'label'
+    case 'genre':
+      return 'category'
+    case 'collection':
+      return 'collections_bookmark'
+    case 'playlist':
+      return 'library_music'
+    default:
+      return 'record_voice_over'
+  }
 }
 
 interface GlobalSearchMenuProps {
@@ -77,6 +92,7 @@ export default function GlobalSearchMenu({ results, focusedIndex, onItemClick, m
 
         const isSelected = focusedIndex === index
         const isAuthor = result.type === 'author'
+        const shouldHighlightSubtitle = result.type === 'book' || result.type === 'podcast' || result.type === 'episode'
         const usePortrait = isAuthor // Authors keep the portrait ratio
         // Books, Series, Podcasts, etc use square
         const containerClass = usePortrait
@@ -104,7 +120,12 @@ export default function GlobalSearchMenu({ results, focusedIndex, onItemClick, m
             <div className="flex items-center gap-3">
               {/* Image / Icon */}
               {hasImage ? (
-                <div className={mergeClasses('flex-shrink-0 relative bg-bg-secondary rounded-sm overflow-hidden flex items-center justify-center shadow-sm', containerClass)}>
+                <div
+                  className={mergeClasses(
+                    'flex-shrink-0 relative bg-bg-secondary rounded-sm overflow-hidden flex items-center justify-center shadow-sm',
+                    containerClass
+                  )}
+                >
                   {result.type === 'author' && result.originalItem ? (
                     <AuthorImage author={result.originalItem} className="w-full h-full" />
                   ) : (
@@ -115,9 +136,7 @@ export default function GlobalSearchMenu({ results, focusedIndex, onItemClick, m
               ) : (
                 // Placeholder or Icon for items without images (Tags/Genres)
                 <div className="flex-shrink-0 w-8 h-8 rounded-full bg-bg-secondary flex items-center justify-center">
-                  <span className="material-symbols text-gray-400 text-lg">
-                    {result.type === 'tag' ? 'label' : result.type === 'genre' ? 'category' : result.type === 'collection' ? 'collections_bookmark' : result.type === 'playlist' ? 'library_music' : 'record_voice_over'}
-                  </span>
+                  <span className="material-symbols text-gray-400 text-lg">{getMaterialSymbolIcon(result.type)}</span>
                 </div>
               )}
 
@@ -129,7 +148,7 @@ export default function GlobalSearchMenu({ results, focusedIndex, onItemClick, m
                 {/* Only show subtitle if it exists */}
                 {result.subtitle && (
                   <div className="text-xxs text-foreground-subdued truncate">
-                    <HighlightMatch text={result.subtitle} query={searchQuery} />
+                    {shouldHighlightSubtitle ? <HighlightMatch text={result.subtitle} query={searchQuery} /> : <span>{result.subtitle}</span>}
                   </div>
                 )}
                 {/* Show author if it exists */}

--- a/src/components/widgets/LibrarySearchBox.tsx
+++ b/src/components/widgets/LibrarySearchBox.tsx
@@ -9,6 +9,7 @@ import { useEffect } from 'react'
 
 interface LibrarySearchBoxProps {
   mediaTypes?: ('book' | 'podcast')[]
+  libraryId?: string
   onBookSelect?: (book: BookLibraryItem | null) => void
   onPodcastSelect?: (podcast: PodcastLibraryItem | null) => void
   onCollectionSelect?: (collection: Collection | null) => void
@@ -23,6 +24,7 @@ interface LibrarySearchBoxProps {
 
 export function LibrarySearchBox({
   mediaTypes = ['book', 'podcast'],
+  libraryId,
   onBookSelect,
   onPodcastSelect,
   onCollectionSelect,
@@ -54,7 +56,8 @@ export function LibrarySearchBox({
     clearSelection
   } = useLibrarySearch({
     autoSelectFirst: true,
-    mediaTypes
+    mediaTypes,
+    libraryId
   })
 
   // Notify parent components when items are selected or cleared

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,25 +1,47 @@
-import { RefObject, useCallback, useEffect } from 'react'
+import { RefObject, useCallback, useEffect, useRef } from 'react'
 
 export function useClickOutside(menuRef: RefObject<HTMLElement | null>, triggerRef: RefObject<HTMLElement | null>, handler: () => void): void {
+  const mouseDownTargetRef = useRef<EventTarget | null>(null)
+
+  const handleMouseDown = useCallback((event: MouseEvent) => {
+    mouseDownTargetRef.current = event.target
+  }, [])
+
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
       if (!menuRef.current || !triggerRef.current) return
 
+      // If mousedown was inside but the click ended up outside, ignore it
+      // This prevents closing when dragging to select text
+      if (mouseDownTargetRef.current) {
+        const mouseDownTarget = mouseDownTargetRef.current as Node
+        if (menuRef.current.contains(mouseDownTarget) || triggerRef.current.contains(mouseDownTarget)) {
+          mouseDownTargetRef.current = null
+          return
+        }
+      }
+
       if (!menuRef.current.contains(event.target as Node) && !triggerRef.current.contains(event.target as Node)) {
         handler()
       }
+
+      mouseDownTargetRef.current = null
     },
     [menuRef, triggerRef, handler]
   )
 
   useEffect(() => {
+    // Track where mousedown occurs to detect drag operations
+    document.addEventListener('mousedown', handleMouseDown)
+
     // Use 'click' instead of 'mousedown' to ensure that interactive elements
     // (like buttons) receive their click events before the menu closes.
     // With 'mousedown', the menu close and React re-render would happen between
     // mousedown and mouseup, preventing the clicked element's onClick from firing.
     document.addEventListener('click', handleClickOutside)
     return () => {
+      document.removeEventListener('mousedown', handleMouseDown)
       document.removeEventListener('click', handleClickOutside)
     }
-  }, [handleClickOutside])
+  }, [handleClickOutside, handleMouseDown])
 }

--- a/src/hooks/useGlobalSearchTransformer.ts
+++ b/src/hooks/useGlobalSearchTransformer.ts
@@ -1,0 +1,215 @@
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
+import { SearchLibraryResponse } from '@/types/api'
+import { useMemo } from 'react'
+
+export type SearchResultType = 'book' | 'podcast' | 'episode' | 'author' | 'series' | 'tag' | 'genre' | 'narrator' | 'collection' | 'playlist' | 'header'
+
+export interface FlatResultItem {
+  type: SearchResultType
+  id: string
+  title: string
+  subtitle?: string
+  link?: string
+  imageSrc?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  originalItem?: any
+  isPlaceholder?: boolean // For "Thinking", "No Results"
+  placeholderText?: string
+  author?: string
+}
+
+interface UseGlobalSearchTransformerProps {
+  searchResults: SearchLibraryResponse | null
+  searchQuery: string
+  isSearching: boolean
+  isTyping: boolean
+  searchError: string | null
+  selectedLibraryId: string
+}
+
+export function useGlobalSearchTransformer({
+  searchResults,
+  searchQuery,
+  isSearching,
+  isTyping,
+  searchError,
+  selectedLibraryId
+}: UseGlobalSearchTransformerProps) {
+  const t = useTypeSafeTranslations()
+
+  const flatResults = useMemo(() => {
+    // If not searching and no results (and no query), empty
+    if (!searchQuery && !searchResults) return []
+
+    const results: FlatResultItem[] = []
+
+    const addGroup = <T,>(
+      items: T[] | undefined,
+      headerId: string,
+      headerTitle: string,
+      mapItem: (item: T) => FlatResultItem | null
+    ) => {
+      if (items?.length) {
+        results.push({ type: 'header', id: headerId, title: headerTitle })
+        items.slice(0, 3).forEach((item) => {
+          const mapped = mapItem(item)
+          if (mapped) results.push(mapped)
+        })
+      }
+    }
+
+    // Only show "Thinking" or "Error" as list items if we have no results to show
+    // otherwise the spinner in the input handles the "Thinking" state feedback
+    const hasResults =
+      searchResults &&
+      (searchResults.book?.length ||
+        searchResults.podcast?.length ||
+        searchResults.episodes?.length ||
+        searchResults.authors?.length ||
+        searchResults.series?.length ||
+        searchResults.tags?.length ||
+        searchResults.genres?.length ||
+        searchResults.narrators?.length ||
+        searchResults.collections?.length ||
+        searchResults.playlists?.length)
+
+    if ((isSearching || isTyping) && !hasResults) {
+      results.push({ type: 'header', id: 'thinking', title: '', isPlaceholder: true, placeholderText: t('MessageThinking') })
+    }
+
+    if (searchError) {
+      results.push({ type: 'header', id: 'error', title: '', isPlaceholder: true, placeholderText: searchError })
+    }
+
+    if (!searchResults) return results
+
+    const isEmpty = !hasResults
+
+    if (isEmpty && searchQuery && !isSearching && !isTyping && !searchError) {
+      results.push({ type: 'header', id: 'no-results', title: '', isPlaceholder: true, placeholderText: t('MessageNoResults') })
+      return results
+    }
+
+    // Continue if we have results (even if searching)
+
+    // Books
+    addGroup(searchResults.book, 'header-books', t('LabelBooks'), (item) => ({
+      type: 'book',
+      id: item.libraryItem.id,
+      title: item.libraryItem.media.metadata.title || 'Unknown Title',
+      subtitle: item.libraryItem.media.metadata.subtitle,
+      author: item.libraryItem.media.metadata.authorName,
+      link: `/item/${item.libraryItem.id}`,
+      imageSrc: getLibraryItemCoverSrc(item.libraryItem, getPlaceholderCoverUrl()),
+      originalItem: item.libraryItem
+    }))
+
+    // Podcasts
+    addGroup(searchResults.podcast, 'header-podcasts', t('LabelPodcasts'), (item) => ({
+      type: 'podcast',
+      id: item.libraryItem.id,
+      title: item.libraryItem.media.metadata.title || 'Unknown Podcast',
+      subtitle: item.libraryItem.media.metadata.author,
+      link: `/item/${item.libraryItem.id}`,
+      imageSrc: getLibraryItemCoverSrc(item.libraryItem, getPlaceholderCoverUrl()),
+      originalItem: item.libraryItem
+    }))
+
+    // Episodes
+    addGroup(searchResults.episodes, 'header-episodes', t('LabelEpisodes'), (item) => {
+      const libItem = item.libraryItem
+      const episode = libItem.recentEpisode
+      if (!episode) return null
+      return {
+        type: 'episode',
+        id: episode.id,
+        title: episode.title, // Episode Title
+        subtitle: libItem.media.metadata.title, // Podcast Title as subtitle
+        link: `/item/${libItem.id}`,
+        imageSrc: getLibraryItemCoverSrc(libItem, getPlaceholderCoverUrl()),
+        originalItem: episode
+      }
+    })
+
+    // Authors
+    addGroup(searchResults.authors, 'header-authors', t('LabelAuthors'), (author) => ({
+      type: 'author',
+      id: author.id,
+      title: author.name,
+      subtitle: author.numBooks ? `${author.numBooks} books` : undefined,
+      link: `/author/${author.id}`,
+      originalItem: author
+    }))
+
+    // Series
+    addGroup(searchResults.series, 'header-series', t('LabelSeries'), (item) => {
+      // Use series cover or fallback to first book cover
+      let imageSrc = ''
+      if (item.series.coverPath) {
+        imageSrc = `/api/series/${item.series.id}/cover?ts=${item.series.updatedAt || 0}`
+      } else if (item.books.length > 0) {
+        imageSrc = getLibraryItemCoverSrc(item.books[0], getPlaceholderCoverUrl())
+      }
+
+      return {
+        type: 'series',
+        id: item.series.id,
+        title: item.series.name,
+        subtitle: item.books?.length ? `${item.books.length} books` : undefined,
+        link: `/library/${selectedLibraryId}/series/${item.series.id}`,
+        imageSrc,
+        originalItem: item.series
+      }
+    })
+
+    // Tags
+    addGroup(searchResults.tags, 'header-tags', t('LabelTags'), (tag) => ({
+      type: 'tag',
+      id: `tag-${tag.name}`,
+      title: tag.name,
+      subtitle: `${tag.numItems} items`,
+      link: `/library/${selectedLibraryId}/bookshelf?filter=tags.${encodeURIComponent(tag.name)}`
+    }))
+
+    // Genres
+    addGroup(searchResults.genres, 'header-genres', t('LabelGenres'), (genre) => ({
+      type: 'genre',
+      id: `genre-${genre.name}`,
+      title: genre.name,
+      subtitle: `${genre.numItems} items`,
+      link: `/library/${selectedLibraryId}/bookshelf?filter=genres.${encodeURIComponent(genre.name)}`
+    }))
+
+    // Narrators
+    addGroup(searchResults.narrators, 'header-narrators', t('LabelNarrators'), (narrator) => ({
+      type: 'narrator',
+      id: `narrator-${narrator.name}`,
+      title: narrator.name,
+      subtitle: `${narrator.numBooks} books`,
+      link: `/library/${selectedLibraryId}/bookshelf?filter=narrators.${encodeURIComponent(narrator.name)}`
+    }))
+
+    // Collections
+    addGroup(searchResults.collections, 'header-collections', t('LabelCollections'), (collection) => ({
+      type: 'collection',
+      id: `collection-${collection.id}`,
+      title: collection.name,
+      subtitle: collection.books?.length ? `${collection.books.length} books` : undefined,
+      link: `/library/${selectedLibraryId}/collections/${collection.id}`
+    }))
+
+    // Playlists
+    addGroup(searchResults.playlists, 'header-playlists', t('LabelPlaylists'), (playlist) => ({
+      type: 'playlist',
+      id: `playlist-${playlist.id}`,
+      title: playlist.name,
+      subtitle: playlist.items?.length ? `${playlist.items.length} items` : undefined,
+      link: `/library/${selectedLibraryId}/playlists/${playlist.id}`
+    }))
+
+    return results
+  }, [searchResults, selectedLibraryId, searchQuery, isSearching, t, isTyping, searchError])
+
+  return flatResults
+}

--- a/src/hooks/useGlobalSearchTransformer.ts
+++ b/src/hooks/useGlobalSearchTransformer.ts
@@ -44,12 +44,7 @@ export function useGlobalSearchTransformer({
 
     const results: FlatResultItem[] = []
 
-    const addGroup = <T,>(
-      items: T[] | undefined,
-      headerId: string,
-      headerTitle: string,
-      mapItem: (item: T) => FlatResultItem | null
-    ) => {
+    const addGroup = <T>(items: T[] | undefined, headerId: string, headerTitle: string, mapItem: (item: T) => FlatResultItem | null) => {
       if (items?.length) {
         results.push({ type: 'header', id: headerId, title: headerTitle })
         items.slice(0, 3).forEach((item) => {
@@ -196,7 +191,7 @@ export function useGlobalSearchTransformer({
       id: `collection-${collection.id}`,
       title: collection.name,
       subtitle: collection.books?.length ? `${collection.books.length} books` : undefined,
-      link: `/library/${selectedLibraryId}/collections/${collection.id}`
+      link: `/library/${selectedLibraryId}/collection/${collection.id}`
     }))
 
     // Playlists
@@ -205,7 +200,7 @@ export function useGlobalSearchTransformer({
       id: `playlist-${playlist.id}`,
       title: playlist.name,
       subtitle: playlist.items?.length ? `${playlist.items.length} items` : undefined,
-      link: `/library/${selectedLibraryId}/playlists/${playlist.id}`
+      link: `/library/${selectedLibraryId}/playlist/${playlist.id}`
     }))
 
     return results

--- a/src/hooks/useLibrarySearch.ts
+++ b/src/hooks/useLibrarySearch.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState } from 'react'
 export interface UseLibrarySearchOptions {
   autoSelectFirst?: boolean
   mediaTypes?: ('book' | 'podcast')[]
+  libraryId?: string
 }
 
 export interface UseLibrarySearchReturn {
@@ -47,8 +48,10 @@ export interface UseLibrarySearchReturn {
   setSelectedAuthor: (author: Author | null) => void
 }
 
+const DEFAULT_MEDIA_TYPES: ('book' | 'podcast')[] = ['book', 'podcast']
+
 export function useLibrarySearch(options: UseLibrarySearchOptions = {}): UseLibrarySearchReturn {
-  const { autoSelectFirst = true, mediaTypes = ['book', 'podcast'] } = options
+  const { autoSelectFirst = true, mediaTypes = DEFAULT_MEDIA_TYPES, libraryId } = options
 
   // Data fetching state
   const [user, setUser] = useState<User | null>(null)
@@ -57,7 +60,7 @@ export function useLibrarySearch(options: UseLibrarySearchOptions = {}): UseLibr
   const [loadError, setLoadError] = useState<string | null>(null)
 
   // Search state
-  const [selectedLibraryId, setSelectedLibraryId] = useState<string>('')
+  const [selectedLibraryId, setSelectedLibraryId] = useState<string>(libraryId || '')
   const [searchQuery, setSearchQuery] = useState('')
   const [searchResults, setSearchResults] = useState<SearchLibraryResponse | null>(null)
   const [isSearching, setIsSearching] = useState(false)
@@ -106,7 +109,7 @@ export function useLibrarySearch(options: UseLibrarySearchOptions = {}): UseLibr
 
         const libs = librariesResponse?.libraries || []
         setLibraries(libs)
-        if (libs.length > 0) {
+        if (!libraryId && libs.length > 0) {
           setSelectedLibraryId(libs[0].id)
         }
       } catch (error) {
@@ -117,7 +120,14 @@ export function useLibrarySearch(options: UseLibrarySearchOptions = {}): UseLibr
     }
 
     loadData()
-  }, [])
+  }, [libraryId])
+
+  // Sync selectedLibraryId with libraryId prop if it changes
+  useEffect(() => {
+    if (libraryId) {
+      setSelectedLibraryId(libraryId)
+    }
+  }, [libraryId])
 
   // Fetch collections and playlists when library changes
   useEffect(() => {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -770,6 +770,7 @@ export interface SearchLibraryResponse {
     books: LibraryItem[]
   }>
   authors: Author[]
+  episodes?: Array<{ libraryItem: PodcastLibraryItem }>
   /** Client-side filtered collections (not from server search API) */
   collections?: Collection[]
   /** Client-side filtered playlists (not from server search API) */


### PR DESCRIPTION
This migrates and enhances GlobalSearch.vue

### Notable changes
- Supports playlist and collection search (client side)
- Adds query highlighting
- Uses loading indicator in place of X icon while searching
- Decreases subtitle font a bit to xxs
- Adds number of books to series results
- Original component refactored into input and menu, and uses hooks for search and search-result transformation

I haven't added examples in this case, just hooked the search box into the app bar.