### PR TITLE
Migrate Item slider

### DIFF
--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import ItemSlider from '@/components/widgets/ItemSlider'
 import { AuthorCard } from '@/components/widgets/media-card/AuthorCard'
 import BookMediaCard from '@/components/widgets/media-card/BookMediaCard'
 import PodcastEpisodeCard from '@/components/widgets/media-card/PodcastEpisodeCard'
 import PodcastMediaCard from '@/components/widgets/media-card/PodcastMediaCard'
 import { SeriesCard } from '@/components/widgets/media-card/SeriesCard'
+import { useCardSize } from '@/contexts/CardSizeContext'
 import { Author, BookshelfView, Library, LibraryItem, MediaProgress, PersonalizedShelf, Series, UserLoginResponse } from '@/types/api'
 interface LibraryClientProps {
   library: Library
@@ -14,22 +16,21 @@ interface LibraryClientProps {
 
 export default function LibraryClient({ library, personalized, currentUser }: LibraryClientProps) {
   const user = currentUser.user
+  const { sizeMultiplier } = useCardSize()
 
   return (
-    <div className="pl-8 py-8 space-y-8">
+    <div className="ps-4e py-4e space-y-2e" style={{ fontSize: sizeMultiplier + 'rem' }}>
       {personalized.map((shelf) => (
-        <div key={shelf.id}>
-          <h4 className="text-base font-semibold mb-4">{shelf.label}</h4>
-          <div className="flex gap-4 overflow-x-auto overflow-y-hidden w-full">
-            {shelf.entities.map((entity) => {
-              if (shelf.type === 'book' || shelf.type === 'podcast') {
-                const EntityMediaCard = shelf.type === 'book' ? BookMediaCard : PodcastMediaCard
-                const libraryItem = entity as LibraryItem
-                const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
+        <ItemSlider key={shelf.id} title={shelf.label}>
+          {shelf.entities.map((entity) => {
+            if (shelf.type === 'book' || shelf.type === 'podcast') {
+              const EntityMediaCard = shelf.type === 'book' ? BookMediaCard : PodcastMediaCard
+              const libraryItem = entity as LibraryItem
+              const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
 
-                return (
+              return (
+                <div key={entity.id + '-' + shelf.id} className="shrink-0">
                   <EntityMediaCard
-                    key={entity.id + '-' + shelf.id}
                     libraryItem={libraryItem}
                     bookshelfView={BookshelfView.DETAIL}
                     dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
@@ -40,20 +41,21 @@ export default function LibraryClient({ library, personalized, currentUser }: Li
                     bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
                     mediaProgress={mediaProgress}
                   />
-                )
-              } else if (shelf.type === 'series') {
-                const series = entity as Series
-                const libraryItems = series.books || []
-                const bookProgressMap = new Map<string, MediaProgress>()
-                libraryItems.forEach((libraryItem) => {
-                  const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
-                  if (mediaProgress) {
-                    bookProgressMap.set(libraryItem.id, mediaProgress)
-                  }
-                })
-                return (
+                </div>
+              )
+            } else if (shelf.type === 'series') {
+              const series = entity as Series
+              const libraryItems = series.books || []
+              const bookProgressMap = new Map<string, MediaProgress>()
+              libraryItems.forEach((libraryItem) => {
+                const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
+                if (mediaProgress) {
+                  bookProgressMap.set(libraryItem.id, mediaProgress)
+                }
+              })
+              return (
+                <div key={entity.id + '-' + shelf.id} className="shrink-0">
                   <SeriesCard
-                    key={entity.id + '-' + shelf.id}
                     series={series}
                     libraryId={library.id}
                     bookshelfView={BookshelfView.DETAIL}
@@ -61,17 +63,18 @@ export default function LibraryClient({ library, personalized, currentUser }: Li
                     bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
                     bookProgressMap={bookProgressMap}
                   />
-                )
-              } else if (shelf.type === 'episode') {
-                const libraryItem = entity as LibraryItem
-                const episode = libraryItem.recentEpisode
-                if (!episode) {
-                  return null
-                }
-                const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.mediaItemId === episode.id)
-                return (
+                </div>
+              )
+            } else if (shelf.type === 'episode') {
+              const libraryItem = entity as LibraryItem
+              const episode = libraryItem.recentEpisode
+              if (!episode) {
+                return null
+              }
+              const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.mediaItemId === episode.id)
+              return (
+                <div key={episode.id + '-' + shelf.id} className="shrink-0">
                   <PodcastEpisodeCard
-                    key={episode.id + '-' + shelf.id}
                     libraryItem={libraryItem}
                     bookshelfView={BookshelfView.DETAIL}
                     dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
@@ -82,14 +85,18 @@ export default function LibraryClient({ library, personalized, currentUser }: Li
                     bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
                     mediaProgress={mediaProgress}
                   />
-                )
-              } else if (shelf.type === 'authors') {
-                const author = entity as Author
-                return <AuthorCard key={author.id + '-' + shelf.id} author={author} userCanUpdate={user.permissions.update} />
-              }
-            })}
-          </div>
-        </div>
+                </div>
+              )
+            } else if (shelf.type === 'authors') {
+              const author = entity as Author
+              return (
+                <div key={author.id + '-' + shelf.id} className="shrink-0">
+                  <AuthorCard author={author} userCanUpdate={user.permissions.update} />
+                </div>
+              )
+            }
+          })}
+        </ItemSlider>
       ))}
     </div>
   )

--- a/src/components/ui/ButtonBase.tsx
+++ b/src/components/ui/ButtonBase.tsx
@@ -10,7 +10,7 @@ interface ButtonBaseProps {
   children: React.ReactNode
   disabled?: boolean
   borderless?: boolean
-  size?: 'small' | 'medium' | 'large' | 'auto'
+  size?: 'small' | 'medium' | 'large' | 'auto' | 'custom'
   onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void
   onMouseDown?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void
   onKeyDown?: (e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => void
@@ -46,7 +46,7 @@ const ButtonBase = ({
     'focus-visible:outline-1 focus-visible:outline-white/80 focus-visible:outline-offset-0',
 
     // Size-based height (identical to InputWrapper)
-    size === 'small' ? 'h-9' : size === 'large' ? 'h-11' : size === 'auto' ? 'min-h-10 h-auto' : 'h-10',
+    size === 'small' ? 'h-9' : size === 'large' ? 'h-11' : size === 'auto' ? 'min-h-10 h-auto' : size === 'custom' ? '' : 'h-10',
 
     // Disabled styles
     'disabled:bg-bg-disabled disabled:cursor-not-allowed disabled:border-none disabled:text-disabled',

--- a/src/components/ui/IconBtn.tsx
+++ b/src/components/ui/IconBtn.tsx
@@ -10,7 +10,7 @@ interface IconBtnProps {
   outlined?: boolean
   borderless?: boolean
   loading?: boolean
-  size?: 'small' | 'medium' | 'large'
+  size?: 'small' | 'medium' | 'large' | 'auto' | 'custom'
   iconClass?: string
   ariaLabel?: string
   to?: string
@@ -61,7 +61,7 @@ export default function IconBtn({
   const isDisabled = disabled || loading
 
   // Icon button specific styling based on size
-  const sizeClass = size === 'small' ? 'w-9 text-lg' : size === 'large' ? 'w-11 text-2xl' : 'w-10 text-xl'
+  const sizeClass = size === 'small' ? 'w-9 text-lg' : size === 'large' ? 'w-11 text-2xl' : size === 'medium' ? 'w-10 text-xl' : size === 'auto' ? 'w-auto' : ''
   const classList = mergeClasses(sizeClass, className)
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => {

--- a/src/components/widgets/CoverSizeWidget.tsx
+++ b/src/components/widgets/CoverSizeWidget.tsx
@@ -7,11 +7,12 @@ import { mergeClasses } from '@/lib/merge-classes'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 /** Available cover sizes in pixels */
-export const availableCoverSizes = [60, 80, 100, 120, 140, 160, 180, 200, 220]
-/** Base cover size for calculating size multiplier */
-const BASE_COVER_SIZE = 120
-/** Default size index */
+export const AVAILABLE_COVER_SIZES = [60, 80, 100, 120, 140, 160, 180, 200, 220]
+export const NUM_AVAILABLE_COVER_SIZES = 9
 const DEFAULT_SIZE_INDEX = 3
+export const NUM_AVAILABLE_MOBILE_COVER_SIZES = 3
+const DEFAULT_MOBILE_SIZE_INDEX = 2
+const BASE_COVER_SIZE = 120
 
 interface CoverSizeWidgetProps {
   className?: string
@@ -19,28 +20,39 @@ interface CoverSizeWidgetProps {
 
 export default function CoverSizeWidget({ className }: CoverSizeWidgetProps) {
   const t = useTypeSafeTranslations()
-  const { setSizeMultiplier } = useCardSize()
-
-  const [sizeIndex, setSizeIndex] = useState(DEFAULT_SIZE_INDEX)
-
-  const coverWidth = useMemo(() => availableCoverSizes[sizeIndex], [sizeIndex])
+  const { isMobile, setSizeMultiplier } = useCardSize()
+  const [sizeIndex, setSizeIndex] = useState(isMobile ? DEFAULT_MOBILE_SIZE_INDEX : DEFAULT_SIZE_INDEX)
+  const numAvailableCoverSizes = isMobile ? NUM_AVAILABLE_MOBILE_COVER_SIZES : NUM_AVAILABLE_COVER_SIZES
+  const [coverWidth, setCoverWidth] = useState(AVAILABLE_COVER_SIZES[sizeIndex])
 
   // Update context sizeMultiplier when size index changes
   useEffect(() => {
+    console.log('isMobile', isMobile)
+    setSizeIndex(isMobile ? DEFAULT_MOBILE_SIZE_INDEX : DEFAULT_SIZE_INDEX)
+  }, [isMobile])
+
+  useEffect(() => {
+    console.log('sizeIndex', sizeIndex)
+    setCoverWidth(AVAILABLE_COVER_SIZES[sizeIndex])
+  }, [sizeIndex])
+
+  useEffect(() => {
+    console.log('coverWidth', coverWidth)
     const multiplier = coverWidth / BASE_COVER_SIZE
+    console.log('multiplier', multiplier)
     setSizeMultiplier(multiplier)
   }, [coverWidth, setSizeMultiplier])
 
   const increaseSize = useCallback(() => {
-    setSizeIndex((prev) => Math.min(availableCoverSizes.length - 1, prev + 1))
-  }, [])
+    setSizeIndex((prev) => Math.min(numAvailableCoverSizes - 1, prev + 1))
+  }, [numAvailableCoverSizes])
 
   const decreaseSize = useCallback(() => {
     setSizeIndex((prev) => Math.max(0, prev - 1))
   }, [])
 
   const isAtMinSize = sizeIndex === 0
-  const isAtMaxSize = sizeIndex === availableCoverSizes.length - 1
+  const isAtMaxSize = sizeIndex === numAvailableCoverSizes - 1
 
   const buttonClass = useMemo(() => 'text-base h-6 w-4 disabled:bg-transparent disabled:cursor-default', [])
   const containerClass = useMemo(

--- a/src/components/widgets/CoverSizeWidget.tsx
+++ b/src/components/widgets/CoverSizeWidget.tsx
@@ -25,21 +25,16 @@ export default function CoverSizeWidget({ className }: CoverSizeWidgetProps) {
   const numAvailableCoverSizes = isMobile ? NUM_AVAILABLE_MOBILE_COVER_SIZES : NUM_AVAILABLE_COVER_SIZES
   const [coverWidth, setCoverWidth] = useState(AVAILABLE_COVER_SIZES[sizeIndex])
 
-  // Update context sizeMultiplier when size index changes
   useEffect(() => {
-    console.log('isMobile', isMobile)
     setSizeIndex(isMobile ? DEFAULT_MOBILE_SIZE_INDEX : DEFAULT_SIZE_INDEX)
   }, [isMobile])
 
   useEffect(() => {
-    console.log('sizeIndex', sizeIndex)
     setCoverWidth(AVAILABLE_COVER_SIZES[sizeIndex])
   }, [sizeIndex])
 
   useEffect(() => {
-    console.log('coverWidth', coverWidth)
     const multiplier = coverWidth / BASE_COVER_SIZE
-    console.log('multiplier', multiplier)
     setSizeMultiplier(multiplier)
   }, [coverWidth, setSizeMultiplier])
 

--- a/src/components/widgets/ItemSlider.tsx
+++ b/src/components/widgets/ItemSlider.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import IconBtn from '@/components/ui/IconBtn'
+import { mergeClasses } from '@/lib/merge-classes'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+
+interface ItemSliderProps {
+  title: React.ReactNode
+  children: React.ReactNode
+  className?: string
+}
+
+export default function ItemSlider({ title, children, className = '' }: ItemSliderProps) {
+  const sliderRef = useRef<HTMLDivElement>(null)
+  const [isScrollable, setIsScrollable] = useState(false)
+  const [canScrollLeft, setCanScrollLeft] = useState(false)
+  const [canScrollRight, setCanScrollRight] = useState(false)
+
+  const checkScroll = useCallback(() => {
+    const slider = sliderRef.current
+    if (!slider) return
+
+    const { scrollLeft, scrollWidth, clientWidth } = slider
+    // Use a small threshold (1px) for float inaccuracies
+    const scrollRemaining = Math.abs(scrollLeft + clientWidth - scrollWidth)
+
+    setIsScrollable(scrollWidth > clientWidth)
+    setCanScrollLeft(scrollLeft > 0)
+    setCanScrollRight(scrollRemaining >= 1)
+  }, [])
+
+  useEffect(() => {
+    checkScroll()
+    const slider = sliderRef.current
+    if (!slider) return
+
+    const resizeObserver = new ResizeObserver(() => checkScroll())
+    resizeObserver.observe(slider)
+
+    return () => resizeObserver.disconnect()
+  }, [checkScroll, children]) // Re-check when children change
+
+  const scrollLeft = () => {
+    const slider = sliderRef.current
+    if (!slider) return
+    const scrollAmount = slider.clientWidth
+    slider.scrollBy({ left: -scrollAmount, behavior: 'smooth' })
+  }
+
+  const scrollRight = () => {
+    const slider = sliderRef.current
+    if (!slider) return
+    const scrollAmount = slider.clientWidth
+    slider.scrollBy({ left: scrollAmount, behavior: 'smooth' })
+  }
+
+  return (
+    <div className={mergeClasses('w-full', className)}>
+      <div className="flex items-center p-2e">
+        <div className="font-bold flex-grow text-foreground">{title}</div>
+
+        {isScrollable && (
+          <div className="flex gap-1e items-center">
+            <IconBtn
+              className={mergeClasses('rounded-full w-8e h-8e', canScrollLeft ? 'text-foreground hover:bg-white/10' : 'text-foreground/30 cursor-default')}
+              borderless
+              size="custom"
+              disabled={!canScrollLeft}
+              onClick={scrollLeft}
+              ariaLabel="Scroll Left"
+            >
+              chevron_left
+            </IconBtn>
+            <IconBtn
+              className={mergeClasses('rounded-full w-8e h-8e', canScrollRight ? 'text-foreground hover:bg-white/10' : 'text-foreground/30 cursor-default')}
+              borderless
+              size="custom"
+              disabled={!canScrollRight}
+              onClick={scrollRight}
+              ariaLabel="Scroll Right"
+            >
+              chevron_right
+            </IconBtn>
+          </div>
+        )}
+      </div>
+
+      <div ref={sliderRef} className="w-full overflow-y-hidden overflow-x-auto no-scroll scroll-smooth flex gap-4e p-4e" onScroll={checkScroll}>
+        {children}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This migrates `ItemSlider.vue`, and modifies `LibraryClient` to use it.

### Notable changes:
- Integrated the new `ItemSlider` into `LibraryClient`
- `CoverSizeWidget` is changed to only support [60, 80, 100] on mobile.
- Changes were made in `LibraryClient`  to scale fonts, spacing and card sizes according to the selected size multiplier.
- Added `custom` size mode for buttons (to pass em-based sizes)