### PR TITLE
Socket auth refresh

### DIFF
--- a/src/app/internal-api/refresh/route.ts
+++ b/src/app/internal-api/refresh/route.ts
@@ -80,6 +80,7 @@ async function handleRefresh(request: Request) {
       return NextResponse.json({ error: 'No new access token received' }, { status: 500 })
     }
 
+    // If the request is an API request, dont redirect (used in socket auth_failed handler)
     if (request.headers.get('accept') === 'application/json') {
       const response = NextResponse.json({ success: true })
       setTokenCookies(response, newAccessToken, newRefreshToken)

--- a/src/app/internal-api/refresh/route.ts
+++ b/src/app/internal-api/refresh/route.ts
@@ -80,6 +80,12 @@ async function handleRefresh(request: Request) {
       return NextResponse.json({ error: 'No new access token received' }, { status: 500 })
     }
 
+    if (request.headers.get('accept') === 'application/json') {
+      const response = NextResponse.json({ success: true })
+      setTokenCookies(response, newAccessToken, newRefreshToken)
+      return response
+    }
+
     // Get redirect URL from query parameters or default to user default path
     const redirectUrlPath = url.searchParams.get('redirect') || getUserDefaultUrlPath(data.userDefaultLibraryId, data.user.type)
     const redirectUrl = new URL(redirectUrlPath, clientBaseUrl)

--- a/src/contexts/SocketContext.tsx
+++ b/src/contexts/SocketContext.tsx
@@ -34,13 +34,6 @@ export function SocketProvider({ children, accessToken }: SocketProviderProps) {
       socketInstance.emit('auth', accessToken)
     }
 
-    // @ts-expect-error Temporary testing function
-    window.testAuthFailed = () => {
-      console.log('Simulating auth failure')
-      // Force emit with an invalid token to trigger auth_failed
-      socketInstance.emit('auth', 'invalid_testing_token123')
-    }
-
     const handleDisconnect = () => {
       setIsConnected(false)
       console.log('Socket disconnected')

--- a/src/contexts/SocketContext.tsx
+++ b/src/contexts/SocketContext.tsx
@@ -34,6 +34,13 @@ export function SocketProvider({ children, accessToken }: SocketProviderProps) {
       socketInstance.emit('auth', accessToken)
     }
 
+    // @ts-expect-error Temporary testing function
+    window.testAuthFailed = () => {
+      console.log('Simulating auth failure')
+      // Force emit with an invalid token to trigger auth_failed
+      socketInstance.emit('auth', 'invalid_testing_token123')
+    }
+
     const handleDisconnect = () => {
       setIsConnected(false)
       console.log('Socket disconnected')

--- a/src/contexts/SocketContext.tsx
+++ b/src/contexts/SocketContext.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { ReactNode, createContext, useContext, useEffect, useState } from 'react'
 import { Socket, io } from 'socket.io-client'
 
@@ -17,6 +18,7 @@ interface SocketProviderProps {
 }
 
 export function SocketProvider({ children, accessToken }: SocketProviderProps) {
+  const router = useRouter()
   const [socket, setSocket] = useState<Socket | null>(null)
   const [isConnected, setIsConnected] = useState(false)
   const [connectionError, setConnectionError] = useState<string | null>(null)
@@ -47,8 +49,25 @@ export function SocketProvider({ children, accessToken }: SocketProviderProps) {
       console.log('Socket initialized successfully')
     }
 
-    const handleAuthFailed = () => {
-      console.error('Socket auth failed')
+    const handleAuthFailed = async () => {
+      console.log('Socket auth failed. Attempting silent token refresh.')
+      try {
+        const res = await fetch('/internal-api/refresh', {
+          headers: {
+            Accept: 'application/json'
+          }
+        })
+        if (res.ok) {
+          console.log('Silent token refresh successful. Refreshing router to get new token.')
+          router.refresh()
+        } else {
+          console.error('Silent token refresh failed.')
+          window.location.reload() // Reload to let middleware trigger redirect to login
+        }
+      } catch (err) {
+        console.error('Error during token refresh:', err)
+        window.location.reload()
+      }
     }
 
     socketInstance.on('connect', handleConnect)
@@ -65,7 +84,7 @@ export function SocketProvider({ children, accessToken }: SocketProviderProps) {
       socketInstance.off('auth_failed', handleAuthFailed)
       socketInstance.disconnect()
     }
-  }, [accessToken])
+  }, [accessToken, router])
 
   const value: SocketContextType = {
     socket,


### PR DESCRIPTION
This change gracefullly handles `auth_failed` socket events that are emitted when the access token expires after a period of inactivity. 

The `auth_failed` handler was modified to:
1. Try calling `internal-api/refresh` as an API request. This generates a new access token cookie.
2. If the request was successful, we call router.refresh(). This re-runs the server components, including `MainLayout` which reads the new access token from the cookie and sets it `SocketProvider`, causing a refreshed socket to be instantiated.

So all this is done without disrupting the React state.