### PR TITLE
Handle homeBookshelfView and bookshelfView server settings correctly

### DIFF
--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -20,7 +20,7 @@ interface LibraryClientProps {
 
 export default function LibraryClient({ personalized, currentUser }: LibraryClientProps) {
   const { sizeMultiplier } = useCardSize()
-  const { library, setContextMenuItems, setContextMenuActionHandler, bookshelfView, boundModal } = useLibrary()
+  const { library, setContextMenuItems, setContextMenuActionHandler, homeBookshelfView, boundModal } = useLibrary()
 
   useEffect(() => {
     const items = []
@@ -64,7 +64,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
 
       {/* bookshelf rows */}
       {personalized.map((shelf) => {
-        const Wrapper = bookshelfView === BookshelfView.STANDARD ? BookShelfRow : ItemSlider
+        const Wrapper = homeBookshelfView === BookshelfView.STANDARD ? BookShelfRow : ItemSlider
 
         return (
           <Wrapper key={shelf.id} title={shelf.label}>
@@ -78,7 +78,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                   <div key={entity.id + '-' + shelf.id} className="shrink-0 mx-2e">
                     <EntityMediaCard
                       libraryItem={libraryItem}
-                      bookshelfView={bookshelfView}
+                      bookshelfView={homeBookshelfView}
                       dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
                       timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
                       userPermissions={currentUser.user.permissions}
@@ -104,7 +104,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                     <SeriesCard
                       series={series}
                       libraryId={library.id}
-                      bookshelfView={bookshelfView}
+                      bookshelfView={homeBookshelfView}
                       dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
                       bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
                       bookProgressMap={bookProgressMap}
@@ -122,7 +122,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                   <div key={episode.id + '-' + shelf.id} className="shrink-0 mx-2e">
                     <PodcastEpisodeCard
                       libraryItem={libraryItem}
-                      bookshelfView={bookshelfView}
+                      bookshelfView={homeBookshelfView}
                       dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
                       timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
                       userPermissions={currentUser.user.permissions}

--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -7,7 +7,7 @@ import { useBookshelfQuery } from '@/hooks/useBookshelfQuery'
 import { useBookshelfVirtualizer } from '@/hooks/useBookshelfVirtualizer'
 import { usePersistentScroll } from '@/hooks/usePersistentScroll'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { BookshelfEntity, EntityType, MediaProgress, UserLoginResponse } from '@/types/api'
+import { BookshelfEntity, BookshelfView, EntityType, MediaProgress, UserLoginResponse } from '@/types/api'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import LibraryEmptyState from '../LibraryEmptyState'
 import { ENTITY_CONFIGS } from './entity-config'
@@ -22,7 +22,7 @@ interface BookshelfClientProps {
 
 export default function BookshelfClient({ entityType, currentUser }: BookshelfClientProps) {
   const t = useTypeSafeTranslations()
-  const { library, setItemCount, orderBy, collapseSeries, showSubtitles, seriesSortBy, updateSetting, filterBy, boundModal } = useLibrary()
+  const { library, setItemCount, orderBy, collapseSeries, showSubtitles, seriesSortBy, updateSetting, filterBy, boundModal, bookshelfView } = useLibrary()
 
   const { query } = useBookshelfQuery(entityType)
 
@@ -85,7 +85,12 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
   const shelfPadding = (dimensions.width < 640 ? 32 : 64) * sizeMultiplier
   const cardMargin = 24 * sizeMultiplier
   const totalEntityCardWidth = cardSize.width + cardMargin
-  const shelfRowHeight = cardSize.height + 16 * sizeMultiplier
+
+  const isAlternativeBookshelfView = bookshelfView === BookshelfView.DETAIL
+  // A standard bookshelf divider is 1.5rem (24px).
+  // In alternative view there is no divider.
+  const dividerHeight = isAlternativeBookshelfView ? 0 : 24
+  const shelfRowHeight = cardSize.height + (16 + dividerHeight) * sizeMultiplier
 
   // Resize Observer for Container
   useEffect(() => {
@@ -253,7 +258,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
   return (
     <div
       ref={containerRef}
-      className="h-full overflow-y-auto relative py-8"
+      className={isAlternativeBookshelfView ? 'h-full overflow-y-auto relative py-8' : 'h-full overflow-y-auto relative'}
       style={{ fontSize: sizeMultiplier + 'rem' }}
       onScroll={(e) => {
         const scrollTop = e.currentTarget.scrollTop
@@ -263,7 +268,13 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
     >
       {/* Measurement Dummy - Hidden but rendered for sizing */}
       <div ref={dummyCardRef} style={{ position: 'absolute', visibility: 'hidden', top: 0, left: 0, zIndex: -1 }} aria-hidden="true">
-        <config.SkeletonComponent coverAspectRatio={coverAspectRatio} seriesSortBy={seriesSortBy} showSubtitles={showSubtitles} orderBy={orderBy} />
+        <config.SkeletonComponent
+          bookshelfView={bookshelfView}
+          coverAspectRatio={coverAspectRatio}
+          seriesSortBy={seriesSortBy}
+          showSubtitles={showSubtitles}
+          orderBy={orderBy}
+        />
       </div>
 
       {/* Error State */}
@@ -295,11 +306,14 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
             return (
               <div
                 key={shelfIndex}
-                className="absolute left-0 w-full flex"
+                className={`absolute left-0 w-full flex ${!isAlternativeBookshelfView ? 'bookshelfRow' : ''}`}
                 style={{
                   top: `${shelfIndex * shelfHeight}px`,
                   height: `${shelfHeight}px`,
                   paddingLeft: `${bookshelfMarginLeft}px`,
+                  // To push the cards to the bottom of the flex container (and touch the divider), we align items to center and add some pt-6e equivalent to the cards or use items-end with padding-bottom for the divider.
+                  // BookShelfRow uses pt-6e (24px) to push the content down. Then the divider is positioned exactly under it.
+                  paddingTop: !isAlternativeBookshelfView ? `${16 * sizeMultiplier}px` : undefined,
                   gap: `${cardMargin}px`
                 }}
               >
@@ -310,6 +324,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
                     return (
                       <div key={`skeleton-wrapper-${startIndex + k}`} style={{ width: `${currentCardWidth}px`, flexShrink: 0 }}>
                         <config.SkeletonComponent
+                          bookshelfView={bookshelfView}
                           coverAspectRatio={coverAspectRatio}
                           seriesSortBy={seriesSortBy}
                           showSubtitles={showSubtitles}
@@ -323,6 +338,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
                     <config.CardComponent
                       key={`card-wrapper-${item.id}`}
                       entity={item}
+                      bookshelfView={bookshelfView}
                       width={currentCardWidth}
                       libraryId={library.id}
                       isPodcastLibrary={isPodcastLibrary}
@@ -335,6 +351,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
                     />
                   )
                 })}
+                {!isAlternativeBookshelfView && <div className="bookshelfDivider w-full absolute bottom-0 left-0 right-0 z-20 h-6e" />}
               </div>
             )
           })}

--- a/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
@@ -31,6 +31,7 @@ import { TranslationKey } from '@/types/translations'
 import React, { ReactNode } from 'react'
 
 export interface SkeletonComponentProps {
+  bookshelfView: BookshelfView
   coverAspectRatio: 0 | 1
   seriesSortBy?: string
   showSubtitles?: boolean
@@ -39,6 +40,7 @@ export interface SkeletonComponentProps {
 
 export interface CardComponentProps {
   entity: BookshelfEntity
+  bookshelfView: BookshelfView
   width: number
   libraryId?: string
   isPodcastLibrary?: boolean
@@ -109,10 +111,10 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
       }
       return isPodcastLibrary ? 'MessageNoPodcastsFound' : 'MessageNoBooksFound'
     },
-    SkeletonComponent: ({ coverAspectRatio, showSubtitles, orderBy }) => (
-      <MediaCardSkeleton bookshelfView={BookshelfView.DETAIL} bookCoverAspectRatio={coverAspectRatio} showSubtitles={showSubtitles} orderBy={orderBy} />
+    SkeletonComponent: ({ bookshelfView, coverAspectRatio, showSubtitles, orderBy }) => (
+      <MediaCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} showSubtitles={showSubtitles} orderBy={orderBy} />
     ),
-    CardComponent: ({ entity, width, isPodcastLibrary, coverAspectRatio, showSubtitles, currentUser, orderBy, bookProgressMap }) => {
+    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, coverAspectRatio, showSubtitles, currentUser, orderBy, bookProgressMap }) => {
       const item = entity as LibraryItem
       const isCollapsedSeries = !!item.collapsedSeries
       const entityProgress = isPodcastLibrary ? null : bookProgressMap.get(item.id)
@@ -123,7 +125,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
           <div style={{ width: `${width}px`, flexShrink: 0 }}>
             <CollapsedSeriesCard
               libraryItem={item}
-              bookshelfView={BookshelfView.DETAIL}
+              bookshelfView={bookshelfView}
               bookCoverAspectRatio={coverAspectRatio}
               mediaProgress={entityProgress}
               isSelectionMode={false}
@@ -142,7 +144,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
           <EntityMediaCard
             libraryItem={item}
-            bookshelfView={BookshelfView.DETAIL}
+            bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
             mediaProgress={entityProgress}
             isSelectionMode={false}
@@ -169,17 +171,17 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     getContextMenuItems: () => [],
     handleContextMenuAction: () => {},
     getEmptyMessageKey: (filterBy) => (filterBy === 'all' ? 'MessageBookshelfNoSeries' : 'MessageNoSeriesFound'),
-    SkeletonComponent: ({ coverAspectRatio, seriesSortBy }) => (
-      <SeriesCardSkeleton bookshelfView={BookshelfView.DETAIL} bookCoverAspectRatio={coverAspectRatio} orderBy={seriesSortBy} />
+    SkeletonComponent: ({ bookshelfView, coverAspectRatio, seriesSortBy }) => (
+      <SeriesCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} orderBy={seriesSortBy} />
     ),
-    CardComponent: ({ entity, width, libraryId, coverAspectRatio, currentUser, seriesSortBy, bookProgressMap }) => {
+    CardComponent: ({ entity, bookshelfView, width, libraryId, coverAspectRatio, currentUser, seriesSortBy, bookProgressMap }) => {
       const series = entity as Series
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
           <SeriesCard
             series={series}
             libraryId={libraryId ?? ''}
-            bookshelfView={BookshelfView.DETAIL}
+            bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
             dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
             orderBy={seriesSortBy}
@@ -224,14 +226,16 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     getContextMenuItems: () => [],
     handleContextMenuAction: () => {},
     getEmptyMessageKey: (filterBy) => (filterBy === 'all' ? 'MessageBookshelfNoCollections' : 'MessageNoCollectionsFound'),
-    SkeletonComponent: ({ coverAspectRatio }) => <CollectionCardSkeleton bookshelfView={BookshelfView.DETAIL} bookCoverAspectRatio={coverAspectRatio} />,
-    CardComponent: ({ entity, width, coverAspectRatio, currentUser }) => {
+    SkeletonComponent: ({ bookshelfView, coverAspectRatio }) => (
+      <CollectionCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} />
+    ),
+    CardComponent: ({ entity, bookshelfView, width, coverAspectRatio, currentUser }) => {
       const collection = entity as Collection
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
           <CollectionCard
             collection={collection}
-            bookshelfView={BookshelfView.DETAIL}
+            bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
             userCanUpdate={currentUser.user.permissions?.update}
             userCanDelete={currentUser.user.permissions?.delete}
@@ -246,14 +250,14 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     getContextMenuItems: () => [],
     handleContextMenuAction: () => {},
     getEmptyMessageKey: () => 'MessageNoUserPlaylists',
-    SkeletonComponent: ({ coverAspectRatio }) => <PlaylistCardSkeleton bookshelfView={BookshelfView.DETAIL} bookCoverAspectRatio={coverAspectRatio} />,
-    CardComponent: ({ entity, width, coverAspectRatio, currentUser }) => {
+    SkeletonComponent: ({ bookshelfView, coverAspectRatio }) => <PlaylistCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} />,
+    CardComponent: ({ entity, bookshelfView, width, coverAspectRatio, currentUser }) => {
       const playlist = entity as Playlist
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
           <PlaylistCard
             playlist={playlist}
-            bookshelfView={BookshelfView.DETAIL}
+            bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
             userCanUpdate={currentUser.user.permissions?.update}
             userCanDelete={currentUser.user.permissions?.delete}

--- a/src/app/(main)/library/[library]/layout.tsx
+++ b/src/app/(main)/library/[library]/layout.tsx
@@ -35,9 +35,10 @@ export default async function LibraryLayout({
   }
 
   const homeBookshelfView = currentUser?.serverSettings?.homeBookshelfView || 0 // Default to STANDARD if undefined
+  const bookshelfView = currentUser?.serverSettings?.bookshelfView || 0 // Default to STANDARD if undefined
 
   return (
-    <LibraryProvider bookshelfView={homeBookshelfView} library={currentLibrary}>
+    <LibraryProvider homeBookshelfView={homeBookshelfView} bookshelfView={bookshelfView} library={currentLibrary}>
       <AppBar currentUser={currentUser} libraries={libraries} currentLibraryId={currentLibraryId} />
       <LibraryLayoutWrapper currentUser={currentUser}>{children}</LibraryLayoutWrapper>
     </LibraryProvider>

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -300,3 +300,13 @@ Bookshelf Label
     rgba(0, 0, 0, 0.7) 100%
   );
 }
+
+.bookshelfRow {
+  background-image: var(--bookshelf-texture-img);
+}
+
+.bookshelfDivider {
+  background: rgb(149, 119, 90);
+  background: var(--bookshelf-divider-bg);
+  box-shadow: 0.125em 0.875em 0.5em #111111aa;
+}

--- a/src/components/modals/AudioFileDataModal.tsx
+++ b/src/components/modals/AudioFileDataModal.tsx
@@ -208,7 +208,7 @@ export default function AudioFileDataModal({ isOpen, audioFile, libraryItemId, o
                 value={prettyFfprobeData}
                 readOnly
                 fillHeight
-                className={mergeClasses('text-xs font-mono flex flex-col flex-1 min-h-0')}
+                className="text-xs font-mono flex flex-col flex-1 min-h-0"
                 label={t('LabelMetaTags')}
               />
               <IconBtn

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -122,7 +122,7 @@ function DropdownSubmenu({
     <ul
       ref={submenuRef}
       role="menu"
-      className={mergeClasses('absolute bg-primary border border-dropdown-menu-border shadow-lg z-[9999] py-1 rounded-md overflow-y-auto')}
+      className="absolute bg-primary border border-dropdown-menu-border shadow-lg z-[9999] py-1 rounded-md overflow-y-auto"
       style={{
         ...floatingStyles,
         width: '192px',

--- a/src/components/ui/EditList.tsx
+++ b/src/components/ui/EditList.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { mergeClasses } from '@/lib/merge-classes'
 import { TranslationKey } from '@/types/translations'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import Modal from '../modals/Modal'
@@ -140,14 +139,14 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
   }
 
   return (
-    <div role="list" className={mergeClasses('border border-border max-w-2xl mx-auto overflow-x-scroll')}>
+    <div role="list" className="border border-border max-w-2xl mx-auto overflow-x-scroll">
       <table className="table-auto w-full">
-        <thead className={mergeClasses('w-full bg-primary/50')}>
+        <thead className="w-full bg-primary/50">
           <tr>
             <th className="text-left py-2 px-3" title="Name">
               {t('LabelName')}
             </th>
-            {showNumBooks && <th className={mergeClasses('hidden md:table-cell')}>{t('LabelBooks')}</th>}
+            {showNumBooks && <th className="hidden md:table-cell">{t('LabelBooks')}</th>}
             {/* Empty header for action col to allow background to match with of rows correctly */}
             <th></th>
           </tr>
@@ -156,11 +155,11 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
           {items.map((item) => (
             <Fragment key={item.id}>
               {item !== editedItem && (
-                <tr key={item.id} className={mergeClasses('p-2 group even:bg-primary/20')}>
+                <tr key={item.id} className="p-2 group even:bg-primary/20">
                   <td className="p-3.5">
                     {showNumBooks ? (
                       <a
-                        className={mergeClasses('text-sm md:text-base text-foreground hover:underline')}
+                        className="text-sm md:text-base text-foreground hover:underline"
                         title={item.name}
                         // Only narrators can be clicked on, tags/genres don't have library info attached.
                         // href could be made an EditListItem prop that is passed in if other pages start using this
@@ -169,18 +168,15 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
                         {item.name}
                       </a>
                     ) : (
-                      <span className={mergeClasses('text-sm md:text-base text-foreground')} title={item.name}>
+                      <span className="text-sm md:text-base text-foreground" title={item.name}>
                         {item.name}
                       </span>
                     )}
                   </td>
                   {showNumBooks && (
-                    <td className={mergeClasses('hidden md:table-cell w-1/6')}>
+                    <td className="hidden md:table-cell w-1/6">
                       <div className="flex justify-center">
-                        <a
-                          className={mergeClasses('text-sm md:text-base text-foreground hover:underline')}
-                          href={`/library/${libraryId}/items?filter=narrators.${item.id}`}
-                        >
+                        <a className="text-sm md:text-base text-foreground hover:underline" href={`/library/${libraryId}/items?filter=narrators.${item.id}`}>
                           {item.numBooks}
                         </a>
                       </div>
@@ -192,7 +188,7 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
                         size="small"
                         borderless={true}
                         onClick={() => handleEditItemClick(item)}
-                        className={mergeClasses('text-foreground-muted group-hover:text-foreground')}
+                        className="text-foreground-muted group-hover:text-foreground"
                         ariaLabel={t('ButtonEdit')}
                       >
                         {t('ButtonEdit')}
@@ -201,7 +197,7 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
                         size="small"
                         borderless={true}
                         onClick={() => handleDeleteClick(item)}
-                        className={mergeClasses('text-foreground-muted group-hover:text-foreground')}
+                        className="text-foreground-muted group-hover:text-foreground"
                         ariaLabel={t('ButtonDelete')}
                       >
                         {t('ButtonDelete')}
@@ -211,14 +207,14 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
                 </tr>
               )}
               {item === editedItem && (
-                <tr key={item.id} className={mergeClasses('p-2 group even:bg-primary/20')}>
+                <tr key={item.id} className="p-2 group even:bg-primary/20">
                   <td className="p-0.5">
                     <TextInput value={newName} onChange={setNewName} onKeyDown={handleInputKeyDown} ref={editInputRef} className="m-1 pe-5"></TextInput>
                   </td>
                   {showNumBooks && (
-                    <td className={mergeClasses('hidden md:table-cell w-1/6')}>
+                    <td className="hidden md:table-cell w-1/6">
                       <div className="flex justify-center">
-                        <a className={mergeClasses('text-sm md:text-base hover:underline')}>{item.numBooks}</a>
+                        <a className="text-sm md:text-base hover:underline">{item.numBooks}</a>
                       </div>
                     </td>
                   )}

--- a/src/components/ui/slate/Editable.tsx
+++ b/src/components/ui/slate/Editable.tsx
@@ -216,7 +216,7 @@ export const Editable = memo(({ editor, disabled, readOnly, placeholder }: Edita
   // Render a placeholder during SSR to prevent hydration mismatches
   if (!isMounted) {
     return (
-      <InputWrapper size="auto" className={mergeClasses('px-1 py-1')} readOnly={readOnly} disabled={disabled}>
+      <InputWrapper size="auto" className="px-1 py-1" readOnly={readOnly} disabled={disabled}>
         <div
           className={editableClass}
           style={{ minHeight: '104px' }} // Match the min-h-26 (26 * 4px = 104px)
@@ -226,7 +226,7 @@ export const Editable = memo(({ editor, disabled, readOnly, placeholder }: Edita
   }
 
   return (
-    <InputWrapper size="auto" className={mergeClasses('px-1 py-1')} readOnly={readOnly} disabled={disabled} inputRef={editableRef}>
+    <InputWrapper size="auto" className="px-1 py-1" readOnly={readOnly} disabled={disabled} inputRef={editableRef}>
       <SlateEditable
         ref={editableRef}
         className={editableClass}

--- a/src/components/widgets/media-card/CollectionCardSkeleton.tsx
+++ b/src/components/widgets/media-card/CollectionCardSkeleton.tsx
@@ -2,7 +2,6 @@
 
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { getCoverAspectRatio } from '@/lib/coverUtils'
-import { mergeClasses } from '@/lib/merge-classes'
 import { BookshelfView } from '@/types/api'
 import { useId, useMemo } from 'react'
 
@@ -39,12 +38,12 @@ export default function CollectionCardSkeleton({ bookshelfView, bookCoverAspectR
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses('relative rounded-xs z-30', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
+      className="relative rounded-xs z-30 focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8"
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton with two book cover effect */}
       <div
-        className={mergeClasses('relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book', 'animate-pulse')}
+        className="relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book animate-pulse"
         style={{ height: `${coverHeight}px` }}
         aria-hidden="true"
       >
@@ -69,13 +68,10 @@ export default function CollectionCardSkeleton({ bookshelfView, bookCoverAspectR
       ) : (
         // Standard view footer skeleton (shiny black placard)
         <div
-          className={mergeClasses('categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center')}
+          className="categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center"
           style={{ width: `${Math.min(200, coverWidth)}px` }}
         >
-          <div
-            className={mergeClasses('w-full h-full flex items-center justify-center rounded-xs', 'animate-pulse bg-gray-700')}
-            style={{ padding: '0em 0.5em' }}
-          >
+          <div className="w-full h-full flex items-center justify-center rounded-xs animate-pulse bg-gray-700" style={{ padding: '0em 0.5em' }}>
             {/* Title text skeleton */}
             <p className="truncate rounded bg-gray-600" style={{ fontSize: `${labelFontSize}em`, width: '60%' }}>
               &nbsp;

--- a/src/components/widgets/media-card/CollectionCardSkeleton.tsx
+++ b/src/components/widgets/media-card/CollectionCardSkeleton.tsx
@@ -39,7 +39,7 @@ export default function CollectionCardSkeleton({ bookshelfView, bookCoverAspectR
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses('relative rounded-xs z-10', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
+      className={mergeClasses('relative rounded-xs z-30', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton with two book cover effect */}
@@ -69,7 +69,7 @@ export default function CollectionCardSkeleton({ bookshelfView, bookCoverAspectR
       ) : (
         // Standard view footer skeleton (shiny black placard)
         <div
-          className={mergeClasses('categoryPlacard absolute z-10 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center')}
+          className={mergeClasses('categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center')}
           style={{ width: `${Math.min(200, coverWidth)}px` }}
         >
           <div

--- a/src/components/widgets/media-card/CollectionGroupCover.tsx
+++ b/src/components/widgets/media-card/CollectionGroupCover.tsx
@@ -2,7 +2,6 @@
 
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
-import { mergeClasses } from '@/lib/merge-classes'
 import type { LibraryItem } from '@/types/api'
 import { useMemo } from 'react'
 
@@ -65,13 +64,13 @@ export default function CollectionGroupCover({ books, width, height, bookCoverAs
         {/* First book cover */}
         <div className="relative h-full" style={{ width: `${width / 2}px` }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={getLibraryItemCoverSrc(books[0], placeholderUrl)} alt="" aria-hidden="true" className={mergeClasses('w-full h-full object-cover')} />
+          <img src={getLibraryItemCoverSrc(books[0], placeholderUrl)} alt="" aria-hidden="true" className="w-full h-full object-cover" />
         </div>
 
         {/* Second book cover */}
         <div className="relative h-full" style={{ width: `${width / 2}px` }}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={getLibraryItemCoverSrc(books[1], placeholderUrl)} alt="" aria-hidden="true" className={mergeClasses('w-full h-full object-cover')} />
+          <img src={getLibraryItemCoverSrc(books[1], placeholderUrl)} alt="" aria-hidden="true" className="w-full h-full object-cover" />
         </div>
       </div>
     </div>

--- a/src/components/widgets/media-card/MediaCardFrame.tsx
+++ b/src/components/widgets/media-card/MediaCardFrame.tsx
@@ -39,7 +39,7 @@ export default function MediaCardFrame({
       tabIndex={0}
       onKeyDown={onKeyDown}
       className={mergeClasses(
-        'relative rounded-xs z-10',
+        'relative rounded-xs z-30',
         'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-[0.5em]',
         className
       )}

--- a/src/components/widgets/media-card/MediaCardSkeleton.tsx
+++ b/src/components/widgets/media-card/MediaCardSkeleton.tsx
@@ -2,7 +2,6 @@
 
 import MediaCardDetailView from '@/components/widgets/media-card/MediaCardDetailView'
 import { useCardSize } from '@/contexts/CardSizeContext'
-import { mergeClasses } from '@/lib/merge-classes'
 import type { LibraryItem } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import { useLocale } from 'next-intl'
@@ -74,12 +73,12 @@ export default function MediaCardSkeleton({
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses('relative rounded-xs z-10 focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
+      className="relative rounded-xs z-10 focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8"
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton */}
       <div
-        className={mergeClasses('relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book', 'animate-pulse')}
+        className="relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book animate-pulse"
         style={{ height: `${coverHeight}px` }}
         aria-hidden="true"
       >

--- a/src/components/widgets/media-card/MediaCardStandardFooter.tsx
+++ b/src/components/widgets/media-card/MediaCardStandardFooter.tsx
@@ -27,7 +27,7 @@ function MediaCardStandardFooter({ displayTitle, fontSize = 0.9, width, classNam
   return (
     <div
       cy-id="standardBottomText"
-      className={mergeClasses('categoryPlacard absolute z-10 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center', className)}
+      className={mergeClasses('categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center', className)}
       style={style}
     >
       <div className="w-full h-full shinyBlack flex items-center justify-center rounded-xs border" style={{ padding: '0em 0.5em' }}>

--- a/src/components/widgets/media-card/PlaylistCardSkeleton.tsx
+++ b/src/components/widgets/media-card/PlaylistCardSkeleton.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useCardSize } from '@/contexts/CardSizeContext'
-import { mergeClasses } from '@/lib/merge-classes'
 import { BookshelfView } from '@/types/api'
 import { useId, useMemo } from 'react'
 
@@ -47,12 +46,12 @@ export default function PlaylistCardSkeleton({
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses('relative rounded-xs z-30', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
+      className="relative rounded-xs z-30 focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8"
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton with 2x2 grid effect */}
       <div
-        className={mergeClasses('relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book', 'animate-pulse')}
+        className="relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book animate-pulse"
         style={{ height: `${coverHeight}px` }}
         aria-hidden="true"
       >
@@ -81,13 +80,10 @@ export default function PlaylistCardSkeleton({
       ) : (
         // Standard view footer skeleton (shiny black placard)
         <div
-          className={mergeClasses('categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center')}
+          className="categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center"
           style={{ width: `${Math.min(200, coverWidth)}px` }}
         >
-          <div
-            className={mergeClasses('w-full h-full flex items-center justify-center rounded-xs', 'animate-pulse bg-gray-700')}
-            style={{ padding: '0em 0.5em' }}
-          >
+          <div className="w-full h-full flex items-center justify-center rounded-xs animate-pulse bg-gray-700" style={{ padding: '0em 0.5em' }}>
             {/* Title text skeleton */}
             <p className="truncate rounded bg-gray-600" style={{ fontSize: `${labelFontSize}em`, width: '60%' }}>
               &nbsp;

--- a/src/components/widgets/media-card/PlaylistCardSkeleton.tsx
+++ b/src/components/widgets/media-card/PlaylistCardSkeleton.tsx
@@ -47,43 +47,25 @@ export default function PlaylistCardSkeleton({
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses(
-        'relative rounded-xs z-10',
-        'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8'
-      )}
+      className={mergeClasses('relative rounded-xs z-30', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton with 2x2 grid effect */}
       <div
-        className={mergeClasses(
-          'relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book',
-          'animate-pulse'
-        )}
+        className={mergeClasses('relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book', 'animate-pulse')}
         style={{ height: `${coverHeight}px` }}
         aria-hidden="true"
       >
         {/* Simulated 2x2 grid of covers */}
         <div className="absolute inset-0 flex flex-wrap">
           {/* Top-left cover placeholder */}
-          <div
-            className="bg-gradient-to-br from-gray-700 to-gray-800"
-            style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
-          />
+          <div className="bg-gradient-to-br from-gray-700 to-gray-800" style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }} />
           {/* Top-right cover placeholder */}
-          <div
-            className="bg-gradient-to-br from-gray-600 to-gray-700"
-            style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
-          />
+          <div className="bg-gradient-to-br from-gray-600 to-gray-700" style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }} />
           {/* Bottom-left cover placeholder */}
-          <div
-            className="bg-gradient-to-br from-gray-600 to-gray-700"
-            style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
-          />
+          <div className="bg-gradient-to-br from-gray-600 to-gray-700" style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }} />
           {/* Bottom-right cover placeholder */}
-          <div
-            className="bg-gradient-to-br from-gray-700 to-gray-800"
-            style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }}
-          />
+          <div className="bg-gradient-to-br from-gray-700 to-gray-800" style={{ width: `${itemWidth}px`, height: `${itemHeight}px` }} />
         </div>
       </div>
 
@@ -92,26 +74,18 @@ export default function PlaylistCardSkeleton({
         // Detail view footer skeleton
         <div className="relative z-30 start-0 end-0 mx-auto py-[0.25em] rounded-md text-center">
           {/* Title skeleton */}
-          <p
-            className="truncate rounded bg-gray-600 animate-pulse mx-auto"
-            style={{ fontSize: `${labelFontSize}em`, width: '70%' }}
-          >
+          <p className="truncate rounded bg-gray-600 animate-pulse mx-auto" style={{ fontSize: `${labelFontSize}em`, width: '70%' }}>
             &nbsp;
           </p>
         </div>
       ) : (
         // Standard view footer skeleton (shiny black placard)
         <div
-          className={mergeClasses(
-            'categoryPlacard absolute z-10 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center'
-          )}
+          className={mergeClasses('categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] rounded-md text-center')}
           style={{ width: `${Math.min(200, coverWidth)}px` }}
         >
           <div
-            className={mergeClasses(
-              'w-full h-full flex items-center justify-center rounded-xs',
-              'animate-pulse bg-gray-700'
-            )}
+            className={mergeClasses('w-full h-full flex items-center justify-center rounded-xs', 'animate-pulse bg-gray-700')}
             style={{ padding: '0em 0.5em' }}
           >
             {/* Title text skeleton */}
@@ -124,4 +98,3 @@ export default function PlaylistCardSkeleton({
     </div>
   )
 }
-

--- a/src/components/widgets/media-card/SeriesCardSkeleton.tsx
+++ b/src/components/widgets/media-card/SeriesCardSkeleton.tsx
@@ -2,7 +2,6 @@
 
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { getCoverAspectRatio } from '@/lib/coverUtils'
-import { mergeClasses } from '@/lib/merge-classes'
 import { BookshelfView } from '@/types/api'
 import { useId, useMemo } from 'react'
 
@@ -40,12 +39,12 @@ export default function SeriesCardSkeleton({ bookshelfView, bookCoverAspectRatio
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses('relative rounded-xs z-30', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
+      className="relative rounded-xs z-30 focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8"
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton with stacked book effect */}
       <div
-        className={mergeClasses('relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book', 'animate-pulse')}
+        className="relative w-full rounded-sm overflow-hidden z-10 bg-primary box-shadow-book animate-pulse"
         style={{ height: `${coverHeight}px` }}
         aria-hidden="true"
       >
@@ -113,10 +112,7 @@ export default function SeriesCardSkeleton({ bookshelfView, bookCoverAspectRatio
       ) : (
         // Standard view footer skeleton (shiny black placard)
         <div className="categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] w-[12em] rounded-md text-center">
-          <div
-            className={mergeClasses('w-full h-full flex items-center justify-center rounded-xs', 'animate-pulse bg-gray-700')}
-            style={{ padding: '0em 0.5em' }}
-          >
+          <div className="w-full h-full flex items-center justify-center rounded-xs animate-pulse bg-gray-700" style={{ padding: '0em 0.5em' }}>
             {/* Title text skeleton - same structure as SeriesCard */}
             <p className="truncate rounded bg-gray-600" style={{ fontSize: `${labelFontSize}em`, width: '60%' }}>
               &nbsp;

--- a/src/components/widgets/media-card/SeriesCardSkeleton.tsx
+++ b/src/components/widgets/media-card/SeriesCardSkeleton.tsx
@@ -40,7 +40,7 @@ export default function SeriesCardSkeleton({ bookshelfView, bookCoverAspectRatio
       tabIndex={0}
       aria-busy="true"
       aria-live="polite"
-      className={mergeClasses('relative rounded-xs z-10', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
+      className={mergeClasses('relative rounded-xs z-30', 'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-8')}
       style={{ minWidth: `${coverWidth}px`, maxWidth: `${coverWidth}px` }}
     >
       {/* Cover skeleton with stacked book effect */}
@@ -112,7 +112,7 @@ export default function SeriesCardSkeleton({ bookshelfView, bookCoverAspectRatio
         </div>
       ) : (
         // Standard view footer skeleton (shiny black placard)
-        <div className="categoryPlacard absolute z-10 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] w-[12em] rounded-md text-center">
+        <div className="categoryPlacard absolute z-30 start-0 end-0 mx-auto -bottom-[1.5em] h-[1.5em] w-[12em] rounded-md text-center">
           <div
             className={mergeClasses('w-full h-full flex items-center justify-center rounded-xs', 'animate-pulse bg-gray-700')}
             style={{ padding: '0em 0.5em' }}

--- a/src/contexts/LibraryContext.tsx
+++ b/src/contexts/LibraryContext.tsx
@@ -73,6 +73,7 @@ interface LibraryContextType extends LibrarySettings {
   setContextMenuItems: (items: ContextMenuDropdownItem[]) => void
   onContextMenuAction: ((action: string) => void) | undefined
   setContextMenuActionHandler: (handler: (action: string) => void) => void
+  homeBookshelfView: BookshelfView
   bookshelfView: BookshelfView
   updateSetting: UpdateSettingFn
   toolbarExtras: React.ReactNode
@@ -87,7 +88,17 @@ interface LibraryContextType extends LibrarySettings {
 
 const LibraryContext = createContext<LibraryContextType | undefined>(undefined)
 
-export function LibraryProvider({ children, bookshelfView, library }: { children: React.ReactNode; bookshelfView: BookshelfView; library: Library }) {
+export function LibraryProvider({
+  children,
+  homeBookshelfView,
+  bookshelfView,
+  library
+}: {
+  children: React.ReactNode
+  homeBookshelfView: BookshelfView
+  bookshelfView: BookshelfView
+  library: Library
+}) {
   const [itemCount, setItemCount] = useState<number | null>(null)
   const [contextMenuItems, setContextMenuItems] = useState<ContextMenuDropdownItem[]>([])
   const [onContextMenuAction, setOnContextMenuActionState] = useState<((action: string) => void) | undefined>(undefined)
@@ -210,6 +221,7 @@ export function LibraryProvider({ children, bookshelfView, library }: { children
       setContextMenuItems,
       onContextMenuAction,
       setContextMenuActionHandler,
+      homeBookshelfView,
       bookshelfView,
       ...settings,
       updateSetting,
@@ -227,6 +239,7 @@ export function LibraryProvider({ children, bookshelfView, library }: { children
       contextMenuItems,
       onContextMenuAction,
       setContextMenuActionHandler,
+      homeBookshelfView,
       bookshelfView,
       settings,
       updateSetting,


### PR DESCRIPTION
This fixes code across `LibraryClient`, `BookshelfClient`, and their child components so that both `STANDARD` and `DETAIL` bookshelf view settings are read and rendered correctly.

Specifically, the `STANDARD` `bookshelfView` server setting now properly renders all `BookshelfClient` pages (items, series, collections, playlists, authors)