### PR TITLE
Add tracks table to book page

### DIFF
--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -4,6 +4,7 @@ import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import Btn from '@/components/ui/Btn'
 import IconBtn from '@/components/ui/IconBtn'
 import ReadIconBtn from '@/components/ui/ReadIconBtn'
+import AudioTracksTable from '@/components/widgets/AudioTracksTable'
 import ChaptersTable from '@/components/widgets/ChaptersTable'
 import ExpandableHtml from '@/components/widgets/ExpandableHtml'
 import LibraryFilesTable from '@/components/widgets/LibraryFilesTable'
@@ -131,6 +132,11 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem, cur
               {/* chapters table */}
               {libraryItem.mediaType === 'book' && (libraryItem.media.chapters?.length ?? 0) > 0 && (
                 <ChaptersTable libraryItem={libraryItem as BookLibraryItem} user={currentUser.user} />
+              )}
+
+              {/* audio tracks table */}
+              {libraryItem.mediaType === 'book' && (libraryItem.media.tracks?.length ?? 0) > 0 && (
+                <AudioTracksTable libraryItem={libraryItem as BookLibraryItem} user={currentUser.user} />
               )}
 
               {/* library files table */}

--- a/src/components/ui/ButtonBase.tsx
+++ b/src/components/ui/ButtonBase.tsx
@@ -43,7 +43,7 @@ const ButtonBase = ({
     'relative shadow-md border border-border rounded-md bg-primary flex items-center justify-center overflow-hidden',
 
     // Focus styles
-    'focus-visible:outline-1 focus-visible:outline-white/80 focus-visible:outline-offset-0',
+    'focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-0',
 
     // Size-based height (identical to InputWrapper)
     size === 'small' ? 'h-9' : size === 'large' ? 'h-11' : size === 'auto' ? 'min-h-10 h-auto' : size === 'custom' ? '' : 'h-10',

--- a/src/components/widgets/AudioTracksTable.tsx
+++ b/src/components/widgets/AudioTracksTable.tsx
@@ -141,8 +141,12 @@ export default function AudioTracksTable({ libraryItem, user, keepOpen = false, 
               className="h-6 w-6 md:h-7 md:w-7"
               onAction={({ action }) => {
                 if (action === 'download') {
-                  const url = `/api/items/${libraryItem.id}/file/${row.audioFile?.ino}/download`
-                  window.open(url, '_blank')
+                  const link = document.createElement('a')
+                  link.href = `/internal-api/items/${libraryItem.id}/file/${row.audioFile?.ino}/download`
+                  link.download = row.metadata.filename
+                  document.body.appendChild(link)
+                  link.click()
+                  document.body.removeChild(link)
                 } else if (action === 'delete') {
                   console.log('Delete track:', row.audioFile?.ino)
                 } else if (action === 'more' && row.audioFile) {

--- a/src/components/widgets/AudioTracksTable.tsx
+++ b/src/components/widgets/AudioTracksTable.tsx
@@ -140,7 +140,7 @@ export default function AudioTracksTable({ libraryItem, user, keepOpen = false, 
             />
           )
         },
-        headerClassName: 'w-16 min-w-11',
+        headerClassName: 'w-12 min-w-11',
         cellClassName: 'text-center py-1 align-middle'
       }
     ],

--- a/src/components/widgets/AudioTracksTable.tsx
+++ b/src/components/widgets/AudioTracksTable.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import Btn from '@/components/ui/Btn'
+import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
+import DataTable from '@/components/ui/DataTable'
+import CollapsibleSection from '@/components/widgets/CollapsibleSection'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { secondsToTimestamp } from '@/lib/datefns'
+import { bytesPretty } from '@/lib/string'
+import { AudioFile, AudioTrack, BookLibraryItem, User } from '@/types/api'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+interface AudioTracksTableProps {
+  libraryItem: BookLibraryItem
+  user: User
+  keepOpen?: boolean
+  expanded?: boolean
+  className?: string
+}
+
+interface TrackWithAudioFile extends AudioTrack {
+  audioFile?: AudioFile
+}
+
+export default function AudioTracksTable({ libraryItem, user, keepOpen = false, expanded: expandedProp = false, className }: AudioTracksTableProps) {
+  const t = useTypeSafeTranslations()
+  const [expanded, setExpanded] = useState(expandedProp)
+  const [showFullPath, setShowFullPath] = useState(false)
+
+  const userCanDownload = user.permissions?.download || false
+  const userCanDelete = user.permissions?.delete || false
+  const userIsAdmin = user.type === 'admin' || user.type === 'root'
+
+  // Sync expanded state with props
+  useEffect(() => {
+    setExpanded(keepOpen || expandedProp)
+  }, [keepOpen, expandedProp])
+
+  // Load showFullPath from localStorage (admin only)
+  useEffect(() => {
+    if (userIsAdmin) {
+      const saved = localStorage.getItem('showFullPath')
+      setShowFullPath(saved === '1')
+    }
+  }, [userIsAdmin])
+
+  const handleToggleFullPath = useCallback(() => {
+    setShowFullPath((prev) => {
+      const newValue = !prev
+      localStorage.setItem('showFullPath', newValue ? '1' : '0')
+      return newValue
+    })
+  }, [])
+
+  const handleShowMore = useCallback((audioFile: AudioFile) => {
+    // TODO: Show audio file data modal
+    console.log('Show more info for:', audioFile)
+  }, [])
+
+  const tracksWithAudioFile = useMemo<TrackWithAudioFile[]>(() => {
+    const tracks = libraryItem.media.tracks || []
+    const audioFiles = libraryItem.media.audioFiles || []
+
+    return tracks.map((track) => ({
+      ...track,
+      audioFile: audioFiles.find((af) => af.metadata.path === track.metadata.path)
+    }))
+  }, [libraryItem.media.tracks, libraryItem.media.audioFiles])
+
+  const columns = useMemo(
+    () => [
+      {
+        label: '#',
+        accessor: 'index' as const,
+        headerClassName: 'text-center w-10 px-2 min-w-10',
+        cellClassName: 'text-center px-2 py-1 align-middle'
+      },
+      {
+        label: t('LabelFilename'),
+        accessor: (row: TrackWithAudioFile) => <span className="break-all font-sans text-sm">{showFullPath ? row.metadata.path : row.metadata.filename}</span>,
+        headerClassName: 'text-start px-2 min-w-[200px]',
+        cellClassName: 'text-start px-2 py-1 align-middle'
+      },
+      {
+        label: t('LabelCodec'),
+        accessor: (row: TrackWithAudioFile) => row.audioFile?.codec || '',
+        headerClassName: 'text-start w-20 px-2 min-w-20',
+        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
+        hiddenBelow: 'lg' as const
+      },
+      {
+        label: t('LabelBitrate'),
+        accessor: (row: TrackWithAudioFile) => (row.audioFile?.bitRate ? bytesPretty(row.audioFile.bitRate, 0) : ''),
+        headerClassName: 'text-start w-24 px-2 min-w-24',
+        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
+        hiddenBelow: 'lg' as const
+      },
+      {
+        label: t('LabelSize'),
+        accessor: (row: TrackWithAudioFile) => bytesPretty(row.metadata.size),
+        headerClassName: 'text-start w-24 px-2 min-w-20',
+        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
+        hiddenBelow: 'md' as const
+      },
+      {
+        label: t('LabelDuration'),
+        accessor: (row: TrackWithAudioFile) => secondsToTimestamp(row.duration),
+        headerClassName: 'text-start w-24 px-2 min-w-20',
+        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
+        hiddenBelow: 'sm' as const
+      },
+      {
+        label: '',
+        accessor: (row: TrackWithAudioFile) => {
+          const items: ContextMenuDropdownItem[] = []
+          if (userCanDownload) items.push({ text: t('LabelDownload'), action: 'download' })
+          if (userCanDelete) items.push({ text: t('ButtonDelete'), action: 'delete' })
+          if (userIsAdmin && row.audioFile) items.push({ text: t('LabelMoreInfo'), action: 'more' })
+
+          if (items.length === 0) return null
+
+          return (
+            <ContextMenuDropdown
+              items={items}
+              autoWidth
+              size="small"
+              borderless
+              className="h-6 w-6 md:h-7 md:w-7"
+              onAction={({ action }) => {
+                if (action === 'download') {
+                  const url = `/api/items/${libraryItem.id}/file/${row.audioFile?.ino}/download`
+                  window.open(url, '_blank')
+                } else if (action === 'delete') {
+                  console.log('Delete track:', row.audioFile?.ino)
+                } else if (action === 'more' && row.audioFile) {
+                  handleShowMore(row.audioFile)
+                }
+              }}
+              usePortal
+            />
+          )
+        },
+        headerClassName: 'w-16 min-w-11',
+        cellClassName: 'text-center py-1 align-middle'
+      }
+    ],
+    [t, showFullPath, userCanDownload, userCanDelete, userIsAdmin, libraryItem.id, handleShowMore]
+  )
+
+  const headerActions = useMemo(() => {
+    const manageTracksBtn = user.permissions?.update ? (
+      <Btn
+        key="manage-tracks"
+        to={`/library/${libraryItem.libraryId}/item/${libraryItem.id}/tracks`}
+        color="bg-primary"
+        size="small"
+        className="me-2"
+        onClick={(e) => {
+          e.stopPropagation()
+        }}
+      >
+        {t('ButtonManageTracks')}
+      </Btn>
+    ) : null
+
+    const fullPathBtn = userIsAdmin ? (
+      <Btn
+        key="full-path"
+        color={showFullPath ? 'bg-button-selected-bg' : ''}
+        size="small"
+        className="me-2 hidden md:inline-flex"
+        onClick={(e) => {
+          e.stopPropagation()
+          handleToggleFullPath()
+        }}
+      >
+        {t('ButtonFullPath')}
+      </Btn>
+    ) : null
+
+    return (
+      <div className="flex items-center">
+        {manageTracksBtn}
+        {fullPathBtn}
+      </div>
+    )
+  }, [userIsAdmin, showFullPath, handleToggleFullPath, t, user.permissions?.update, libraryItem.id, libraryItem.libraryId])
+
+  if (tracksWithAudioFile.length === 0) {
+    return null
+  }
+
+  return (
+    <CollapsibleSection
+      title={t('LabelStatsAudioTracks')}
+      count={tracksWithAudioFile.length}
+      expanded={expanded}
+      onExpandedChange={setExpanded}
+      keepOpen={keepOpen}
+      headerActions={headerActions}
+      className={className}
+    >
+      <DataTable data={tracksWithAudioFile} columns={columns} getRowKey={(row) => row.index} />
+    </CollapsibleSection>
+  )
+}

--- a/src/components/widgets/AudioTracksTable.tsx
+++ b/src/components/widgets/AudioTracksTable.tsx
@@ -10,6 +10,19 @@ import { bytesPretty } from '@/lib/string'
 import { AudioFile, AudioTrack, BookLibraryItem, User } from '@/types/api'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
+const MIN_INDEX_WIDTH = 40
+const MIN_ACTIONS_WIDTH = 44
+const MIN_HIDEABLE_COLUMN_WIDTH = 80
+const TABLE_BORDER = 2
+const PATH_MIN_WIDTH = 300
+
+// Calculate minTableWidth for columns
+const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH + MIN_INDEX_WIDTH
+const DURATION_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
+const SIZE_MIN_TABLE_WIDTH = DURATION_MIN_TABLE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
+const BITRATE_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
+const CODEC_MIN_TABLE_WIDTH = BITRATE_MIN_TABLE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
+
 interface AudioTracksTableProps {
   libraryItem: BookLibraryItem
   user: User
@@ -78,7 +91,7 @@ export default function AudioTracksTable({ libraryItem, user, keepOpen = false, 
       {
         label: t('LabelFilename'),
         accessor: (row: TrackWithAudioFile) => <span className="break-all font-sans text-sm">{showFullPath ? row.metadata.path : row.metadata.filename}</span>,
-        headerClassName: 'text-start px-2 min-w-[200px]',
+        headerClassName: 'text-start px-2 min-w-[300px]',
         cellClassName: 'text-start px-2 py-1 align-middle'
       },
       {
@@ -86,28 +99,28 @@ export default function AudioTracksTable({ libraryItem, user, keepOpen = false, 
         accessor: (row: TrackWithAudioFile) => row.audioFile?.codec || '',
         headerClassName: 'text-start w-20 px-2 min-w-20',
         cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        hiddenBelow: 'lg' as const
+        minTableWidth: CODEC_MIN_TABLE_WIDTH
       },
       {
         label: t('LabelBitrate'),
         accessor: (row: TrackWithAudioFile) => (row.audioFile?.bitRate ? bytesPretty(row.audioFile.bitRate, 0) : ''),
-        headerClassName: 'text-start w-24 px-2 min-w-24',
+        headerClassName: 'text-start w-22 px-2 min-w-20',
         cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        hiddenBelow: 'lg' as const
+        minTableWidth: BITRATE_MIN_TABLE_WIDTH
       },
       {
         label: t('LabelSize'),
         accessor: (row: TrackWithAudioFile) => bytesPretty(row.metadata.size),
-        headerClassName: 'text-start w-24 px-2 min-w-20',
+        headerClassName: 'text-start w-22 px-2 min-w-20',
         cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        hiddenBelow: 'md' as const
+        minTableWidth: SIZE_MIN_TABLE_WIDTH
       },
       {
         label: t('LabelDuration'),
         accessor: (row: TrackWithAudioFile) => secondsToTimestamp(row.duration),
-        headerClassName: 'text-start w-24 px-2 min-w-20',
+        headerClassName: 'text-start w-22 px-2 min-w-20',
         cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        hiddenBelow: 'sm' as const
+        minTableWidth: DURATION_MIN_TABLE_WIDTH
       },
       {
         label: '',

--- a/src/components/widgets/CollapsibleSection.tsx
+++ b/src/components/widgets/CollapsibleSection.tsx
@@ -101,7 +101,7 @@ export default function CollapsibleSection({
       mergeClasses(
         'w-full bg-primary py-2 pl-4 pr-2 md:pl-6 md:pr-3 flex items-center',
         'transition-colors duration-150',
-        keepOpen ? '' : 'cursor-pointer focus-visible:outline-1 focus-visible:outline-white/80 focus-visible:outline-offset-0'
+        keepOpen ? '' : 'cursor-pointer focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-0'
       ),
     [keepOpen]
   )
@@ -152,7 +152,10 @@ export default function CollapsibleSection({
           <IconBtn
             borderless
             size="custom"
-            className={mergeClasses(iconClasses, 'cursor-pointer focus-visible:outline-1 focus-visible:outline-white/80 focus-visible:outline-offset-0')}
+            className={mergeClasses(
+              iconClasses,
+              'cursor-pointer focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-0'
+            )}
             iconClass="text-2xl md:text-3xl"
             onClick={handleToggle}
             onKeyDown={handleKeyDown}

--- a/src/components/widgets/LibraryFilesTable.tsx
+++ b/src/components/widgets/LibraryFilesTable.tsx
@@ -213,7 +213,7 @@ export default function LibraryFilesTable({ libraryItem, user, keepOpen = false,
         <Btn
           color={showFullPath ? 'bg-button-selected-bg' : ''}
           size="small"
-          className="mr-2"
+          className="mr-2 hidden md:inline-flex"
           onClick={(e) => {
             e.stopPropagation()
             toggleFullPath()

--- a/src/components/widgets/LibraryFilesTable.tsx
+++ b/src/components/widgets/LibraryFilesTable.tsx
@@ -188,7 +188,7 @@ export default function LibraryFilesTable({ libraryItem, user, keepOpen = false,
             />
           )
         },
-        headerClassName: 'w-16 min-w-11',
+        headerClassName: 'w-12 min-w-11',
         cellClassName: 'text-center py-1 align-middle'
       }
     ],

--- a/src/components/widgets/LibraryFilesTable.tsx
+++ b/src/components/widgets/LibraryFilesTable.tsx
@@ -13,6 +13,27 @@ import { AudioFile, BookLibraryItem, LibraryFile, PodcastLibraryItem, User } fro
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import ConfirmDialog from './ConfirmDialog'
 
+// Minimum widths for columns (in pixels)
+// Actions: min-w-10 = 40px (w-10 = 2.5rem = 40px)
+// Size: min-w-12 = 48px (w-12 = 3rem = 48px)
+// Type: min-w-12 = 48px (w-12 = 3rem = 48px)
+// Path: flexible, can wrap
+const MIN_ACTIONS_WIDTH = 44
+const MIN_SIZE_WIDTH = 80
+const MIN_TYPE_WIDTH = 72
+const TABLE_BORDER = 2
+const PATH_MIN_WIDTH = 300
+
+// Calculate minTableWidth for columns
+// Path is always shown (base)
+const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH
+
+// Size requires base + size width
+const SIZE_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_SIZE_WIDTH
+
+// Type requires base + size width + type width
+const TYPE_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_TYPE_WIDTH
+
 interface LibraryFileWithAudio extends LibraryFile {
   audioFile?: AudioFile
 }
@@ -115,27 +136,6 @@ export default function LibraryFilesTable({ libraryItem, user, keepOpen = false,
     [libraryItem.id]
   )
 
-  // Minimum widths for columns (in pixels)
-  // Actions: min-w-10 = 40px (w-10 = 2.5rem = 40px)
-  // Size: min-w-12 = 48px (w-12 = 3rem = 48px)
-  // Type: min-w-12 = 48px (w-12 = 3rem = 48px)
-  // Path: flexible, can wrap
-  const MIN_ACTIONS_WIDTH = 44
-  const MIN_SIZE_WIDTH = 80
-  const MIN_TYPE_WIDTH = 72
-  const TABLE_BORDER = 2
-  const PATH_MIN_WIDTH = 300
-
-  // Calculate minTableWidth for columns
-  // Path is always shown (base)
-  const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH
-
-  // Size requires base + size width
-  const SIZE_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_SIZE_WIDTH
-
-  // Type requires base + size width + type width
-  const TYPE_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_TYPE_WIDTH
-
   const columns = useMemo(
     () => [
       {
@@ -147,7 +147,7 @@ export default function LibraryFilesTable({ libraryItem, user, keepOpen = false,
       {
         label: t('LabelSize'),
         accessor: (row: LibraryFileWithAudio) => bytesPretty(row.metadata.size),
-        headerClassName: 'text-start w-24 min-w-20 px-2',
+        headerClassName: 'text-start w-22 min-w-20 px-2',
         cellClassName: 'text-start py-1 text-xs md:text-sm whitespace-nowrap px-2 align-middle',
         minTableWidth: SIZE_MIN_TABLE_WIDTH
       },
@@ -158,7 +158,7 @@ export default function LibraryFilesTable({ libraryItem, user, keepOpen = false,
             <p className="truncate">{row.fileType}</p>
           </div>
         ),
-        headerClassName: 'text-start w-24 min-w-18 px-2',
+        headerClassName: 'text-start w-22 min-w-18 px-2',
         cellClassName: 'text-start text-xs py-1 whitespace-nowrap px-2 align-middle',
         minTableWidth: TYPE_MIN_TABLE_WIDTH
       },
@@ -192,19 +192,7 @@ export default function LibraryFilesTable({ libraryItem, user, keepOpen = false,
         cellClassName: 'text-center py-1 align-middle'
       }
     ],
-    [
-      t,
-      showFullPath,
-      userCanDownload,
-      userCanDelete,
-      userIsAdmin,
-      inModal,
-      handleDeleteFile,
-      handleDownload,
-      handleShowMore,
-      SIZE_MIN_TABLE_WIDTH,
-      TYPE_MIN_TABLE_WIDTH
-    ]
+    [t, showFullPath, userCanDownload, userCanDelete, userIsAdmin, inModal, handleDeleteFile, handleDownload, handleShowMore]
   )
 
   const headerActions = useMemo(


### PR DESCRIPTION
This adds the audio tracks section to the book page, using `CollapsibleSection` and `DataTable`.

The Full Path button is also removed from the header of both Library Files and Audio Tracks on smaller screens, like in the old client.