### PR TITLE
UserContext: Refactor UserLoginResponse into client side state

### DIFF
--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -3,8 +3,9 @@
 import IconBtn from '@/components/ui/IconBtn'
 import Tooltip from '@/components/ui/Tooltip'
 import { useMediaContext } from '@/contexts/MediaContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { Library, UserLoginResponse } from '@/types/api'
+import { Library } from '@/types/api'
 import Image from 'next/image'
 import Link from 'next/link'
 import { useCallback, useState } from 'react'
@@ -15,12 +16,11 @@ import LibrariesDropdown from './LibrariesDropdown'
 interface AppBarProps {
   libraries?: Library[]
   currentLibraryId?: string
-  currentUser: UserLoginResponse
 }
 
-export default function AppBar({ libraries, currentLibraryId, currentUser }: AppBarProps) {
+export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
   const t = useTypeSafeTranslations()
-  const user = currentUser.user
+  const { user, userDefaultLibraryId } = useUser()
   const userCanUpload = user.permissions.upload
   const [isSearchMode, setIsSearchMode] = useState(false)
   // When not on a library page, use the last current library id when navigating home
@@ -37,7 +37,7 @@ export default function AppBar({ libraries, currentLibraryId, currentUser }: App
   const isAdmin = ['admin', 'root'].includes(user.type)
 
   const currentLibrary = libraries?.find((lib) => lib.id === currentLibraryId)
-  const redirectLibraryId = currentLibraryId || lastCurrentLibraryId || currentUser.userDefaultLibraryId
+  const redirectLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
   // New installs have no libraries, so redirect to settings
   const redirectUrl = redirectLibraryId ? `/library/${redirectLibraryId}` : '/settings'
 

--- a/src/app/(main)/account/layout.tsx
+++ b/src/app/(main)/account/layout.tsx
@@ -1,7 +1,4 @@
 import type { Metadata } from 'next'
-import { redirect } from 'next/navigation'
-import '../../../assets/globals.css'
-import { getCurrentUser, getData } from '../../../lib/api'
 import AppBar from '../AppBar'
 
 export const metadata: Metadata = {
@@ -10,15 +7,9 @@ export const metadata: Metadata = {
 }
 
 export default async function AccountLayout({ children }: Readonly<{ children: React.ReactNode }>) {
-  const [currentUser] = await getData(getCurrentUser())
-  if (!currentUser?.user) {
-    console.error('Error getting user data')
-    redirect(`/login`)
-  }
-
   return (
     <>
-      <AppBar currentUser={currentUser} />
+      <AppBar />
       <div className="page-bg-gradient h-[calc(100vh-4rem)]">
         <div className="w-full h-full overflow-x-hidden overflow-y-auto">{children}</div>
       </div>

--- a/src/app/(main)/components_catalog/items/page.tsx
+++ b/src/app/(main)/components_catalog/items/page.tsx
@@ -85,7 +85,7 @@ export default function ItemDetailsExamplesPage() {
   }
 
   return (
-    <LibraryProvider homeBookshelfView={0} bookshelfView={0} library={activeLibrary}>
+    <LibraryProvider library={activeLibrary}>
       <div className="p-8 w-full max-w-7xl mx-auto">
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-4">Item Details & Cover Examples</h1>

--- a/src/app/(main)/components_catalog/layout.tsx
+++ b/src/app/(main)/components_catalog/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from 'next'
-import { redirect } from 'next/navigation'
 import '../../../assets/globals.css'
 import { ComponentsCatalogProvider } from '../../../contexts/ComponentsCatalogContext'
-import { getCurrentUser, getData, getLibraries } from '../../../lib/api'
+import { getData, getLibraries } from '../../../lib/api'
 import AppBar from '../AppBar'
 
 export const metadata: Metadata = {
@@ -11,16 +10,12 @@ export const metadata: Metadata = {
 }
 
 export default async function ComponentsCatalogLayout({ children }: Readonly<{ children: React.ReactNode }>) {
-  const [currentUser, librariesRes] = await getData(getCurrentUser(), getLibraries())
-  if (!currentUser?.user) {
-    console.error('Error getting user data')
-    redirect(`/login`)
-  }
+  const [librariesRes] = await getData(getLibraries())
 
   return (
     <>
-      <AppBar currentUser={currentUser} libraries={librariesRes?.libraries} />
-      <ComponentsCatalogProvider currentUser={currentUser} libraries={librariesRes?.libraries || []}>
+      <AppBar libraries={librariesRes?.libraries} />
+      <ComponentsCatalogProvider libraries={librariesRes?.libraries || []}>
         <div className="w-full h-full max-h-screen overflow-x-hidden overflow-y-auto">{children}</div>
       </ComponentsCatalogProvider>
     </>

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -2,17 +2,28 @@ import { MediaProvider } from '@/contexts/MediaContext'
 import { MetadataProvider } from '@/contexts/MetadataContext'
 import { SocketProvider } from '@/contexts/SocketContext'
 import { TasksProvider } from '@/contexts/TasksContext'
-import { getAccessToken } from '@/lib/api'
+import { UserProvider } from '@/contexts/UserContext'
+import { getAccessToken, getCurrentUser, getData } from '@/lib/api'
+import { redirect } from 'next/navigation'
 
 export default async function MainLayout({ children }: { children: React.ReactNode }) {
   const accesstoken = await getAccessToken()
+  const [currentUser] = await getData(getCurrentUser())
+
+  if (!currentUser?.user) {
+    console.error('Error getting user data')
+    redirect(`/login`)
+  }
+
   return (
     <SocketProvider accessToken={accesstoken}>
-      <TasksProvider>
-        <MetadataProvider>
-          <MediaProvider>{children}</MediaProvider>
-        </MetadataProvider>
-      </TasksProvider>
+      <UserProvider initialUser={currentUser}>
+        <TasksProvider>
+          <MetadataProvider>
+            <MediaProvider>{children}</MediaProvider>
+          </MetadataProvider>
+        </TasksProvider>
+      </UserProvider>
     </SocketProvider>
   )
 }

--- a/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
@@ -10,9 +10,10 @@ import BookMediaCard from '@/components/widgets/media-card/BookMediaCard'
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { useLibrary } from '@/contexts/LibraryContext'
 import { useSocketEvent } from '@/contexts/SocketContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { filterEncode } from '@/lib/filterUtils'
-import { Author, BookshelfView, UserLoginResponse } from '@/types/api'
+import { Author, BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -20,12 +21,12 @@ import AuthorEditModal from '@/components/modals/AuthorEditModal'
 
 interface AuthorClientProps {
   author: Author
-  currentUser: UserLoginResponse
 }
 
-export default function AuthorClient({ author: authorProp, currentUser }: AuthorClientProps) {
+export default function AuthorClient({ author: authorProp }: AuthorClientProps) {
   const t = useTypeSafeTranslations()
   const { library, showSubtitles } = useLibrary()
+  const { user, serverSettings, ereaderDevices } = useUser()
   const { sizeMultiplier } = useCardSize()
   const router = useRouter()
 
@@ -102,16 +103,16 @@ export default function AuthorClient({ author: authorProp, currentUser }: Author
             className="!ps-0"
           >
             {libraryItems.map((libraryItem) => {
-              const mediaProgress = currentUser.user.mediaProgress.find((progress) => progress.libraryItemId === libraryItem.id)
+              const mediaProgress = user.mediaProgress.find((progress) => progress.libraryItemId === libraryItem.id)
               return (
                 <div key={libraryItem.id} className="shrink-0 mx-2e">
                   <BookMediaCard
                     libraryItem={libraryItem}
                     bookshelfView={BookshelfView.DETAIL}
-                    dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-                    timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
-                    userPermissions={currentUser.user.permissions}
-                    ereaderDevices={currentUser.ereaderDevices}
+                    dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                    timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+                    userPermissions={user.permissions}
+                    ereaderDevices={ereaderDevices}
                     showSubtitles={showSubtitles}
                     bookCoverAspectRatio={library?.settings?.coverAspectRatio ?? 1}
                     mediaProgress={mediaProgress}
@@ -136,16 +137,16 @@ export default function AuthorClient({ author: authorProp, currentUser }: Author
           <div key={bookSeries.id} className="shrink-0 -ms-2e">
             <ItemSlider title={seriesTitle} className="!ps-0">
               {bookSeries.items?.map((libraryItem) => {
-                const mediaProgress = currentUser.user.mediaProgress.find((progress) => progress.libraryItemId === libraryItem.id)
+                const mediaProgress = user.mediaProgress.find((progress) => progress.libraryItemId === libraryItem.id)
                 return (
                   <div key={libraryItem.id} className="shrink-0 mx-2e">
                     <BookMediaCard
                       libraryItem={libraryItem}
                       bookshelfView={BookshelfView.DETAIL}
-                      dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-                      timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
-                      userPermissions={currentUser.user.permissions}
-                      ereaderDevices={currentUser.ereaderDevices}
+                      dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                      timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+                      userPermissions={user.permissions}
+                      ereaderDevices={ereaderDevices}
                       showSubtitles={showSubtitles}
                       bookCoverAspectRatio={library?.settings?.coverAspectRatio ?? 1}
                       mediaProgress={mediaProgress}
@@ -158,7 +159,7 @@ export default function AuthorClient({ author: authorProp, currentUser }: Author
         )
       })}
 
-      {isEditModalOpen && <AuthorEditModal isOpen={isEditModalOpen} user={currentUser.user} author={author} onClose={() => setIsEditModalOpen(false)} />}
+      {isEditModalOpen && <AuthorEditModal isOpen={isEditModalOpen} user={user} author={author} onClose={() => setIsEditModalOpen(false)} />}
     </div>
   )
 }

--- a/src/app/(main)/library/[library]/(book)/authors/[author]/page.tsx
+++ b/src/app/(main)/library/[library]/(book)/authors/[author]/page.tsx
@@ -1,19 +1,19 @@
-import { getAuthor, getCurrentUser, getData } from '@/lib/api'
+import { getAuthor, getData } from '@/lib/api'
 import AuthorClient from './AuthorClient'
 
 export default async function AuthorPage({ params }: { params: Promise<{ author: string; library: string }> }) {
   const { author: authorId } = await params
-  const [author, currentUser] = await getData(getAuthor(authorId, 'include=items,series'), getCurrentUser())
+  const [author] = await getData(getAuthor(authorId, 'include=items,series'))
 
   // TODO: Handle loading data error?
-  if (!author || !currentUser) {
-    console.error('Error getting author or user data')
+  if (!author) {
+    console.error('Error getting author data')
     return null
   }
 
   return (
     <div className="p-8 w-full">
-      <AuthorClient author={author} currentUser={currentUser} />
+      <AuthorClient author={author} />
     </div>
   )
 }

--- a/src/app/(main)/library/[library]/(book)/series/[series]/SeriesClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/series/[series]/SeriesClient.tsx
@@ -2,16 +2,17 @@
 
 import BookMediaCard from '@/components/widgets/media-card/BookMediaCard'
 import { useLibrary } from '@/contexts/LibraryContext'
-import { BookshelfView, GetLibraryItemsResponse, UserLoginResponse } from '@/types/api'
+import { useUser } from '@/contexts/UserContext'
+import { BookshelfView, GetLibraryItemsResponse } from '@/types/api'
 
 interface SeriesClientProps {
-  currentUser: UserLoginResponse
   libraryItems: GetLibraryItemsResponse
 }
 
-export default function SeriesClient({ currentUser, libraryItems }: SeriesClientProps) {
+export default function SeriesClient({ libraryItems }: SeriesClientProps) {
   const { library } = useLibrary()
-  const userMediaProgress = currentUser.user.mediaProgress
+  const { user, serverSettings, ereaderDevices } = useUser()
+  const userMediaProgress = user.mediaProgress
   return (
     <div>
       <div className="flex flex-wrap gap-4">
@@ -22,10 +23,10 @@ export default function SeriesClient({ currentUser, libraryItems }: SeriesClient
               key={libraryItem.id}
               libraryItem={libraryItem}
               bookshelfView={BookshelfView.DETAIL}
-              dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-              timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
-              userPermissions={currentUser.user.permissions}
-              ereaderDevices={currentUser.ereaderDevices}
+              dateFormat={serverSettings.dateFormat}
+              timeFormat={serverSettings.timeFormat}
+              userPermissions={user.permissions}
+              ereaderDevices={ereaderDevices}
               showSubtitles={true}
               bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
               mediaProgress={entityProgress}

--- a/src/app/(main)/library/[library]/(book)/series/[series]/page.tsx
+++ b/src/app/(main)/library/[library]/(book)/series/[series]/page.tsx
@@ -1,22 +1,21 @@
-import { getCurrentUser, getData, getLibraryItems, getSeries } from '@/lib/api'
+import { getData, getLibraryItems, getSeries } from '@/lib/api'
 import SeriesClient from './SeriesClient'
 
 export default async function SeriesPage({ params }: { params: Promise<{ series: string; library: string }> }) {
   const { series: seriesId, library: libraryId } = await params
-  const [series, currentUser, libraryItems] = await getData(
+  const [series, libraryItems] = await getData(
     getSeries(libraryId, seriesId),
-    getCurrentUser(),
     getLibraryItems(libraryId, `filter=series.${encodeURIComponent(Buffer.from(seriesId).toString('base64'))}`)
   )
 
-  if (!series || !currentUser || !libraryItems) {
-    console.error('Error getting series or user or library items data')
+  if (!series || !libraryItems) {
+    console.error('Error getting series or library items data')
     return null
   }
 
   return (
     <div className="p-8 w-full">
-      <SeriesClient currentUser={currentUser} libraryItems={libraryItems} />
+      <SeriesClient libraryItems={libraryItems} />
     </div>
   )
 }

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -9,23 +9,24 @@ import PodcastMediaCard from '@/components/widgets/media-card/PodcastMediaCard'
 import { SeriesCard } from '@/components/widgets/media-card/SeriesCard'
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { useLibrary } from '@/contexts/LibraryContext'
-import { Author, BookshelfView, LibraryItem, MediaProgress, PersonalizedShelf, Series, UserLoginResponse } from '@/types/api'
+import { useUser } from '@/contexts/UserContext'
+import { Author, BookshelfView, LibraryItem, MediaProgress, PersonalizedShelf, Series } from '@/types/api'
 import { useEffect } from 'react'
 import LibraryEmptyState from './LibraryEmptyState'
 
 interface LibraryClientProps {
   personalized: PersonalizedShelf[]
-  currentUser: UserLoginResponse
 }
 
-export default function LibraryClient({ personalized, currentUser }: LibraryClientProps) {
+export default function LibraryClient({ personalized }: LibraryClientProps) {
   const { sizeMultiplier } = useCardSize()
+  const { user, serverSettings, ereaderDevices } = useUser()
   const { library, setContextMenuItems, setContextMenuActionHandler, homeBookshelfView, boundModal } = useLibrary()
 
   useEffect(() => {
     const items = []
 
-    if (currentUser.user.permissions.update) {
+    if (user.permissions.update) {
       items.push({
         text: 'Scan Library',
         action: 'scan'
@@ -51,14 +52,14 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
       setContextMenuItems([])
       setContextMenuActionHandler(() => {})
     }
-  }, [currentUser.user.permissions.update, setContextMenuItems, setContextMenuActionHandler])
+  }, [user.permissions.update, setContextMenuItems, setContextMenuActionHandler])
 
   return (
     <div style={{ fontSize: sizeMultiplier + 'rem' }}>
       {/* empty state with scan button if user is admin or root */}
       {personalized.length === 0 && (
         <div className="py-8">
-          <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(currentUser.user.type)} />
+          <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(user.type)} />
         </div>
       )}
 
@@ -72,17 +73,17 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
               if (shelf.type === 'book' || shelf.type === 'podcast') {
                 const EntityMediaCard = shelf.type === 'book' ? BookMediaCard : PodcastMediaCard
                 const libraryItem = entity as LibraryItem
-                const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
+                const mediaProgress = user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
 
                 return (
                   <div key={entity.id + '-' + shelf.id} className="shrink-0 mx-2e">
                     <EntityMediaCard
                       libraryItem={libraryItem}
                       bookshelfView={homeBookshelfView}
-                      dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-                      timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
-                      userPermissions={currentUser.user.permissions}
-                      ereaderDevices={currentUser.ereaderDevices}
+                      dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                      timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+                      userPermissions={user.permissions}
+                      ereaderDevices={ereaderDevices}
                       showSubtitles={true}
                       bookCoverAspectRatio={library?.settings?.coverAspectRatio ?? 1}
                       mediaProgress={mediaProgress}
@@ -94,7 +95,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                 const libraryItems = series.books || []
                 const bookProgressMap = new Map<string, MediaProgress>()
                 libraryItems.forEach((libraryItem) => {
-                  const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
+                  const mediaProgress = user.mediaProgress.find((mediaProgress) => mediaProgress.libraryItemId === libraryItem.id)
                   if (mediaProgress) {
                     bookProgressMap.set(libraryItem.id, mediaProgress)
                   }
@@ -105,7 +106,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                       series={series}
                       libraryId={library.id}
                       bookshelfView={homeBookshelfView}
-                      dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                      dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
                       bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
                       bookProgressMap={bookProgressMap}
                     />
@@ -117,16 +118,16 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                 if (!episode) {
                   return null
                 }
-                const mediaProgress = currentUser.user.mediaProgress.find((mediaProgress) => mediaProgress.mediaItemId === episode.id)
+                const mediaProgress = user.mediaProgress.find((mediaProgress) => mediaProgress.mediaItemId === episode.id)
                 return (
                   <div key={episode.id + '-' + shelf.id} className="shrink-0 mx-2e">
                     <PodcastEpisodeCard
                       libraryItem={libraryItem}
                       bookshelfView={homeBookshelfView}
-                      dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-                      timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
-                      userPermissions={currentUser.user.permissions}
-                      ereaderDevices={currentUser.ereaderDevices}
+                      dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                      timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+                      userPermissions={user.permissions}
+                      ereaderDevices={ereaderDevices}
                       showSubtitles={true}
                       bookCoverAspectRatio={library.settings?.coverAspectRatio ?? 1}
                       mediaProgress={mediaProgress}
@@ -137,7 +138,7 @@ export default function LibraryClient({ personalized, currentUser }: LibraryClie
                 const author = entity as Author
                 return (
                   <div key={author.id + '-' + shelf.id} className="shrink-0 mx-2e">
-                    <AuthorCard author={author} user={currentUser.user} />
+                    <AuthorCard author={author} user={user} />
                   </div>
                 )
               }

--- a/src/app/(main)/library/[library]/LibraryLayoutWrapper.tsx
+++ b/src/app/(main)/library/[library]/LibraryLayoutWrapper.tsx
@@ -3,8 +3,8 @@
 import CoverSizeWidget from '@/components/widgets/CoverSizeWidget'
 import { useLibrary } from '@/contexts/LibraryContext'
 import { useMediaContext } from '@/contexts/MediaContext'
+import { useUser } from '@/contexts/UserContext'
 import { mergeClasses } from '@/lib/merge-classes'
-import { UserLoginResponse } from '@/types/api'
 import { usePathname } from 'next/navigation'
 import { useEffect } from 'react'
 import SideRail from '../../SideRail'
@@ -12,14 +12,14 @@ import Toolbar from './Toolbar'
 
 interface LibraryLayoutWrapperProps {
   children: React.ReactNode
-  currentUser: UserLoginResponse
 }
 
-export default function LibraryLayoutWrapper({ children, currentUser }: LibraryLayoutWrapperProps) {
+export default function LibraryLayoutWrapper({ children }: LibraryLayoutWrapperProps) {
   const { libraryItemIdStreaming, setLastCurrentLibraryId } = useMediaContext()
+  const { Source, serverSettings } = useUser()
   const { library } = useLibrary()
-  const serverVersion = currentUser?.serverSettings?.version || 'Error'
-  const installSource = currentUser?.Source || 'Unknown'
+  const serverVersion = serverSettings?.version || 'Error'
+  const installSource = Source || 'Unknown'
   const isLibraryItemPage = usePathname().includes('/item/')
 
   useEffect(() => {

--- a/src/app/(main)/library/[library]/LibraryServer.tsx
+++ b/src/app/(main)/library/[library]/LibraryServer.tsx
@@ -1,13 +1,13 @@
-import { getCurrentUser, getData, getLibraryPersonalized } from '../../../../lib/api'
+import { getData, getLibraryPersonalized } from '../../../../lib/api'
 import LibraryClient from './LibraryClient'
 
 export default async function LibraryDataFetcher({ libraryId }: { libraryId: string }) {
-  const [personalized, currentUser] = await getData(getLibraryPersonalized(libraryId), getCurrentUser())
+  const [personalized] = await getData(getLibraryPersonalized(libraryId))
 
   if (!personalized) {
     console.error('Error getting personalized data')
     return null
   }
 
-  return <LibraryClient personalized={personalized} currentUser={currentUser} />
+  return <LibraryClient personalized={personalized} />
 }

--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -2,12 +2,13 @@
 
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { useLibrary } from '@/contexts/LibraryContext'
+import { useUser } from '@/contexts/UserContext'
 import { useBookshelfData } from '@/hooks/useBookshelfData'
 import { useBookshelfQuery } from '@/hooks/useBookshelfQuery'
 import { useBookshelfVirtualizer } from '@/hooks/useBookshelfVirtualizer'
 import { usePersistentScroll } from '@/hooks/usePersistentScroll'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { BookshelfEntity, BookshelfView, EntityType, MediaProgress, UserLoginResponse } from '@/types/api'
+import { BookshelfEntity, BookshelfView, EntityType, MediaProgress } from '@/types/api'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import LibraryEmptyState from '../LibraryEmptyState'
 import { ENTITY_CONFIGS } from './entity-config'
@@ -17,12 +18,12 @@ interface BookshelfClientProps {
   // Different APIs return different structures:
   // - items/series/collections/playlists: { results: T[], total?: number }
   // - authors: { authors: Author[], total?: number }
-  currentUser: UserLoginResponse
 }
 
-export default function BookshelfClient({ entityType, currentUser }: BookshelfClientProps) {
+export default function BookshelfClient({ entityType }: BookshelfClientProps) {
   const t = useTypeSafeTranslations()
   const { library, setItemCount, orderBy, collapseSeries, showSubtitles, seriesSortBy, updateSetting, filterBy, boundModal, bookshelfView } = useLibrary()
+  const { user } = useUser()
 
   const { query } = useBookshelfQuery(entityType)
 
@@ -186,7 +187,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
     }
   }, [hasMeasuredCard, visibleShelfStart, visibleShelfEnd, columns, totalEntities, itemsPerPage, loadPage])
 
-  const userMediaProgress = currentUser.user.mediaProgress
+  const userMediaProgress = user.mediaProgress
 
   const bookProgressMap = useMemo(() => {
     const map = new Map<string, MediaProgress>()
@@ -205,10 +206,10 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
   useEffect(() => {
     if (!config) return
     // Set up toolbar extras based on entity config
-    setToolbarExtras(config.getToolbarExtras(currentUser.user, library))
+    setToolbarExtras(config.getToolbarExtras(user, library))
 
     // Build context menu items based on entity config
-    const rawMenuItems = config.getContextMenuItems(currentUser.user, library, { showSubtitles, collapseSeries })
+    const rawMenuItems = config.getContextMenuItems(user, library, { showSubtitles, collapseSeries })
     const menuItems = rawMenuItems.map((item) => ({
       text: t(item.textKey),
       action: item.action
@@ -225,19 +226,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
       setToolbarExtras(null)
       setContextMenuItems([])
     }
-  }, [
-    entityType,
-    config,
-    setToolbarExtras,
-    setContextMenuItems,
-    setContextMenuActionHandler,
-    updateSetting,
-    library,
-    showSubtitles,
-    collapseSeries,
-    currentUser.user,
-    t
-  ])
+  }, [entityType, config, setToolbarExtras, setContextMenuItems, setContextMenuActionHandler, updateSetting, library, showSubtitles, collapseSeries, user, t])
 
   // Get empty state message based on entity config
   const getEmptyMessage = () => {
@@ -344,7 +333,6 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
                       isPodcastLibrary={isPodcastLibrary}
                       coverAspectRatio={coverAspectRatio}
                       showSubtitles={showSubtitles}
-                      currentUser={currentUser}
                       orderBy={orderBy}
                       seriesSortBy={seriesSortBy}
                       bookProgressMap={bookProgressMap}
@@ -360,7 +348,7 @@ export default function BookshelfClient({ entityType, currentUser }: BookshelfCl
           {isInitialized && !isLoading && fetchedTotal === 0 && (
             <>
               {entityType === 'items' && filterBy === 'all' ? (
-                <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(currentUser.user.type)} />
+                <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(user.type)} />
               ) : (
                 <div className="flex h-full items-center justify-center p-10">
                   <p className="text-xl">{getEmptyMessage()}</p>

--- a/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
@@ -13,20 +13,8 @@ import PodcastMediaCard from '@/components/widgets/media-card/PodcastMediaCard'
 import SeriesCard from '@/components/widgets/media-card/SeriesCard'
 import SeriesCardSkeleton from '@/components/widgets/media-card/SeriesCardSkeleton'
 import { UpdateSettingFn } from '@/contexts/LibraryContext'
-import {
-  Author,
-  BookshelfEntity,
-  BookshelfView,
-  Collection,
-  EntityType,
-  Library,
-  LibraryItem,
-  MediaProgress,
-  Playlist,
-  Series,
-  User,
-  UserLoginResponse
-} from '@/types/api'
+import { useUser } from '@/contexts/UserContext'
+import { Author, BookshelfEntity, BookshelfView, Collection, EntityType, Library, LibraryItem, MediaProgress, Playlist, Series, User } from '@/types/api'
 import { TranslationKey } from '@/types/translations'
 import React, { ReactNode } from 'react'
 
@@ -46,7 +34,6 @@ export interface CardComponentProps {
   isPodcastLibrary?: boolean
   coverAspectRatio: 0 | 1
   showSubtitles?: boolean
-  currentUser: UserLoginResponse
   orderBy?: string
   seriesSortBy?: string
   bookProgressMap: Map<string, MediaProgress>
@@ -114,7 +101,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     SkeletonComponent: ({ bookshelfView, coverAspectRatio, showSubtitles, orderBy }) => (
       <MediaCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} showSubtitles={showSubtitles} orderBy={orderBy} />
     ),
-    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, coverAspectRatio, showSubtitles, currentUser, orderBy, bookProgressMap }) => {
+    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, coverAspectRatio, showSubtitles, orderBy, bookProgressMap }) => {
+      const { user, serverSettings, ereaderDevices } = useUser()
       const item = entity as LibraryItem
       const isCollapsedSeries = !!item.collapsedSeries
       const entityProgress = isPodcastLibrary ? null : bookProgressMap.get(item.id)
@@ -131,8 +119,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
               isSelectionMode={false}
               selected={false}
               onSelect={() => {}}
-              dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-              timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
+              dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+              timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
               showSubtitles={showSubtitles ?? false}
               orderBy={orderBy ?? ''}
             />
@@ -150,10 +138,10 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             isSelectionMode={false}
             selected={false}
             onSelect={() => {}}
-            dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-            timeFormat={currentUser.serverSettings?.timeFormat ?? 'HH:mm'}
-            userPermissions={currentUser.user.permissions}
-            ereaderDevices={currentUser.ereaderDevices}
+            dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+            timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+            userPermissions={user.permissions}
+            ereaderDevices={ereaderDevices}
             showSubtitles={showSubtitles ?? false}
             orderBy={orderBy ?? ''}
           />
@@ -174,7 +162,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     SkeletonComponent: ({ bookshelfView, coverAspectRatio, seriesSortBy }) => (
       <SeriesCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} orderBy={seriesSortBy} />
     ),
-    CardComponent: ({ entity, bookshelfView, width, libraryId, coverAspectRatio, currentUser, seriesSortBy, bookProgressMap }) => {
+    CardComponent: ({ entity, bookshelfView, width, libraryId, coverAspectRatio, seriesSortBy, bookProgressMap }) => {
+      const { serverSettings } = useUser()
       const series = entity as Series
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
@@ -183,7 +172,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             libraryId={libraryId ?? ''}
             bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
-            dateFormat={currentUser.serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+            dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
             orderBy={seriesSortBy}
             bookProgressMap={bookProgressMap}
           />
@@ -212,11 +201,12 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     },
     getEmptyMessageKey: () => 'MessageNoAuthorsFound',
     SkeletonComponent: () => <AuthorCardSkeleton />,
-    CardComponent: ({ entity, width, currentUser }) => {
+    CardComponent: ({ entity, width }) => {
+      const { user } = useUser()
       const author = entity as Author
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
-          <AuthorCard author={author} user={currentUser.user} />
+          <AuthorCard author={author} user={user} />
         </div>
       )
     }
@@ -229,7 +219,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     SkeletonComponent: ({ bookshelfView, coverAspectRatio }) => (
       <CollectionCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} />
     ),
-    CardComponent: ({ entity, bookshelfView, width, coverAspectRatio, currentUser }) => {
+    CardComponent: ({ entity, bookshelfView, width, coverAspectRatio }) => {
+      const { user } = useUser()
       const collection = entity as Collection
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
@@ -237,9 +228,9 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             collection={collection}
             bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
-            userCanUpdate={currentUser.user.permissions?.update}
-            userCanDelete={currentUser.user.permissions?.delete}
-            userIsAdmin={currentUser.user.type === 'admin' || currentUser.user.type === 'root'}
+            userCanUpdate={user.permissions?.update}
+            userCanDelete={user.permissions?.delete}
+            userIsAdmin={user.type === 'admin' || user.type === 'root'}
           />
         </div>
       )
@@ -251,7 +242,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     handleContextMenuAction: () => {},
     getEmptyMessageKey: () => 'MessageNoUserPlaylists',
     SkeletonComponent: ({ bookshelfView, coverAspectRatio }) => <PlaylistCardSkeleton bookshelfView={bookshelfView} bookCoverAspectRatio={coverAspectRatio} />,
-    CardComponent: ({ entity, bookshelfView, width, coverAspectRatio, currentUser }) => {
+    CardComponent: ({ entity, bookshelfView, width, coverAspectRatio }) => {
+      const { user } = useUser()
       const playlist = entity as Playlist
       return (
         <div style={{ width: `${width}px`, flexShrink: 0 }}>
@@ -259,8 +251,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             playlist={playlist}
             bookshelfView={bookshelfView}
             bookCoverAspectRatio={coverAspectRatio}
-            userCanUpdate={currentUser.user.permissions?.update}
-            userCanDelete={currentUser.user.permissions?.delete}
+            userCanUpdate={user.permissions?.update}
+            userCanDelete={user.permissions?.delete}
           />
         </div>
       )

--- a/src/app/(main)/library/[library]/[entityType]/page.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/page.tsx
@@ -1,4 +1,3 @@
-import { getCurrentUser } from '@/lib/api'
 import { EntityType } from '@/types/api'
 
 import BookshelfClient from './BookshelfClient'
@@ -7,16 +6,9 @@ export default async function EntityPage({ params }: { params: Promise<{ library
   const { entityType: entityTypeString } = await params
   const entityType = entityTypeString as EntityType
 
-  // 1. Fetch user data
-  const currentUser = await getCurrentUser()
-
-  if (!currentUser?.user) {
-    // Check handled in layout usually, but safe to keep
-  }
-
   return (
     <div className="w-full h-full">
-      <BookshelfClient key={entityType} entityType={entityType} currentUser={currentUser} />
+      <BookshelfClient key={entityType} entityType={entityType} />
     </div>
   )
 }

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -10,19 +10,20 @@ import ExpandableHtml from '@/components/widgets/ExpandableHtml'
 import LibraryFilesTable from '@/components/widgets/LibraryFilesTable'
 import { useLibrary } from '@/contexts/LibraryContext'
 import { useMediaContext } from '@/contexts/MediaContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { BookLibraryItem, BookMetadata, PodcastLibraryItem, PodcastMetadata, UserLoginResponse } from '@/types/api'
+import { BookLibraryItem, BookMetadata, PodcastLibraryItem, PodcastMetadata } from '@/types/api'
 import { Fragment, useState } from 'react'
 import LibraryItemCover from './LibraryItemCover'
 import LibraryItemDetails from './LibraryItemDetails'
 
 interface LibraryItemClientProps {
   libraryItem: BookLibraryItem | PodcastLibraryItem
-  currentUser: UserLoginResponse
 }
 
-export default function LibraryItemClient({ libraryItem: initialLibraryItem, currentUser }: LibraryItemClientProps) {
+export default function LibraryItemClient({ libraryItem: initialLibraryItem }: LibraryItemClientProps) {
   const { library } = useLibrary()
+  const { user } = useUser()
   const { playItem } = useMediaContext()
   const t = useTypeSafeTranslations()
 
@@ -37,8 +38,8 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem, cur
   const bookSeries = 'series' in metadata ? metadata.series || [] : []
   const description = 'description' in metadata ? metadata.description : undefined
 
-  const userProgress = currentUser.user.mediaProgress.find((progress) => progress.libraryItemId === libraryItem.id)
-  const userCanUpdate = currentUser.user.permissions?.update || currentUser.user.type === 'admin' || currentUser.user.type === 'root'
+  const userProgress = user.mediaProgress.find((progress) => progress.libraryItemId === libraryItem.id)
+  const userCanUpdate = user.permissions?.update || user.type === 'admin' || user.type === 'root'
 
   // TODO: Implement play logic
   const handlePlay = () => {
@@ -131,16 +132,16 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem, cur
             <div className="mt-20 flex flex-col gap-4">
               {/* chapters table */}
               {libraryItem.mediaType === 'book' && (libraryItem.media.chapters?.length ?? 0) > 0 && (
-                <ChaptersTable libraryItem={libraryItem as BookLibraryItem} user={currentUser.user} />
+                <ChaptersTable libraryItem={libraryItem as BookLibraryItem} user={user} />
               )}
 
               {/* audio tracks table */}
               {libraryItem.mediaType === 'book' && (libraryItem.media.tracks?.length ?? 0) > 0 && (
-                <AudioTracksTable libraryItem={libraryItem as BookLibraryItem} user={currentUser.user} />
+                <AudioTracksTable libraryItem={libraryItem as BookLibraryItem} user={user} />
               )}
 
               {/* library files table */}
-              {(libraryItem.libraryFiles?.length ?? 0) > 0 && <LibraryFilesTable libraryItem={libraryItem} user={currentUser.user} />}
+              {(libraryItem.libraryFiles?.length ?? 0) > 0 && <LibraryFilesTable libraryItem={libraryItem} user={user} />}
             </div>
           </div>
         </div>

--- a/src/app/(main)/library/[library]/item/[item]/page.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/page.tsx
@@ -1,20 +1,20 @@
-import { getCurrentUser, getData, getLibraryItem } from '@/lib/api'
+import { getData, getLibraryItem } from '@/lib/api'
 import { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
 import LibraryItemClient from './LibraryItemClient'
 
 export default async function ItemPage({ params }: { params: Promise<{ item: string; library: string }> }) {
   const { item: itemId } = await params
-  const [libraryItem, currentUser] = await getData(getLibraryItem(itemId, true), getCurrentUser())
+  const [libraryItem] = await getData(getLibraryItem(itemId, true))
 
   // TODO: Handle loading data error?
-  if (!libraryItem || !currentUser) {
-    console.error('Error getting library item or user data')
+  if (!libraryItem) {
+    console.error('Error getting library item')
     return null
   }
 
   return (
     <div className="p-8 w-full">
-      <LibraryItemClient libraryItem={libraryItem as BookLibraryItem | PodcastLibraryItem} currentUser={currentUser} />
+      <LibraryItemClient libraryItem={libraryItem as BookLibraryItem | PodcastLibraryItem} />
     </div>
   )
 }

--- a/src/app/(main)/library/[library]/layout.tsx
+++ b/src/app/(main)/library/[library]/layout.tsx
@@ -1,8 +1,7 @@
 import { LibraryProvider } from '@/contexts/LibraryContext'
 import type { Metadata } from 'next'
 import { redirect } from 'next/navigation'
-import '../../../../assets/globals.css'
-import { getCurrentUser, getData, getLibraries } from '../../../../lib/api'
+import { getData, getLibraries } from '../../../../lib/api'
 import AppBar from '../../AppBar'
 import LibraryLayoutWrapper from './LibraryLayoutWrapper'
 
@@ -20,12 +19,7 @@ export default async function LibraryLayout({
 }>) {
   const { library: currentLibraryId } = await params
 
-  const [librariesResponse, currentUser] = await getData(getLibraries(), getCurrentUser())
-
-  if (!currentUser?.user) {
-    console.error('Error getting user data')
-    redirect(`/login`)
-  }
+  const [librariesResponse] = await getData(getLibraries())
 
   const libraries = librariesResponse?.libraries || []
   const currentLibrary = libraries.find((library) => library.id === currentLibraryId)
@@ -34,13 +28,10 @@ export default async function LibraryLayout({
     redirect(`/`)
   }
 
-  const homeBookshelfView = currentUser?.serverSettings?.homeBookshelfView || 0 // Default to STANDARD if undefined
-  const bookshelfView = currentUser?.serverSettings?.bookshelfView || 0 // Default to STANDARD if undefined
-
   return (
-    <LibraryProvider homeBookshelfView={homeBookshelfView} bookshelfView={bookshelfView} library={currentLibrary}>
-      <AppBar currentUser={currentUser} libraries={libraries} currentLibraryId={currentLibraryId} />
-      <LibraryLayoutWrapper currentUser={currentUser}>{children}</LibraryLayoutWrapper>
+    <LibraryProvider library={currentLibrary}>
+      <AppBar libraries={libraries} currentLibraryId={currentLibraryId} />
+      <LibraryLayoutWrapper>{children}</LibraryLayoutWrapper>
     </LibraryProvider>
   )
 }

--- a/src/app/(main)/settings/SettingsLayoutWrapper.tsx
+++ b/src/app/(main)/settings/SettingsLayoutWrapper.tsx
@@ -1,20 +1,20 @@
 'use client'
 
 import { useMediaContext } from '@/contexts/MediaContext'
+import { useUser } from '@/contexts/UserContext'
 import { mergeClasses } from '@/lib/merge-classes'
-import { UserLoginResponse } from '@/types/api'
 import SideNav from './SideNav'
 import SideNavMobileDrawer from './SideNavMobileDrawer'
 
 interface SettingsLayoutWrapperProps {
   children: React.ReactNode
-  currentUser: UserLoginResponse
 }
 
-export default function SettingsLayoutWrapper({ children, currentUser }: SettingsLayoutWrapperProps) {
+export default function SettingsLayoutWrapper({ children }: SettingsLayoutWrapperProps) {
   const { libraryItemIdStreaming } = useMediaContext()
-  const installSource = currentUser?.Source || 'Unknown'
-  const serverVersion = currentUser?.serverSettings?.version || 'Error'
+  const { Source, serverSettings } = useUser()
+  const installSource = Source || 'Unknown'
+  const serverVersion = serverSettings?.version || 'Error'
 
   return (
     <div className={mergeClasses('flex page-wrapper overflow-x-hidden', libraryItemIdStreaming ? 'streaming' : '')}>

--- a/src/app/(main)/settings/api-keys/ApiKeysClient.tsx
+++ b/src/app/(main)/settings/api-keys/ApiKeysClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { ApiKey, User, UserLoginResponse } from '@/types/api'
+import { ApiKey, User } from '@/types/api'
 import { useCallback, useState } from 'react'
 import SettingsContent from '../SettingsContent'
 import { createApiKey, updateApiKey } from './actions'
@@ -11,11 +11,10 @@ import NewApiKeyModal from './NewApiKeyModal'
 
 interface ApiKeysClientProps {
   apiKeys: ApiKey[]
-  currentUser: UserLoginResponse
   users: User[]
 }
 
-export default function ApiKeysClient({ apiKeys, currentUser, users }: ApiKeysClientProps) {
+export default function ApiKeysClient({ apiKeys, users }: ApiKeysClientProps) {
   const t = useTypeSafeTranslations()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [editingApiKey, setEditingApiKey] = useState<ApiKey | null>(null)
@@ -72,7 +71,7 @@ export default function ApiKeysClient({ apiKeys, currentUser, users }: ApiKeysCl
         onClick: handleAddClick
       }}
     >
-      <ApiKeysTable apiKeys={apiKeys} currentUser={currentUser} onEditClick={handleEditClick} />
+      <ApiKeysTable apiKeys={apiKeys} onEditClick={handleEditClick} />
 
       <EditApiKeyModal isOpen={isModalOpen} apiKey={editingApiKey} users={users} onClose={handleCloseModal} onSubmit={handleSubmit} />
 

--- a/src/app/(main)/settings/api-keys/ApiKeysTable.tsx
+++ b/src/app/(main)/settings/api-keys/ApiKeysTable.tsx
@@ -4,25 +4,25 @@ import DataTable, { DataTableColumn } from '@/components/ui/DataTable'
 import IconBtn from '@/components/ui/IconBtn'
 import Tooltip from '@/components/ui/Tooltip'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatJsDate, formatJsDatetime } from '@/lib/datefns'
-import { ApiKey, UserLoginResponse } from '@/types/api'
+import { ApiKey } from '@/types/api'
 import Link from 'next/link'
 import { useCallback, useRef, useState } from 'react'
 import { deleteApiKey } from './actions'
 
 interface ApiKeysTableProps {
   apiKeys: ApiKey[]
-  currentUser: UserLoginResponse
   onEditClick: (apiKey: ApiKey) => void
 }
 
-export default function ApiKeysTable({ apiKeys, currentUser, onEditClick }: ApiKeysTableProps) {
+export default function ApiKeysTable({ apiKeys, onEditClick }: ApiKeysTableProps) {
   const t = useTypeSafeTranslations()
+  const { serverSettings } = useUser()
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [deletingApiKeyId, setDeletingApiKeyId] = useState<string | null>(null)
   const deletingApiKeyRef = useRef<ApiKey | null>(null)
-  const serverSettings = currentUser.serverSettings
   const dateFormat = serverSettings.dateFormat
   const timeFormat = serverSettings.timeFormat
 

--- a/src/app/(main)/settings/api-keys/page.tsx
+++ b/src/app/(main)/settings/api-keys/page.tsx
@@ -1,12 +1,12 @@
-import { getApiKeys, getCurrentUser, getData, getUsers } from '@/lib/api'
+import { getApiKeys, getData, getUsers } from '@/lib/api'
 import ApiKeysClient from './ApiKeysClient'
 
 export const dynamic = 'force-dynamic'
 
 export default async function ApiKeysPage() {
-  const [apiKeysResponse, currentUser, usersResponse] = await getData(getApiKeys(), getCurrentUser(), getUsers())
+  const [apiKeysResponse, usersResponse] = await getData(getApiKeys(), getUsers())
   const apiKeys = apiKeysResponse?.apiKeys || []
   const users = usersResponse?.users || []
 
-  return <ApiKeysClient apiKeys={apiKeys} currentUser={currentUser} users={users} />
+  return <ApiKeysClient apiKeys={apiKeys} users={users} />
 }

--- a/src/app/(main)/settings/backups/BackupsClient.tsx
+++ b/src/app/(main)/settings/backups/BackupsClient.tsx
@@ -7,10 +7,11 @@ import TextInput from '@/components/ui/TextInput'
 import Tooltip from '@/components/ui/Tooltip'
 import CronExpressionPreview from '@/components/widgets/CronExpressionPreview'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatJsDatetime } from '@/lib/datefns'
 import { bytesPretty } from '@/lib/string'
-import { Backup, GetBackupsResponse, ServerSettings, UserLoginResponse } from '@/types/api'
+import { Backup, GetBackupsResponse, ServerSettings } from '@/types/api'
 import { useMemo, useState, useTransition } from 'react'
 import { UpdateServerSettingsApiResponse } from '../actions'
 import SettingsContent from '../SettingsContent'
@@ -20,19 +21,18 @@ import BackupScheduleModal from './BackupScheduleModal'
 
 interface BackupsClientProps {
   backupResponse: GetBackupsResponse
-  currentUser: UserLoginResponse
   updateServerSettings: (settingsUpdatePayload: Partial<ServerSettings>) => Promise<UpdateServerSettingsApiResponse>
 }
 
-export default function BackupsClient({ backupResponse, currentUser, updateServerSettings }: BackupsClientProps) {
+export default function BackupsClient({ backupResponse, updateServerSettings }: BackupsClientProps) {
   const t = useTypeSafeTranslations()
   const [isPending, startTransition] = useTransition()
   const [previousCronExpress, setPreviousCronExpress] = useState<string | false>()
   const [isBackupScheduleModalOpen, setIsBackupScheduleModalOpen] = useState(false)
   const { showToast } = useGlobalToast()
+  const { serverSettings } = useUser()
 
   const backups = backupResponse.backups
-  const serverSettings = currentUser.serverSettings
   const dateFormat = serverSettings.dateFormat
   const timeFormat = serverSettings.timeFormat
 
@@ -171,12 +171,8 @@ export default function BackupsClient({ backupResponse, currentUser, updateServe
         </div>
 
         <div className="mb-4 mt-8 flex justify-between">
-          <Btn onClick={() => {}}>
-            {t('ButtonUploadBackup')}
-          </Btn>
-          <Btn onClick={() => {}}>
-            {t('ButtonCreateBackup')}
-          </Btn>
+          <Btn onClick={() => {}}>{t('ButtonUploadBackup')}</Btn>
+          <Btn onClick={() => {}}>{t('ButtonCreateBackup')}</Btn>
         </div>
 
         {/* backups table */}
@@ -185,7 +181,6 @@ export default function BackupsClient({ backupResponse, currentUser, updateServe
         ) : (
           <p className="text-center text-lg text-foreground py-4">{t('MessageNoBackups')}</p>
         )}
-
       </div>
       <BackupScheduleModal
         isOpen={isBackupScheduleModalOpen}

--- a/src/app/(main)/settings/backups/page.tsx
+++ b/src/app/(main)/settings/backups/page.tsx
@@ -1,15 +1,15 @@
-import { getBackups, getCurrentUser, getData } from '@/lib/api'
+import { getBackups, getData } from '@/lib/api'
 import { updateServerSettings } from '../actions'
 import BackupsClient from './BackupsClient'
 
 export const dynamic = 'force-dynamic'
 
 export default async function BackupsPage() {
-  const [backupsResponse, currentUser] = await getData(getBackups(), getCurrentUser())
+  const [backupsResponse] = await getData(getBackups())
 
   if (!backupsResponse) {
     return <div>Error loading backups</div>
   }
 
-  return <BackupsClient backupResponse={backupsResponse} currentUser={currentUser} updateServerSettings={updateServerSettings} />
+  return <BackupsClient backupResponse={backupsResponse} updateServerSettings={updateServerSettings} />
 }

--- a/src/app/(main)/settings/layout.tsx
+++ b/src/app/(main)/settings/layout.tsx
@@ -25,8 +25,8 @@ export default async function SettingsLayout({ children }: Readonly<{ children: 
 
   return (
     <SettingsDrawerProvider>
-      <AppBar currentUser={currentUser} />
-      <SettingsLayoutWrapper currentUser={currentUser}>{children}</SettingsLayoutWrapper>
+      <AppBar />
+      <SettingsLayoutWrapper>{children}</SettingsLayoutWrapper>
     </SettingsDrawerProvider>
   )
 }

--- a/src/app/(main)/settings/rss-feeds/RssFeedsClient.tsx
+++ b/src/app/(main)/settings/rss-feeds/RssFeedsClient.tsx
@@ -1,20 +1,19 @@
 'use client'
 
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { RssFeed, UserLoginResponse } from '@/types/api'
+import { RssFeed } from '@/types/api'
 import SettingsContent from '../SettingsContent'
 import RssFeedsTable from './RssFeedsTable'
 
 interface RssFeedsClientProps {
   rssFeeds: RssFeed[]
-  currentUser: UserLoginResponse
 }
 
-export default function RssFeedsClient({ rssFeeds, currentUser }: RssFeedsClientProps) {
+export default function RssFeedsClient({ rssFeeds }: RssFeedsClientProps) {
   const t = useTypeSafeTranslations()
   return (
     <SettingsContent title={t('HeaderRSSFeeds')} moreInfoUrl="https://www.audiobookshelf.org/guides/rss_feeds">
-      <RssFeedsTable currentUser={currentUser} rssFeeds={rssFeeds} />
+      <RssFeedsTable rssFeeds={rssFeeds} />
     </SettingsContent>
   )
 }

--- a/src/app/(main)/settings/rss-feeds/RssFeedsTable.tsx
+++ b/src/app/(main)/settings/rss-feeds/RssFeedsTable.tsx
@@ -5,30 +5,30 @@ import IconBtn from '@/components/ui/IconBtn'
 import Tooltip from '@/components/ui/Tooltip'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatJsDate, formatJsDatetime } from '@/lib/datefns'
-import { RssFeed, UserLoginResponse } from '@/types/api'
+import { RssFeed } from '@/types/api'
 import { useCallback, useRef, useState } from 'react'
 import { closeRssFeed } from './actions'
 import RssFeedModal from './RssFeedModal'
 
 interface RssFeedsTableProps {
   rssFeeds: RssFeed[]
-  currentUser: UserLoginResponse
 }
 
-export default function RssFeedsTable({ rssFeeds: initialFeeds, currentUser }: RssFeedsTableProps) {
+export default function RssFeedsTable({ rssFeeds: initialFeeds }: RssFeedsTableProps) {
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
   const [rssFeeds, setRssFeeds] = useState(initialFeeds)
   const [selectedFeed, setSelectedFeed] = useState<RssFeed | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+  const { serverSettings } = useUser()
   const [closingFeedId, setClosingFeedId] = useState<string | null>(null)
   const closingFeedRef = useRef<RssFeed | null>(null)
-  const serverSettings = currentUser.serverSettings
-  const dateFormat = serverSettings.dateFormat
-  const timeFormat = serverSettings.timeFormat
+  const dateFormat = serverSettings?.dateFormat
+  const timeFormat = serverSettings?.timeFormat
 
   const handleCloseClick = useCallback((rssFeed: RssFeed) => {
     closingFeedRef.current = rssFeed

--- a/src/app/(main)/settings/rss-feeds/page.tsx
+++ b/src/app/(main)/settings/rss-feeds/page.tsx
@@ -1,11 +1,11 @@
-import { getCurrentUser, getData, getRssFeeds } from '@/lib/api'
+import { getData, getRssFeeds } from '@/lib/api'
 import RssFeedsClient from './RssFeedsClient'
 
 export const dynamic = 'force-dynamic'
 
 export default async function RssFeedsPage() {
-  const [rssFeedsResponse, currentUser] = await getData(getRssFeeds(), getCurrentUser())
+  const [rssFeedsResponse] = await getData(getRssFeeds())
   const rssFeeds = rssFeedsResponse?.feeds || []
 
-  return <RssFeedsClient currentUser={currentUser} rssFeeds={rssFeeds} />
+  return <RssFeedsClient rssFeeds={rssFeeds} />
 }

--- a/src/app/(main)/settings/users/UsersClient.tsx
+++ b/src/app/(main)/settings/users/UsersClient.tsx
@@ -1,20 +1,20 @@
 'use client'
 
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { ServerSettings, User, UserLoginResponse } from '@/types/api'
+import { User } from '@/types/api'
 import { useState } from 'react'
 import SettingsContent from '../SettingsContent'
 import UserAccountModal, { UserFormData } from './UserAccountModal'
 import UsersTable from './UsersTable'
 
 interface UsersClientProps {
-  currentUser: UserLoginResponse
   users: User[]
-  serverSettings: ServerSettings
 }
 
-export default function UsersClient({ currentUser, users, serverSettings }: UsersClientProps) {
+export default function UsersClient({ users }: UsersClientProps) {
   const t = useTypeSafeTranslations()
+  const { serverSettings } = useUser()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [editingUser, setEditingUser] = useState<User | null>(null)
 
@@ -54,13 +54,7 @@ export default function UsersClient({ currentUser, users, serverSettings }: User
           onClick: handleAddUser
         }}
       >
-        <UsersTable
-          currentUser={currentUser}
-          users={users}
-          dateFormat={serverSettings.dateFormat}
-          timeFormat={serverSettings.timeFormat}
-          onEditUser={handleEditUser}
-        />
+        <UsersTable users={users} dateFormat={serverSettings.dateFormat} timeFormat={serverSettings.timeFormat} onEditUser={handleEditUser} />
       </SettingsContent>
 
       <UserAccountModal isOpen={isModalOpen} user={editingUser} onClose={handleCloseModal} onSubmit={handleSubmit} onUnlinkOpenId={handleUnlinkOpenId} />

--- a/src/app/(main)/settings/users/UsersTable.tsx
+++ b/src/app/(main)/settings/users/UsersTable.tsx
@@ -6,30 +6,31 @@ import Tooltip from '@/components/ui/Tooltip'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import OnlineIndicator from '@/components/widgets/OnlineIndicator'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatJsDate, formatJsDatetime } from '@/lib/datefns'
-import { DeviceInfo, User, UserLoginResponse } from '@/types/api'
+import { DeviceInfo, User } from '@/types/api'
 import { formatDistanceToNow } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import { useCallback, useRef, useState } from 'react'
 import { deleteUser } from './actions'
 
 interface UsersTableProps {
-  currentUser: UserLoginResponse
   users: User[]
   dateFormat: string
   timeFormat: string
   onEditUser: (user: User) => void
 }
 
-export default function UsersTable({ currentUser, users, dateFormat, timeFormat, onEditUser }: UsersTableProps) {
+export default function UsersTable({ users, dateFormat, timeFormat, onEditUser }: UsersTableProps) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const { showToast } = useGlobalToast()
+  const { user } = useUser()
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const [deletingUserId, setDeletingUserId] = useState<string | null>(null)
   const deletingUserRef = useRef<User | null>(null)
-  const currentUserId = currentUser.user.id
+  const currentUserId = user.id
 
   const handleDeleteClick = useCallback((user: User) => {
     deletingUserRef.current = user

--- a/src/app/(main)/settings/users/page.tsx
+++ b/src/app/(main)/settings/users/page.tsx
@@ -1,11 +1,11 @@
-import { getCurrentUser, getData, getUsers } from '../../../../lib/api'
+import { getData, getUsers } from '../../../../lib/api'
 import UsersClient from './UsersClient'
 
 export const dynamic = 'force-dynamic'
 
 export default async function UsersPage() {
-  const [usersResponse, currentUser] = await getData(getUsers('include=latestSession'), getCurrentUser())
+  const [usersResponse] = await getData(getUsers('include=latestSession'))
   const users = usersResponse?.users || []
 
-  return <UsersClient currentUser={currentUser} users={users} serverSettings={currentUser.serverSettings} />
+  return <UsersClient users={users} />
 }

--- a/src/app/(main)/upload/layout.tsx
+++ b/src/app/(main)/upload/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next'
-import { redirect } from 'next/navigation'
 import '../../../assets/globals.css'
-import { getCurrentUser, getData } from '../../../lib/api'
 import AppBar from '../AppBar'
 import UploadLayoutWrapper from './UploadLayoutWrapper'
 
@@ -15,16 +13,9 @@ export default async function UploadLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const [currentUser] = await getData(getCurrentUser())
-
-  if (!currentUser?.user) {
-    console.error('Error getting user data')
-    redirect(`/login`)
-  }
-
   return (
     <>
-      <AppBar currentUser={currentUser} />
+      <AppBar />
       <UploadLayoutWrapper>{children}</UploadLayoutWrapper>
     </>
   )

--- a/src/contexts/ComponentsCatalogContext.tsx
+++ b/src/contexts/ComponentsCatalogContext.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { Library, User, UserLoginResponse } from '@/types/api'
-import React, { createContext, ReactNode, useContext } from 'react'
+import { useUser } from '@/contexts/UserContext'
+import { Library, User } from '@/types/api'
+import { createContext, ReactNode, useContext } from 'react'
 
 interface ComponentsCatalogContextType {
   user: User
@@ -13,13 +14,14 @@ const ComponentsCatalogContext = createContext<ComponentsCatalogContextType | un
 
 interface ComponentsCatalogProviderProps {
   children: ReactNode
-  currentUser: UserLoginResponse
   libraries: Library[]
 }
 
-export const ComponentsCatalogProvider: React.FC<ComponentsCatalogProviderProps> = ({ children, currentUser, libraries }) => {
+export function ComponentsCatalogProvider({ children, libraries }: ComponentsCatalogProviderProps) {
+  const { user } = useUser()
+
   const value: ComponentsCatalogContextType = {
-    user: currentUser.user,
+    user,
     libraries,
     bookCoverAspectRatio: 1
   }

--- a/src/contexts/LibraryContext.tsx
+++ b/src/contexts/LibraryContext.tsx
@@ -2,6 +2,7 @@
 
 import { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
 import { useSocketEvent } from '@/contexts/SocketContext'
+import { useUser } from '@/contexts/UserContext'
 import { useFilterData } from '@/hooks/useFilterData'
 import { BookshelfView, Library, LibraryFilterData, LibraryItem } from '@/types/api'
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
@@ -88,17 +89,7 @@ interface LibraryContextType extends LibrarySettings {
 
 const LibraryContext = createContext<LibraryContextType | undefined>(undefined)
 
-export function LibraryProvider({
-  children,
-  homeBookshelfView,
-  bookshelfView,
-  library
-}: {
-  children: React.ReactNode
-  homeBookshelfView: BookshelfView
-  bookshelfView: BookshelfView
-  library: Library
-}) {
+export function LibraryProvider({ children, library }: { children: React.ReactNode; library: Library }) {
   const [itemCount, setItemCount] = useState<number | null>(null)
   const [contextMenuItems, setContextMenuItems] = useState<ContextMenuDropdownItem[]>([])
   const [onContextMenuAction, setOnContextMenuActionState] = useState<((action: string) => void) | undefined>(undefined)
@@ -106,6 +97,10 @@ export function LibraryProvider({
   const [toolbarExtras, setToolbarExtras] = useState<React.ReactNode>(null)
   const [boundModal, setBoundModal] = useState<React.ReactNode | null>(null)
   const [isSettingsLoaded, setIsSettingsLoaded] = useState(false)
+
+  const { serverSettings } = useUser()
+  const homeBookshelfView = serverSettings?.homeBookshelfView || 0
+  const bookshelfView = serverSettings?.bookshelfView || 0
 
   // Filter data hook
   const { filterData, isLoading: filterDataLoading, updateFilterDataWithItem, removeSeriesFromFilterData } = useFilterData(library.id)

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -19,13 +19,15 @@ export function UserProvider({ children, initialUser }: { children: ReactNode; i
   const [currentUserData, setCurrentUserData] = useState<UserLoginResponse>(initialUser)
 
   useSocketEvent<User>('user_updated', (updatedUser) => {
-    setCurrentUserData((prev) => ({
-      ...prev,
-      user: updatedUser
-    }))
+    if (updatedUser.id === currentUserData.user.id) {
+      setCurrentUserData((prev) => ({
+        ...prev,
+        user: updatedUser
+      }))
+    }
   })
 
-  // To capture if initialUser changes from server refresh (optional, but good practice in Next.js)
+  // To capture if initialUser changes from server refresh
   useEffect(() => {
     setCurrentUserData(initialUser)
   }, [initialUser])

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { EReaderDevice, ServerSettings, User, UserLoginResponse } from '@/types/api'
+import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { useSocketEvent } from './SocketContext'
+
+interface UserContextType {
+  user: User
+  token: string
+  serverSettings: ServerSettings
+  userDefaultLibraryId?: string
+  ereaderDevices: EReaderDevice[]
+  Source: string
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined)
+
+export function UserProvider({ children, initialUser }: { children: ReactNode; initialUser: UserLoginResponse }) {
+  const [currentUserData, setCurrentUserData] = useState<UserLoginResponse>(initialUser)
+
+  useSocketEvent<User>('user_updated', (updatedUser) => {
+    setCurrentUserData((prev) => ({
+      ...prev,
+      user: updatedUser
+    }))
+  })
+
+  // To capture if initialUser changes from server refresh (optional, but good practice in Next.js)
+  useEffect(() => {
+    setCurrentUserData(initialUser)
+  }, [initialUser])
+
+  const contextValue: UserContextType = {
+    user: currentUserData.user,
+    token: currentUserData.user.token,
+    serverSettings: currentUserData.serverSettings,
+    userDefaultLibraryId: currentUserData.userDefaultLibraryId,
+    ereaderDevices: currentUserData.ereaderDevices,
+    Source: currentUserData.Source
+  }
+
+  return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>
+}
+
+export function useUser() {
+  const context = useContext(UserContext)
+  if (context === undefined) {
+    throw new Error('useUser must be used within a UserProvider')
+  }
+  return context
+}


### PR DESCRIPTION
This change refactors `UserLoginResponse`, returned by the `getCurrentUser` api call to be kept as a client-side state in a new context `UserContext`.

The refactor was performed to make it possible for the user state to be updated on the client without requiring server refresh, including via websocket events such as `user_updated`.

**Notes**:
- Now the various fields comprising `UserLoginResponse` can be returned separately by deconstructing the `useUser` response object.
- I added a `getCurrentUser` call to `MainLayout`, passing its return value to a `LibraryProvider`
- I removed `getCurrentUser' from **most** other layouts/pages, excluding a few places where it's required for some specific server-side check (but it's OK to have it called twice in the same request since it's cached)
- I replaced `currentUser` props on main client side components with `useUser()` calls that grab the required fields from the context
  - We can reduce `currentUser` prop-drilling even further if we choose to - I didn't bother with that right now.