### PR TITLE
Implement media item share

### DIFF
--- a/src/app/(main)/components_catalog/examples/media-card/BookMediaCardExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/media-card/BookMediaCardExamples.tsx
@@ -515,7 +515,25 @@ export function BookMediaCardExamples({ selectedBook }: BookMediaCardExamplesPro
                         slug: 'example-book-feed',
                         entityId: selectedBook.id,
                         entityType: 'book',
+                        entityUpdatedAt: Date.now(),
+                        coverPath: selectedBook.media.coverPath ?? '',
                         feedUrl: 'https://example.com/book-feed.xml',
+                        serverAddress: 'https://example.com',
+                        userId: user.id,
+                        meta: {
+                          author: selectedBook.media.metadata.authorName ?? 'Unknown Author',
+                          description: selectedBook.media.metadata.description ?? '',
+                          explicit: false,
+                          feedUrl: 'https://example.com/book-feed.xml',
+                          imageUrl: '',
+                          language: selectedBook.media.metadata.language ?? 'en',
+                          link: 'https://example.com',
+                          ownerEmail: null,
+                          ownerName: null,
+                          preventIndexing: false,
+                          title: selectedBook.media.metadata.title,
+                          type: 'serial'
+                        },
                         createdAt: Date.now(),
                         updatedAt: Date.now()
                       },
@@ -523,10 +541,11 @@ export function BookMediaCardExamples({ selectedBook }: BookMediaCardExamplesPro
                         id: 'share-book-123',
                         mediaItemId: selectedBook.id,
                         mediaItemType: 'book',
-                        userId: user.id,
                         slug: 'example-book-share',
-                        createdAt: Date.now(),
-                        updatedAt: Date.now()
+                        expiresAt: null,
+                        createdAt: new Date().toISOString(),
+                        updatedAt: new Date().toISOString(),
+                        isDownloadable: true
                       }
                     } as BookLibraryItem
                   }

--- a/src/app/(main)/components_catalog/examples/media-card/PodcastMediaCardExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/media-card/PodcastMediaCardExamples.tsx
@@ -321,18 +321,37 @@ export function PodcastMediaCardExamples({ selectedPodcast }: PodcastMediaCardEx
                         slug: 'example-podcast-feed',
                         entityId: selectedPodcast.id,
                         entityType: 'podcast',
+                        entityUpdatedAt: Date.now(),
+                        coverPath: selectedPodcast.media.coverPath ?? '',
                         feedUrl: 'https://example.com/feed.xml',
+                        serverAddress: 'https://example.com',
+                        userId: user.id,
+                        meta: {
+                          author: selectedPodcast.media.metadata.author ?? 'Unknown Author',
+                          description: selectedPodcast.media.metadata.description ?? '',
+                          explicit: false,
+                          feedUrl: 'https://example.com/feed.xml',
+                          imageUrl: '',
+                          language: selectedPodcast.media.metadata.language ?? 'en',
+                          link: 'https://example.com',
+                          ownerEmail: null,
+                          ownerName: null,
+                          preventIndexing: false,
+                          title: selectedPodcast.media.metadata.title,
+                          type: 'episodic'
+                        },
                         createdAt: Date.now(),
                         updatedAt: Date.now()
                       },
                       mediaItemShare: {
                         id: 'share-123',
-                        mediaItemId: selectedPodcast.id,
-                        mediaItemType: 'book',
-                        userId: user.id,
+                        mediaItemId: 'episode-123',
+                        mediaItemType: 'podcastEpisode',
                         slug: 'example-podcast-share',
-                        createdAt: Date.now(),
-                        updatedAt: Date.now()
+                        expiresAt: null,
+                        createdAt: new Date().toISOString(),
+                        updatedAt: new Date().toISOString(),
+                        isDownloadable: true
                       }
                     } as PodcastLibraryItem
                   }

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -9,9 +9,10 @@ import PodcastMediaCard from '@/components/widgets/media-card/PodcastMediaCard'
 import { SeriesCard } from '@/components/widgets/media-card/SeriesCard'
 import { useCardSize } from '@/contexts/CardSizeContext'
 import { useLibrary } from '@/contexts/LibraryContext'
+import { useSocketEvent } from '@/contexts/SocketContext'
 import { useUser } from '@/contexts/UserContext'
-import { Author, BookshelfView, LibraryItem, MediaProgress, PersonalizedShelf, Series } from '@/types/api'
-import { useEffect } from 'react'
+import { Author, BookshelfView, LibraryItem, MediaItemShare, MediaProgress, PersonalizedShelf, PersonalizedShelfType, RssFeed, Series } from '@/types/api'
+import { useCallback, useEffect, useState } from 'react'
 import LibraryEmptyState from './LibraryEmptyState'
 
 interface LibraryClientProps {
@@ -22,6 +23,103 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   const { sizeMultiplier } = useCardSize()
   const { user, serverSettings, ereaderDevices, getLibraryItemProgress, getEpisodeProgress } = useUser()
   const { library, setContextMenuItems, setContextMenuActionHandler, homeBookshelfView, boundModal } = useLibrary()
+
+  const [shelves, setShelves] = useState(personalized)
+
+  useEffect(() => {
+    setShelves(personalized)
+  }, [personalized])
+
+  /**
+   * Updates entities within shelves of matching types.
+   * Only triggers a re-render if the updater returns a new reference for at least one entity.
+   * @param shelfTypes - Shelf types to apply the update to.
+   * @param updater - Called for each entity; must return the same reference if unchanged.
+   */
+  const updateShelfEntities = useCallback(
+    (shelfTypes: PersonalizedShelfType[], updater: (entity: LibraryItem | Series | Author) => LibraryItem | Series | Author) => {
+      setShelves((prev) => {
+        let shelvesChanged = false
+        const nextShelves = prev.map((shelf) => {
+          if (!shelfTypes.includes(shelf.type)) return shelf
+
+          let changed = false
+          const nextEntities = (shelf.entities as (LibraryItem | Series | Author)[]).map((entity) => {
+            const next = updater(entity)
+            if (next !== entity) changed = true
+            return next
+          })
+
+          if (!changed) return shelf
+          shelvesChanged = true
+          return { ...shelf, entities: nextEntities } as PersonalizedShelf
+        })
+        return shelvesChanged ? nextShelves : prev
+      })
+    },
+    []
+  )
+
+  // Shares only apply to book libraries
+  const handleShareOpen = useCallback(
+    (mediaItemShare: MediaItemShare) => {
+      if (library.mediaType !== 'book') return
+
+      updateShelfEntities(['book'], (entity) => {
+        const li = entity as LibraryItem
+        if (li.media?.id !== mediaItemShare.mediaItemId) return entity
+        return { ...li, mediaItemShare }
+      })
+    },
+    [library.mediaType, updateShelfEntities]
+  )
+
+  const handleShareClosed = useCallback(
+    (mediaItemShare: MediaItemShare) => {
+      if (library.mediaType !== 'book') return
+
+      updateShelfEntities(['book'], (entity) => {
+        const li = entity as LibraryItem
+        if (li.media?.id !== mediaItemShare.mediaItemId) return entity
+        return { ...li, mediaItemShare: undefined }
+      })
+    },
+    [library.mediaType, updateShelfEntities]
+  )
+
+  // RSS feeds on home shelves are relevant for books and series
+  const handleRssFeedOpen = useCallback(
+    (rssFeed: RssFeed) => {
+      if (library.mediaType !== 'book') return
+
+      const shelfTypes: PersonalizedShelfType[] = rssFeed.entityType === 'libraryItem' ? ['book'] : rssFeed.entityType === 'series' ? ['series'] : []
+
+      updateShelfEntities(shelfTypes, (entity) => {
+        if (entity.id !== rssFeed.entityId) return entity
+        return { ...entity, rssFeed }
+      })
+    },
+    [library.mediaType, updateShelfEntities]
+  )
+
+  const handleRssFeedClosed = useCallback(
+    (rssFeed: RssFeed) => {
+      if (library.mediaType !== 'book') return
+
+      const shelfTypes: PersonalizedShelfType[] = rssFeed.entityType === 'libraryItem' ? ['book'] : rssFeed.entityType === 'series' ? ['series'] : []
+
+      updateShelfEntities(shelfTypes, (entity) => {
+        if (entity.id !== rssFeed.entityId) return entity
+        return { ...entity, rssFeed: undefined }
+      })
+    },
+    [library.mediaType, updateShelfEntities]
+  )
+
+  useSocketEvent<MediaItemShare>('share_open', handleShareOpen)
+  useSocketEvent<MediaItemShare>('share_closed', handleShareClosed)
+  useSocketEvent<RssFeed>('rss_feed_open', handleRssFeedOpen)
+  useSocketEvent<RssFeed>('rss_feed_closed', handleRssFeedClosed)
 
   useEffect(() => {
     const items = []
@@ -57,14 +155,14 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   return (
     <div style={{ fontSize: sizeMultiplier + 'rem' }}>
       {/* empty state with scan button if user is admin or root */}
-      {personalized.length === 0 && (
+      {shelves.length === 0 && (
         <div className="py-8">
           <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(user.type)} />
         </div>
       )}
 
       {/* bookshelf rows */}
-      {personalized.map((shelf) => {
+      {shelves.map((shelf) => {
         const Wrapper = homeBookshelfView === BookshelfView.STANDARD ? BookShelfRow : ItemSlider
 
         return (

--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -149,7 +149,6 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
     isInitialized,
     error
   } = useBookshelfData({
-    libraryId: library.id,
     entityType,
     query,
     itemsPerPage

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
+import ShareModal from '@/components/modals/ShareModal'
 import Btn from '@/components/ui/Btn'
 import ContextMenuDropdown, { type ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
 import IconBtn from '@/components/ui/IconBtn'
@@ -56,29 +57,41 @@ export default function LibraryItemActionButtons({ libraryItem, onEdit, rssFeed 
   const showReadButton = isBook && !!ebookFile
   const isStreamingFromDifferentLib = isStreamingFromDifferentLibrary(libraryItem.libraryId)
 
-  const { processing, confirmState, rssFeedModalOpen, closeConfirm, closeRssFeedModal, handleReadEBook, handleMoreAction, moreMenuItems } = useMediaCardActions(
-    {
-      libraryItem,
-      media: libraryItem.media,
-      title: libraryItem.media.metadata.title ?? '',
-      author: 'authors' in libraryItem.media.metadata ? (libraryItem.media.metadata.authors ?? []).map((a) => a.name).join(', ') : null,
-      episodeForQueue: null,
-      mediaProgress,
-      itemIsFinished: isRead,
-      userProgressPercent: mediaProgress?.progress ?? 0,
-      isPodcast,
-      ereaderDevices,
-      continueListeningShelf: false,
-      libraryItemIdStreaming,
-      isStreaming: isStreamingFn,
-      isStreamingFromDifferentLib,
-      isQueued,
-      onDeleteSuccess: () => {
-        window.location.href = `/library/${libraryItem.libraryId}`
-      },
-      playerControls: playerHandler.controls
-    }
-  )
+  const {
+    processing,
+    confirmState,
+    rssFeedModalOpen,
+    shareModalOpen,
+    mediaItemShare,
+    closeConfirm,
+    closeRssFeedModal,
+    closeShareModal,
+    handleShareChange,
+    handleReadEBook,
+    handleMoreAction,
+    moreMenuItems
+  } = useMediaCardActions({
+    libraryItem,
+    media: libraryItem.media,
+    title: libraryItem.media.metadata.title ?? '',
+    author: 'authors' in libraryItem.media.metadata ? (libraryItem.media.metadata.authors ?? []).map((a) => a.name).join(', ') : null,
+    episodeForQueue: null,
+    mediaProgress,
+    itemIsFinished: isRead,
+    userProgressPercent: mediaProgress?.progress ?? 0,
+    isPodcast,
+    ereaderDevices,
+    continueListeningShelf: false,
+    libraryItemIdStreaming,
+    isStreaming: isStreamingFn,
+    isStreamingFromDifferentLib,
+    isQueued,
+    initialShare: libraryItem.mediaItemShare ?? null,
+    onDeleteSuccess: () => {
+      window.location.href = `/library/${libraryItem.libraryId}`
+    },
+    playerControls: playerHandler.controls
+  })
 
   const handlePlay = useCallback(() => {
     if (isStreaming) {
@@ -239,6 +252,13 @@ export default function LibraryItemActionButtons({ libraryItem, onEdit, rssFeed 
           feed: rssFeed ?? null,
           hasEpisodesWithoutPubDate: isPodcast && podcastEpisodes.some((ep) => !ep.pubDate)
         }}
+      />
+      <ShareModal
+        isOpen={shareModalOpen}
+        onClose={closeShareModal}
+        mediaItemId={libraryItem.media.id ?? ''}
+        mediaItemShare={mediaItemShare}
+        onShareChange={handleShareChange}
       />
     </>
   )

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next'
+import '../../assets/globals.css'
+
+export const metadata: Metadata = {
+  title: 'audiobookshelf'
+}
+
+export default function PublicLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode
+}>) {
+  return <>{children}</>
+}

--- a/src/app/(public)/share/[slug]/SharePlayer.tsx
+++ b/src/app/(public)/share/[slug]/SharePlayer.tsx
@@ -1,0 +1,576 @@
+'use client'
+
+import IconBtn from '@/components/ui/IconBtn'
+import Tooltip from '@/components/ui/Tooltip'
+import LoadingSpinner from '@/components/widgets/LoadingSpinner'
+import { usePlayerSettings } from '@/hooks/usePlayerSettings'
+import { getCoverAspectRatio } from '@/lib/coverUtils'
+import { secondsToTimestamp } from '@/lib/datefns'
+import { AudioTrack } from '@/lib/player/AudioTrack'
+import { LocalAudioPlayer } from '@/lib/player/LocalAudioPlayer'
+import type { AudioTrackData, Chapter, MediaItemShareResponse } from '@/types/api'
+import { PlayerState } from '@/types/api'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+interface SharePlayerProps {
+  slug: string
+  startTime?: number
+}
+
+const PROGRESS_SYNC_INTERVAL = 30 // seconds
+
+export default function SharePlayer({ slug, startTime: startTimeParam }: SharePlayerProps) {
+  // Share data
+  const [shareData, setShareData] = useState<MediaItemShareResponse | null>(null)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // Player state
+  const [playerState, setPlayerState] = useState<PlayerState>(PlayerState.IDLE)
+  const [currentTime, setCurrentTime] = useState(0)
+  const [duration, setDuration] = useState(0)
+  const [bufferedTime, setBufferedTime] = useState(0)
+
+  // Viewport
+  const [windowWidth, setWindowWidth] = useState(0)
+  const [windowHeight, setWindowHeight] = useState(0)
+
+  // Refs
+  const playerRef = useRef<LocalAudioPlayer | null>(null)
+  const playIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const listeningTimeSinceSync = useRef(0)
+  const lastTickRef = useRef(Date.now())
+
+  // Player settings (persisted in local storage)
+  const playerSettings = usePlayerSettings()
+  const { settings } = playerSettings
+
+  // ============================================================================
+  // Fetch share data
+  // ============================================================================
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function fetchShareData() {
+      try {
+        let endpoint = `/public/share/${slug}`
+        if (startTimeParam != null) {
+          endpoint += `?t=${startTimeParam}`
+        }
+
+        const response = await fetch(endpoint, { credentials: 'include' })
+        if (!response.ok) {
+          if (response.status === 404) {
+            setFetchError('Media item not found or expired')
+          } else {
+            setFetchError(`Failed to load (${response.status})`)
+          }
+          return
+        }
+
+        const data: MediaItemShareResponse = await response.json()
+        if (!cancelled) {
+          setShareData(data)
+        }
+      } catch (err) {
+        console.error('[SharePlayer] Failed to fetch share data:', err)
+        if (!cancelled) {
+          setFetchError('Failed to load shared item')
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    fetchShareData()
+    return () => {
+      cancelled = true
+    }
+  }, [slug, startTimeParam])
+
+  // ============================================================================
+  // Derived data
+  // ============================================================================
+
+  const playbackSession = shareData?.playbackSession ?? null
+  const chapters = useMemo<Chapter[]>(() => playbackSession?.chapters ?? [], [playbackSession?.chapters])
+  const isPlaying = playerState === PlayerState.PLAYING
+  const hasLoaded = playerState !== PlayerState.IDLE && playerState !== PlayerState.LOADING
+  const coverAspectRatio = getCoverAspectRatio(playbackSession?.coverAspectRatio as 0 | 1 | undefined)
+
+  const coverUrl = playbackSession?.coverPath ? `/public/share/${slug}/cover` : '/images/book_placeholder.jpg'
+
+  const downloadUrl = `/public/share/${slug}/download`
+
+  const audioTracks: AudioTrack[] = useMemo(() => {
+    if (!playbackSession?.audioTracks) return []
+    return playbackSession.audioTracks.map((track: AudioTrackData) => new AudioTrack(track))
+  }, [playbackSession?.audioTracks])
+
+  const currentChapter = useMemo(() => chapters.find((ch) => ch.start <= currentTime && currentTime < ch.end) ?? null, [chapters, currentTime])
+
+  // Cover size calculations
+  const isMobileLandscape = windowWidth > windowHeight && windowHeight < 450
+
+  const coverWidth = useMemo(() => {
+    const availableCoverWidth = Math.min(450, windowWidth - 32)
+    const availableCoverHeight = Math.min(450, windowHeight - 250)
+    const mostCoverHeight = availableCoverWidth * coverAspectRatio
+    if (mostCoverHeight > availableCoverHeight) {
+      return availableCoverHeight / coverAspectRatio
+    }
+    return availableCoverWidth
+  }, [windowWidth, windowHeight, coverAspectRatio])
+
+  const coverHeight = coverWidth * coverAspectRatio
+
+  // Track bar calculations
+  const playedPercent = duration ? Math.min(100, (currentTime / duration) * 100) : 0
+  const bufferedPercent = duration ? Math.min(100, (bufferedTime / duration) * 100) : 0
+  const timeRemaining = duration - currentTime
+  const currentTimeFormatted = secondsToTimestamp(currentTime)
+  const timeRemainingFormatted = timeRemaining < 0 ? secondsToTimestamp(timeRemaining * -1) : `-${secondsToTimestamp(timeRemaining)}`
+
+  // ============================================================================
+  // Progress sync
+  // ============================================================================
+
+  const sendProgressSync = useCallback(
+    (time: number) => {
+      fetch(`/public/share/${slug}/progress`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentTime: time }),
+        credentials: 'include'
+      }).catch((err) => console.error('[SharePlayer] Progress sync failed:', err))
+    },
+    [slug]
+  )
+
+  // ============================================================================
+  // Play interval (time tracking + progress sync)
+  // ============================================================================
+
+  const startPlayInterval = useCallback(() => {
+    if (playIntervalRef.current) clearInterval(playIntervalRef.current)
+    lastTickRef.current = Date.now()
+
+    playIntervalRef.current = setInterval(() => {
+      if (!playerRef.current) return
+      const time = playerRef.current.getCurrentTime()
+      setCurrentTime(time)
+
+      const exactTimeElapsed = (Date.now() - lastTickRef.current) / 1000
+      lastTickRef.current = Date.now()
+      listeningTimeSinceSync.current += exactTimeElapsed
+      if (listeningTimeSinceSync.current >= PROGRESS_SYNC_INTERVAL) {
+        listeningTimeSinceSync.current = 0
+        sendProgressSync(time)
+      }
+    }, 1000)
+  }, [sendProgressSync])
+
+  const stopPlayInterval = useCallback(() => {
+    if (playIntervalRef.current) {
+      clearInterval(playIntervalRef.current)
+      playIntervalRef.current = null
+    }
+  }, [])
+
+  // ============================================================================
+  // Player setup
+  // ============================================================================
+
+  useEffect(() => {
+    if (!shareData || !playbackSession || audioTracks.length === 0) return
+
+    const player = new LocalAudioPlayer()
+    playerRef.current = player
+
+    player.on('stateChange', (state) => {
+      setPlayerState(state)
+
+      if (state === PlayerState.LOADED || state === PlayerState.PLAYING) {
+        setDuration(player.getDuration())
+      }
+    })
+
+    player.on('timeupdate', (time) => {
+      setCurrentTime(time)
+    })
+
+    player.on('buffertimeUpdate', (time) => {
+      setBufferedTime(time)
+    })
+
+    player.on('error', (error) => {
+      console.error('[SharePlayer] Player error:', error)
+    })
+
+    player.on('finished', () => {
+      console.log('[SharePlayer] Playback finished')
+    })
+
+    const sessionStartTime = playbackSession.currentTime || 0
+    player.set(null, audioTracks, false, sessionStartTime, false)
+
+    return () => {
+      player.destroy()
+      playerRef.current = null
+    }
+    // Only init player once when shareData/audioTracks become available
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shareData, audioTracks])
+
+  // Manage play interval based on player state
+  useEffect(() => {
+    if (isPlaying) {
+      startPlayInterval()
+    } else {
+      stopPlayInterval()
+    }
+    return stopPlayInterval
+  }, [isPlaying, startPlayInterval, stopPlayInterval])
+
+  // ============================================================================
+  // Controls
+  // ============================================================================
+
+  const play = useCallback(() => {
+    playerRef.current?.play()
+  }, [])
+
+  const pause = useCallback(() => {
+    playerRef.current?.pause()
+  }, [])
+
+  const playPause = useCallback(() => {
+    if (isPlaying) {
+      pause()
+    } else {
+      play()
+    }
+  }, [isPlaying, play, pause])
+
+  const seek = useCallback(
+    (time: number) => {
+      if (!playerRef.current || !hasLoaded) return
+      playerRef.current.seek(time, isPlaying)
+      setCurrentTime(time)
+    },
+    [hasLoaded, isPlaying]
+  )
+
+  const jumpForward = useCallback(() => {
+    if (!playerRef.current || !hasLoaded) return
+    const time = playerRef.current.getCurrentTime()
+    seek(Math.min(time + settings.jumpForwardAmount, duration))
+  }, [hasLoaded, seek, settings.jumpForwardAmount, duration])
+
+  const jumpBackward = useCallback(() => {
+    if (!playerRef.current || !hasLoaded) return
+    const time = playerRef.current.getCurrentTime()
+    seek(Math.max(time - settings.jumpBackwardAmount, 0))
+  }, [hasLoaded, seek, settings.jumpBackwardAmount])
+
+  const setVolume = useCallback(
+    (vol: number) => {
+      playerSettings.setVolume(vol)
+      playerRef.current?.setVolume(vol)
+    },
+    [playerSettings]
+  )
+
+  const setPlaybackRate = useCallback(
+    (rate: number) => {
+      playerSettings.setPlaybackRate(rate)
+      playerRef.current?.setPlaybackRate(rate)
+    },
+    [playerSettings]
+  )
+
+  // Apply settings when player is ready
+  useEffect(() => {
+    if (isPlaying && playerRef.current) {
+      playerRef.current.setPlaybackRate(settings.playbackRate)
+      playerRef.current.setVolume(settings.volume)
+    }
+  }, [isPlaying, settings.playbackRate, settings.volume])
+
+  // ============================================================================
+  // Media Session API
+  // ============================================================================
+
+  useEffect(() => {
+    if (!playbackSession || !('mediaSession' in navigator)) return
+
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: playbackSession.displayTitle || 'No title',
+      artist: playbackSession.displayAuthor || 'Unknown',
+      artwork: playbackSession.coverPath ? [{ src: coverUrl }] : []
+    })
+
+    navigator.mediaSession.setActionHandler('play', play)
+    navigator.mediaSession.setActionHandler('pause', pause)
+    navigator.mediaSession.setActionHandler('stop', pause)
+    navigator.mediaSession.setActionHandler('seekbackward', jumpBackward)
+    navigator.mediaSession.setActionHandler('seekforward', jumpForward)
+    navigator.mediaSession.setActionHandler('seekto', (e) => {
+      if (e.seekTime != null && !isNaN(e.seekTime)) seek(e.seekTime)
+    })
+    navigator.mediaSession.setActionHandler('previoustrack', jumpBackward)
+    navigator.mediaSession.setActionHandler('nexttrack', jumpForward)
+  }, [playbackSession, coverUrl, play, pause, jumpBackward, jumpForward, seek])
+
+  // Update media session playback state
+  useEffect(() => {
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused'
+    }
+  }, [isPlaying])
+
+  // ============================================================================
+  // Window resize
+  // ============================================================================
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowWidth(window.innerWidth)
+      setWindowHeight(window.innerHeight)
+    }
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  // ============================================================================
+  // Keyboard hotkeys
+  // ============================================================================
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!playerRef.current || !hasLoaded) return
+
+      switch (e.key) {
+        case ' ':
+        case 'MediaPlayPause':
+          e.preventDefault()
+          playPause()
+          break
+        case 'ArrowLeft':
+          e.preventDefault()
+          jumpBackward()
+          break
+        case 'ArrowRight':
+          e.preventDefault()
+          jumpForward()
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setVolume(Math.min(settings.volume + 0.05, 1))
+          break
+        case 'ArrowDown':
+          e.preventDefault()
+          setVolume(Math.max(settings.volume - 0.05, 0))
+          break
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [hasLoaded, playPause, jumpBackward, jumpForward, setVolume, settings.volume])
+
+  // ============================================================================
+  // Track bar interaction
+  // ============================================================================
+
+  const trackRef = useRef<HTMLDivElement>(null)
+
+  const handleTrackClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!hasLoaded || !trackRef.current || !duration) return
+      const rect = trackRef.current.getBoundingClientRect()
+      const offsetX = e.clientX - rect.left
+      const perc = offsetX / rect.width
+      const time = perc * duration
+      if (!isNaN(time)) seek(time)
+    },
+    [hasLoaded, duration, seek]
+  )
+
+  // ============================================================================
+  // Download
+  // ============================================================================
+
+  const downloadShareItem = useCallback(() => {
+    const a = document.createElement('a')
+    a.href = downloadUrl
+    a.download = ''
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+  }, [downloadUrl])
+
+  // ============================================================================
+  // Volume icon
+  // ============================================================================
+
+  const volumeIcon = settings.volume === 0 ? 'volume_off' : settings.volume < 0.5 ? 'volume_down' : 'volume_up'
+
+  const toggleMute = useCallback(() => {
+    const newVol = playerSettings.toggleMute()
+    playerRef.current?.setVolume(newVol)
+  }, [playerSettings])
+
+  // ============================================================================
+  // Render
+  // ============================================================================
+
+  if (isLoading) {
+    return (
+      <div className="w-full h-dvh flex items-center justify-center bg-neutral-900 text-foreground" role="status" aria-live="polite">
+        <div className="flex flex-col items-center gap-4">
+          <LoadingSpinner size="la-2x" color="rgb(148 163 184)" dark />
+          <p className="text-lg text-slate-400">Loading...</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (fetchError || !shareData || !playbackSession) {
+    return (
+      <div className="w-full h-dvh flex items-center justify-center bg-neutral-900 text-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <span className="material-symbols text-5xl text-slate-500">error</span>
+          <p className="text-xl text-slate-400">{fetchError || 'Failed to load shared item'}</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="w-full max-w-full h-dvh max-h-dvh overflow-hidden bg-neutral-900">
+      {/* Background gradient overlay */}
+      <div className="w-screen h-screen absolute inset-0 pointer-events-none bg-gradient-to-b from-transparent via-transparent to-neutral-800" />
+
+      {/* Main content */}
+      <div className="absolute inset-0 w-screen h-dvh flex items-center justify-center z-10">
+        <div className="w-full p-2 sm:p-4 md:p-8">
+          {/* Cover image */}
+          {!isMobileLandscape && (
+            <div className="mx-auto overflow-hidden rounded-xl my-2" style={{ width: coverWidth, height: coverHeight }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={coverUrl} alt="" className="object-contain w-full h-full" crossOrigin="anonymous" />
+            </div>
+          )}
+
+          {/* Title */}
+          <p className="text-2xl lg:text-3xl font-semibold text-center mb-1 line-clamp-2 text-foreground">{playbackSession.displayTitle || 'No title'}</p>
+
+          {/* Author */}
+          {playbackSession.displayAuthor && (
+            <p className="text-lg lg:text-xl text-slate-400 font-semibold text-center mb-1 truncate">{playbackSession.displayAuthor}</p>
+          )}
+
+          {/* Player UI */}
+          <div className="w-full pt-8 max-w-2xl mx-auto">
+            {/* Track bar */}
+            <div className="mb-2">
+              <div
+                ref={trackRef}
+                className="w-full h-2 bg-white/10 relative cursor-pointer transition-transform duration-100 hover:scale-y-125 rounded-full overflow-hidden"
+                onClick={handleTrackClick}
+              >
+                {/* Buffered */}
+                <div
+                  className="h-full bg-white/20 absolute top-0 left-0 pointer-events-none transition-[width] duration-75"
+                  style={{ width: `${bufferedPercent}%` }}
+                />
+                {/* Played */}
+                <div
+                  className="h-full bg-white absolute top-0 left-0 pointer-events-none transition-[width] duration-75"
+                  style={{ width: `${playedPercent}%` }}
+                />
+                {/* Loading shimmer */}
+                {playerState === PlayerState.LOADING && (
+                  <div className="h-full w-1/4 absolute top-0 pointer-events-none bg-gradient-to-r from-transparent via-white/20 to-transparent loading-track-slide" />
+                )}
+              </div>
+
+              {/* Time display */}
+              <div className="flex items-center justify-between mt-1">
+                <p className="text-xs text-slate-400 font-mono">{currentTimeFormatted}</p>
+                {currentChapter && <p className="text-xs text-slate-400 truncate px-2">{currentChapter.title}</p>}
+                <p className="text-xs text-slate-400 font-mono">{timeRemainingFormatted}</p>
+              </div>
+            </div>
+
+            {/* Controls */}
+            <div className="flex items-center justify-center gap-3 sm:gap-4">
+              {/* Volume */}
+              <Tooltip text="Volume" position="top">
+                <IconBtn borderless size="custom" className="w-9 text-2xl" onClick={toggleMute}>
+                  {volumeIcon}
+                </IconBtn>
+              </Tooltip>
+
+              {/* Jump backward */}
+              <Tooltip text={`Jump back ${settings.jumpBackwardAmount}s`} position="top">
+                <IconBtn borderless size="custom" className="w-10 text-3xl" onClick={jumpBackward}>
+                  replay
+                </IconBtn>
+              </Tooltip>
+
+              {/* Play/Pause */}
+              <IconBtn
+                borderless
+                size="custom"
+                loading={playerState === PlayerState.LOADING}
+                outlined={false}
+                className="w-12 h-12 bg-white text-neutral-900 hover:text-neutral-900 hover:not-disabled:text-neutral-900 rounded-full text-3xl"
+                onClick={playPause}
+              >
+                {isPlaying ? 'pause' : 'play_arrow'}
+              </IconBtn>
+
+              {/* Jump forward */}
+              <Tooltip text={`Jump forward ${settings.jumpForwardAmount}s`} position="top">
+                <IconBtn borderless size="custom" className="w-10 text-3xl" onClick={jumpForward}>
+                  forward_media
+                </IconBtn>
+              </Tooltip>
+
+              {/* Playback rate */}
+              <Tooltip text="Playback speed" position="top">
+                <button
+                  type="button"
+                  onClick={() => {
+                    const rates = [0.5, 0.75, 1, 1.25, 1.5, 2]
+                    const currentIdx = rates.indexOf(settings.playbackRate)
+                    const nextRate = rates[(currentIdx + 1) % rates.length]
+                    setPlaybackRate(nextRate)
+                  }}
+                  className="text-sm font-medium text-slate-300 hover:text-white transition-colors tabular-nums min-w-[3rem] text-center cursor-pointer"
+                >
+                  {settings.playbackRate}x
+                </button>
+              </Tooltip>
+            </div>
+          </div>
+
+          {/* Download button */}
+          {shareData.isDownloadable && (
+            <Tooltip text="Download" position="bottom" className="absolute top-0 left-0 m-4">
+              <button aria-label="Download" className="text-gray-300 hover:text-white cursor-pointer" onClick={downloadShareItem}>
+                <span className="material-symbols text-2xl sm:text-3xl">download</span>
+              </button>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(public)/share/[slug]/page.tsx
+++ b/src/app/(public)/share/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import SharePlayer from './SharePlayer'
+
+interface SharePageProps {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<{ t?: string }>
+}
+
+export default async function SharePage({ params, searchParams }: SharePageProps) {
+  const { slug } = await params
+  const { t } = await searchParams
+  const startTime = t && !isNaN(Number(t)) ? Number(t) : undefined
+
+  return <SharePlayer slug={slug} startTime={startTime} />
+}

--- a/src/app/actions/shareActions.ts
+++ b/src/app/actions/shareActions.ts
@@ -1,0 +1,17 @@
+'use server'
+
+import * as api from '@/lib/api'
+import type { OpenMediaItemSharePayload } from '@/types/api'
+import { revalidatePath } from 'next/cache'
+
+export async function openMediaItemShareAction(payload: OpenMediaItemSharePayload) {
+  const result = await api.openMediaItemShare(payload)
+  revalidatePath('/library', 'layout')
+  return result
+}
+
+export async function closeMediaItemShareAction(shareId: string) {
+  const result = await api.closeMediaItemShare(shareId)
+  revalidatePath('/library', 'layout')
+  return result
+}

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -227,7 +227,7 @@ export default function ShareModal({ isOpen, onClose, mediaItemId, mediaItemShar
               <ToggleSwitch size="medium" value={isDownloadable} onChange={setIsDownloadable} />
               <Tooltip text={t('LabelShareDownloadableHelp')} position="right" maxWidth={160} openOnClick addTabIndex>
                 <span className="text-foreground-muted inline-flex items-center justify-center w-8 h-8 sm:w-auto sm:h-auto cursor-pointer">
-                  <span className="material-symbols icon-text text-lg sm:text-base">info</span>
+                  <span className="material-symbols icon-text text-lg">info</span>
                 </span>
               </Tooltip>
             </div>

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -9,6 +9,7 @@ import ToggleSwitch from '@/components/ui/ToggleSwitch'
 import Tooltip from '@/components/ui/Tooltip'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { ApiError } from '@/lib/api'
 import { elapsedPretty } from '@/lib/timeUtils'
 import type { MediaItemShare } from '@/types/api'
 import { useLocale } from 'next-intl'
@@ -156,7 +157,7 @@ export default function ShareModal({ isOpen, onClose, mediaItemId, mediaItemShar
       onShareChange?.(share)
     } catch (error) {
       console.error('openShare', error)
-      showToast('Failed to share item', { type: 'error' })
+      showToast((error as ApiError).message || 'Failed to share item', { type: 'error' })
     } finally {
       setProcessing(false)
     }
@@ -223,9 +224,9 @@ export default function ShareModal({ isOpen, onClose, mediaItemId, mediaItemShar
 
             <div className="flex items-center w-full md:w-1/2 mb-4">
               <p className="text-sm text-foreground-muted py-1 px-1">{t('LabelDownloadable')}</p>
-              <ToggleSwitch size="small" value={isDownloadable} onChange={setIsDownloadable} />
+              <ToggleSwitch size="medium" value={isDownloadable} onChange={setIsDownloadable} />
               <Tooltip text={t('LabelShareDownloadableHelp')} position="right" maxWidth={160} openOnClick addTabIndex>
-                <span className="pl-3 sm:pl-4 text-foreground-muted inline-flex items-center justify-center w-8 h-8 sm:w-auto sm:h-auto cursor-pointer">
+                <span className="text-foreground-muted inline-flex items-center justify-center w-8 h-8 sm:w-auto sm:h-auto cursor-pointer">
                   <span className="material-symbols icon-text text-lg sm:text-base">info</span>
                 </span>
               </Tooltip>

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -1,0 +1,264 @@
+'use client'
+
+import { closeMediaItemShareAction, openMediaItemShareAction } from '@/app/actions/shareActions'
+import Modal from '@/components/modals/Modal'
+import Btn from '@/components/ui/Btn'
+import Dropdown from '@/components/ui/Dropdown'
+import TextInput from '@/components/ui/TextInput'
+import ToggleSwitch from '@/components/ui/ToggleSwitch'
+import Tooltip from '@/components/ui/Tooltip'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { elapsedPretty } from '@/lib/timeUtils'
+import type { MediaItemShare } from '@/types/api'
+import { useLocale } from 'next-intl'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+type ShareDurationUnit = 'minutes' | 'hours' | 'days'
+
+interface ShareModalProps {
+  isOpen: boolean
+  onClose: () => void
+  mediaItemId?: string
+  mediaItemShare: MediaItemShare | null
+  onShareChange?: (share: MediaItemShare | null) => void
+}
+
+function getRandomSlug(length = 10) {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
+  let result = ''
+  for (let i = 0; i < length; i++) {
+    result += alphabet[Math.floor(Math.random() * alphabet.length)]
+  }
+  return result
+}
+
+function toUnixMs(value: number | string | null | undefined): number | null {
+  if (value == null) return null
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  const parsed = Date.parse(value)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+export default function ShareModal({ isOpen, onClose, mediaItemId, mediaItemShare, onShareChange }: ShareModalProps) {
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+  const locale = useLocale()
+
+  const [processing, setProcessing] = useState(false)
+  const [newShareSlug, setNewShareSlug] = useState('')
+  const [newShareDuration, setNewShareDuration] = useState(0)
+  const [shareDurationUnit, setShareDurationUnit] = useState<ShareDurationUnit>('minutes')
+  const [isDownloadable, setIsDownloadable] = useState(false)
+  const [currentShare, setCurrentShare] = useState<MediaItemShare | null>(null)
+
+  const handleDurationChange = useCallback((value: string) => {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      setNewShareDuration(0)
+      return
+    }
+    const parsed = Number.parseInt(trimmed, 10)
+    if (Number.isNaN(parsed) || parsed < 0) {
+      setNewShareDuration(0)
+      return
+    }
+    setNewShareDuration(parsed)
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    setNewShareSlug(getRandomSlug(10))
+    setNewShareDuration(0)
+    setShareDurationUnit('minutes')
+    setIsDownloadable(false)
+    setCurrentShare(mediaItemShare ? { ...mediaItemShare } : null)
+  }, [isOpen, mediaItemShare])
+
+  const durationUnits = useMemo(
+    () => [
+      { text: t('LabelMinutes'), value: 'minutes' },
+      { text: t('LabelHours'), value: 'hours' },
+      { text: t('LabelDays'), value: 'days' }
+    ],
+    [t]
+  )
+
+  const expireDurationSeconds = useMemo(() => {
+    const duration = Number(newShareDuration)
+    if (!duration || Number.isNaN(duration) || duration < 0) return 0
+    if (shareDurationUnit === 'hours') return duration * 3600
+    if (shareDurationUnit === 'days') return duration * 86400
+    return duration * 60
+  }, [newShareDuration, shareDurationUnit])
+
+  const demoShareUrl = useMemo(() => {
+    if (typeof window === 'undefined') return ''
+    return `${window.location.origin}/share/${newShareSlug}`
+  }, [newShareSlug])
+
+  const currentShareUrl = useMemo(() => {
+    if (!currentShare || typeof window === 'undefined') return ''
+    return `${window.location.origin}/share/${currentShare.slug}`
+  }, [currentShare])
+
+  const currentShareTimeRemaining = useMemo(() => {
+    if (!currentShare) return t('LabelPermanent')
+    const expiresAtMs = toUnixMs(currentShare.expiresAt)
+    if (!expiresAtMs) return t('LabelPermanent')
+    const remainingMs = expiresAtMs - Date.now()
+    if (remainingMs <= 0) return 'Expired'
+    return elapsedPretty(remainingMs / 1000, locale, true, false, true)
+  }, [currentShare, locale, t])
+
+  const expirationDateString = useMemo(() => {
+    if (!expireDurationSeconds) return t('LabelPermanent')
+    const date = new Date(Date.now() + expireDurationSeconds * 1000)
+    return date.toLocaleString(locale)
+  }, [expireDurationSeconds, locale, t])
+
+  const handleDeleteShare = useCallback(async () => {
+    if (!currentShare) return
+    setProcessing(true)
+    try {
+      await closeMediaItemShareAction(currentShare.id)
+      setCurrentShare(null)
+      onShareChange?.(null)
+    } catch (error) {
+      console.error('deleteShare', error)
+      showToast('Failed to delete share', { type: 'error' })
+    } finally {
+      setProcessing(false)
+    }
+  }, [currentShare, onShareChange, showToast])
+
+  const handleOpenShare = useCallback(async () => {
+    if (!mediaItemId) {
+      showToast(t('ToastFailedToUpdate'), { type: 'error' })
+      return
+    }
+    const slug = newShareSlug.trim()
+    if (!slug) {
+      showToast(t('ToastSlugRequired'), { type: 'error' })
+      return
+    }
+
+    setProcessing(true)
+    try {
+      const share = await openMediaItemShareAction({
+        slug,
+        mediaItemType: 'book',
+        mediaItemId,
+        expiresAt: expireDurationSeconds ? Date.now() + expireDurationSeconds * 1000 : 0,
+        isDownloadable
+      })
+      setCurrentShare(share)
+      onShareChange?.(share)
+    } catch (error) {
+      console.error('openShare', error)
+      showToast('Failed to share item', { type: 'error' })
+    } finally {
+      setProcessing(false)
+    }
+  }, [expireDurationSeconds, isDownloadable, mediaItemId, newShareSlug, onShareChange, showToast, t])
+
+  const outerContent = (
+    <div className="absolute top-0 start-0 p-4">
+      <p className="text-xl font-semibold text-foreground truncate max-w-[calc(100vw-4rem)]">{t('LabelShare')}</p>
+    </div>
+  )
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} outerContent={outerContent} processing={processing} className="sm:max-w-[520px] md:max-w-[560px] lg:max-w-[560px]">
+      <div className="px-4 sm:px-6 py-6 text-sm max-h-[80vh] overflow-y-auto overflow-x-hidden">
+        <div className="absolute top-0 end-0 p-4">
+          <Tooltip text={t('LabelClickForMoreInfo')} className="inline-flex">
+            <a
+              href="https://www.audiobookshelf.org/guides/media-item-shares"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex text-foreground-muted hover:text-foreground"
+            >
+              <span className="material-symbols text-xl">help_outline</span>
+            </a>
+          </Tooltip>
+        </div>
+
+        {currentShare ? (
+          <>
+            <div className="w-full py-2">
+              <label className="px-1 text-sm font-semibold block">{t('LabelShareURL')}</label>
+              <TextInput value={currentShareUrl} showCopy readOnly />
+            </div>
+            <div className="w-full py-2 px-1 space-y-1">
+              {currentShare.isDownloadable && <p className="text-sm">{t('LabelDownloadable')}</p>}
+              {currentShare.expiresAt ? <p>{t('MessageShareExpiresIn', { 0: currentShareTimeRemaining })}</p> : <p>{t('LabelPermanent')}</p>}
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-[12rem_auto] sm:items-end gap-y-3 sm:gap-x-4 mb-2">
+              <div className="w-full sm:w-48">
+                <label className="px-1 text-sm font-semibold block">{t('LabelSlug')}</label>
+                <TextInput value={newShareSlug} onChange={setNewShareSlug} className="text-base h-10" />
+              </div>
+              <div className="w-full sm:w-auto">
+                <label className="px-1 text-sm font-semibold block">{t('LabelDuration')}</label>
+                <div className="inline-flex items-center gap-2">
+                  <TextInput
+                    value={newShareDuration}
+                    onChange={handleDurationChange}
+                    type="number"
+                    step={1}
+                    min={0}
+                    className="max-w-20 min-w-20 sm:max-w-16 sm:min-w-16 h-10 text-base text-center"
+                    customInputClass="text-center"
+                  />
+                  <div className="w-28">
+                    <Dropdown value={shareDurationUnit} items={durationUnits} onChange={(value) => setShareDurationUnit(value as ShareDurationUnit)} />
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center w-full md:w-1/2 mb-4">
+              <p className="text-sm text-foreground-muted py-1 px-1">{t('LabelDownloadable')}</p>
+              <ToggleSwitch size="small" value={isDownloadable} onChange={setIsDownloadable} />
+              <Tooltip text={t('LabelShareDownloadableHelp')} position="right" maxWidth={160} openOnClick addTabIndex>
+                <span className="pl-3 sm:pl-4 text-foreground-muted inline-flex items-center justify-center w-8 h-8 sm:w-auto sm:h-auto cursor-pointer">
+                  <span className="material-symbols icon-text text-lg sm:text-base">info</span>
+                </span>
+              </Tooltip>
+            </div>
+
+            <p className="text-sm text-foreground-muted py-1 px-1">
+              {t.rich('MessageShareURLWillBe', {
+                0: demoShareUrl,
+                strong: (chunks) => <strong>{chunks}</strong>
+              })}
+            </p>
+            <p className="text-sm text-foreground-muted py-1 px-1">
+              {t.rich('MessageShareExpirationWillBe', {
+                0: expirationDateString,
+                strong: (chunks) => <strong>{chunks}</strong>
+              })}
+            </p>
+          </>
+        )}
+
+        <div className="flex items-center pt-6">
+          <div className="grow" />
+          {currentShare ? (
+            <Btn color="bg-error" size="small" onClick={handleDeleteShare} disabled={processing}>
+              {t('ButtonDelete')}
+            </Btn>
+          ) : (
+            <Btn color="bg-success" size="small" onClick={handleOpenShare} disabled={processing}>
+              {t('ButtonShare')}
+            </Btn>
+          )}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -21,6 +21,7 @@ interface TooltipProps {
   tooltipClassName?: string
   disabled?: boolean
   addTabIndex?: boolean
+  openOnClick?: boolean
 }
 
 const placementMap: Record<NonNullable<TooltipProps['position']>, Placement> = {
@@ -43,7 +44,8 @@ const Tooltip = ({
   closeOnClick = false,
   tooltipClassName,
   disabled = false,
-  addTabIndex = false
+  addTabIndex = false,
+  openOnClick = false
 }: TooltipProps) => {
   const tooltipId = useId()
   const [open, setOpen] = useState(false)
@@ -152,6 +154,12 @@ const Tooltip = ({
           activeElement.blur()
         }
       }
+      return
+    }
+
+    if (!disabled && openOnClick) {
+      clearHideTimeout()
+      setOpen((prev) => !prev)
     }
   }
 

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -2,6 +2,7 @@
 
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
+import ShareModal from '@/components/modals/ShareModal'
 import MediaCardCover from '@/components/widgets/media-card/MediaCardCover'
 import MediaCardDetailView from '@/components/widgets/media-card/MediaCardDetailView'
 import MediaCardFrame from '@/components/widgets/media-card/MediaCardFrame'
@@ -159,7 +160,6 @@ function MediaCard(props: MediaCardProps) {
   const isAuthorBookshelfView = bookshelfView === BookshelfView.AUTHOR
 
   const [rssFeed, setRssFeed] = useState(libraryItem.rssFeed ?? null)
-  const mediaItemShare = libraryItem.mediaItemShare ?? null
 
   useEffect(() => {
     setRssFeed(libraryItem.rssFeed ?? null)
@@ -235,8 +235,22 @@ function MediaCard(props: MediaCardProps) {
 
   const showReadButton = !isSelectionMode && !showPlayButton && isBookMedia(media) && !!media.ebookFormat
 
-  const { processing, isPending, confirmState, rssFeedModalOpen, closeConfirm, closeRssFeedModal, handlePlay, handleReadEBook, handleMoreAction, moreMenuItems } =
-    useMediaCardActions({
+  const {
+    processing,
+    isPending,
+    confirmState,
+    rssFeedModalOpen,
+    shareModalOpen,
+    mediaItemShare,
+    closeConfirm,
+    closeRssFeedModal,
+    closeShareModal,
+    handleShareChange,
+    handlePlay,
+    handleReadEBook,
+    handleMoreAction,
+    moreMenuItems
+  } = useMediaCardActions({
     libraryItem,
     media,
     title,
@@ -252,6 +266,7 @@ function MediaCard(props: MediaCardProps) {
     isStreaming,
     isStreamingFromDifferentLib,
     isQueued,
+    initialShare: libraryItem.mediaItemShare ?? null,
     playerControls: playerHandler.controls
   })
 
@@ -364,6 +379,15 @@ function MediaCard(props: MediaCardProps) {
             feed: rssFeed ?? null,
             hasEpisodesWithoutPubDate: isPodcast && ((media as PodcastMedia).episodes ?? []).some((ep) => !ep.pubDate)
           }}
+        />
+      )}
+      {shareModalOpen && (
+        <ShareModal
+          isOpen={shareModalOpen}
+          onClose={closeShareModal}
+          mediaItemId={libraryItem.media.id ?? ''}
+          mediaItemShare={mediaItemShare}
+          onShareChange={handleShareChange}
         />
       )}
     </>

--- a/src/components/widgets/media-card/useMediaCardActions.ts
+++ b/src/components/widgets/media-card/useMediaCardActions.ts
@@ -15,8 +15,8 @@ import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { downloadLibraryItem } from '@/lib/download'
 import type { PlayerHandlerControls } from '@/hooks/usePlayerHandler'
-import type { EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode } from '@/types/api'
-import { useCallback, useMemo, useState, useTransition } from 'react'
+import type { EReaderDevice, LibraryItem, MediaItemShare, MediaProgress, PodcastEpisode } from '@/types/api'
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import { MediaCardMoreMenuItem } from './MediaCardMoreMenu'
 
 interface UseMediaCardActionsProps {
@@ -35,6 +35,8 @@ interface UseMediaCardActionsProps {
   isStreaming: (libraryItemId: string, episodeId: string | null) => boolean
   isStreamingFromDifferentLib: boolean
   isQueued: boolean
+  initialShare?: MediaItemShare | null
+  onShareChange?: (share: MediaItemShare | null) => void
   onDeleteSuccess?: () => void
   playerControls: PlayerHandlerControls
 }
@@ -55,6 +57,8 @@ export function useMediaCardActions({
   isStreaming,
   isStreamingFromDifferentLib,
   isQueued,
+  initialShare = null,
+  onShareChange,
   onDeleteSuccess,
   playerControls
 }: UseMediaCardActionsProps) {
@@ -66,8 +70,14 @@ export function useMediaCardActions({
   const [isPending, startTransition] = useTransition()
   const [confirmState, setConfirmState] = useState<ConfirmState | null>(null)
   const [rssFeedModalOpen, setRssFeedModalOpen] = useState(false)
+  const [shareModalOpen, setShareModalOpen] = useState(false)
+  const [mediaItemShare, setMediaItemShare] = useState<MediaItemShare | null>(initialShare)
   const rssFeed = libraryItem.rssFeed ?? null
   const showRssFeedButton = userIsAdminOrUp || rssFeed != null
+
+  useEffect(() => {
+    setMediaItemShare(initialShare)
+  }, [initialShare])
 
   const handlePlay = useCallback(() => {
     if (isStreaming(libraryItem.id, episodeForQueue?.id ?? null)) {
@@ -195,8 +205,10 @@ export function useMediaCardActions({
       } else if (action === 'removeFromQueue') {
         const episodeId = episodeForQueue ? episodeForQueue.id : null
         removeItemFromQueue({ libraryItemId: libraryItem.id, episodeId })
-      } else if (action === 'openCollections' || action === 'openPlaylists' || action === 'openShare') {
+      } else if (action === 'openCollections' || action === 'openPlaylists') {
         showToast('This action is not implemented yet.', { type: 'info' })
+      } else if (action === 'openShare') {
+        setShareModalOpen(true)
       } else if (action === 'openRssFeed') {
         setRssFeedModalOpen(true)
       } else if (action === 'download') {
@@ -455,13 +467,29 @@ export function useMediaCardActions({
     setRssFeedModalOpen(false)
   }, [])
 
+  const closeShareModal = useCallback(() => {
+    setShareModalOpen(false)
+  }, [])
+
+  const handleShareChange = useCallback(
+    (share: MediaItemShare | null) => {
+      setMediaItemShare(share)
+      onShareChange?.(share)
+    },
+    [onShareChange]
+  )
+
   return {
     processing: processing || isPending,
     isPending,
     confirmState,
     rssFeedModalOpen,
+    shareModalOpen,
+    mediaItemShare,
     closeConfirm,
     closeRssFeedModal,
+    closeShareModal,
+    handleShareChange,
     handlePlay,
     handleReadEBook,
     handleMoreAction,

--- a/src/hooks/useBookshelfData.ts
+++ b/src/hooks/useBookshelfData.ts
@@ -1,10 +1,10 @@
 import { fetchAuthorsAction, fetchCollectionsAction, fetchLibraryItemsAction, fetchPlaylistsAction, fetchSeriesAction } from '@/app/actions/libraryActions'
+import { useLibrary } from '@/contexts/LibraryContext'
 import { useSocketEvent } from '@/contexts/SocketContext'
-import { Author, BookshelfEntity, Collection, EntityType, LibraryItem, Playlist, Series } from '@/types/api'
+import { Author, BookshelfEntity, Collection, EntityType, LibraryItem, MediaItemShare, Playlist, RssFeed, Series } from '@/types/api'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UseBookshelfDataProps {
-  libraryId: string
   entityType: EntityType
   query: string // URLSearchParams string
   itemsPerPage: number
@@ -52,7 +52,9 @@ function getResultsFromResponse(entityType: EntityType, data: unknown): Bookshel
   }
 }
 
-export function useBookshelfData({ libraryId, entityType, query, itemsPerPage }: UseBookshelfDataProps) {
+export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshelfDataProps) {
+  const { library } = useLibrary()
+  const libraryId = library.id
   const [state, setState] = useState<BookshelfDataState>({
     items: [],
     totalEntities: 0,
@@ -94,14 +96,6 @@ export function useBookshelfData({ libraryId, entityType, query, itemsPerPage }:
       itemsPerPageRef.current = itemsPerPage
     }
   }, [itemsPerPage, state.isInitialized])
-
-  // Update a single item in the items array by ID
-  const updateItem = useCallback((id: string, updatedItem: BookshelfEntity) => {
-    setState((prev) => ({
-      ...prev,
-      items: prev.items.map((item) => (item?.id === id ? updatedItem : item))
-    }))
-  }, [])
 
   // Remove a single item from the items array by ID
   // Clears page tracking since indices shift after removal
@@ -185,11 +179,36 @@ export function useBookshelfData({ libraryId, entityType, query, itemsPerPage }:
     [libraryId, entityType, query]
   )
 
+  /**
+   * Maps over loaded items, applying the updater to each non-null entry.
+   * Only triggers a re-render if the updater returns a new reference for at least one item.
+   */
+  const updateItems = useCallback((updater: (item: BookshelfEntity) => BookshelfEntity) => {
+    setState((prev) => {
+      let changed = false
+      const nextItems = prev.items.map((item) => {
+        if (!item) return item
+
+        const nextItem = updater(item)
+        if (nextItem !== item) {
+          changed = true
+        }
+        return nextItem
+      })
+
+      if (!changed) return prev
+      return {
+        ...prev,
+        items: nextItems
+      }
+    })
+  }, [])
+
   // Socket listeners for Author updates
   // Only active when viewing authors
   const handleAuthorAdded = useCallback(
     (author: Author) => {
-      if (entityType !== 'authors' || author.libraryId !== libraryId) return
+      if (author.libraryId !== libraryId || entityType !== 'authors') return
 
       // Since an author was added, the sort order might change completely
       // We must invalidate the current data and refetch
@@ -210,10 +229,14 @@ export function useBookshelfData({ libraryId, entityType, query, itemsPerPage }:
 
   const handleAuthorUpdated = useCallback(
     (author: Author) => {
-      if (entityType !== 'authors' || author.libraryId !== libraryId) return
-      updateItem(author.id, author)
+      if (author.libraryId !== libraryId || entityType !== 'authors') return
+
+      updateItems((item) => {
+        if (item.id !== author.id) return item
+        return author
+      })
     },
-    [entityType, libraryId, updateItem]
+    [entityType, libraryId, updateItems]
   )
 
   const handleAuthorRemoved = useCallback(
@@ -222,7 +245,9 @@ export function useBookshelfData({ libraryId, entityType, query, itemsPerPage }:
       const libId = 'libraryId' in data ? data.libraryId : (data as Author).libraryId
       const id = 'id' in data ? data.id : (data as Author).id
 
-      if (entityType !== 'authors' || libId !== libraryId) return
+      if (libId !== libraryId) return
+
+      if (entityType !== 'authors') return
       removeItem(id)
     },
     [entityType, libraryId, removeItem]
@@ -231,6 +256,66 @@ export function useBookshelfData({ libraryId, entityType, query, itemsPerPage }:
   useSocketEvent<Author>('author_added', handleAuthorAdded)
   useSocketEvent<Author>('author_updated', handleAuthorUpdated)
   useSocketEvent<Author | { id: string; libraryId: string }>('author_removed', handleAuthorRemoved)
+
+  // Socket listeners for share updates
+  // Shares only apply to book library items
+  const handleShareOpen = useCallback(
+    (mediaItemShare: MediaItemShare) => {
+      if (library.mediaType !== 'book' || entityType !== 'items') return
+
+      updateItems((item) => {
+        const li = item as LibraryItem
+        if (li.media.id !== mediaItemShare.mediaItemId) return item
+        return { ...li, mediaItemShare }
+      })
+    },
+    [entityType, library.mediaType, updateItems]
+  )
+
+  const handleShareClosed = useCallback(
+    (mediaItemShare: MediaItemShare) => {
+      if (library.mediaType !== 'book' || entityType !== 'items') return
+
+      updateItems((item) => {
+        const li = item as LibraryItem
+        if (li.media.id !== mediaItemShare.mediaItemId) return item
+        return { ...li, mediaItemShare: undefined }
+      })
+    },
+    [entityType, library.mediaType, updateItems]
+  )
+
+  useSocketEvent<MediaItemShare>('share_open', handleShareOpen)
+  useSocketEvent<MediaItemShare>('share_closed', handleShareClosed)
+
+  // Socket listeners for RSS feed updates
+  // Relevant for entity types that can be published via RSS
+  const handleRssFeedOpen = useCallback(
+    (rssFeed: RssFeed) => {
+      if (entityType !== 'items' && entityType !== 'series' && entityType !== 'collections') return
+
+      updateItems((item) => {
+        if (item.id !== rssFeed.entityId) return item
+        return { ...item, rssFeed } as BookshelfEntity
+      })
+    },
+    [entityType, updateItems]
+  )
+
+  const handleRssFeedClosed = useCallback(
+    (rssFeed: RssFeed) => {
+      if (entityType !== 'items' && entityType !== 'series' && entityType !== 'collections') return
+
+      updateItems((item) => {
+        if (item.id !== rssFeed.entityId) return item
+        return { ...item, rssFeed: undefined } as BookshelfEntity
+      })
+    },
+    [entityType, updateItems]
+  )
+
+  useSocketEvent<RssFeed>('rss_feed_open', handleRssFeedOpen)
+  useSocketEvent<RssFeed>('rss_feed_closed', handleRssFeedClosed)
 
   return {
     ...state,

--- a/src/hooks/useItemPageSocket.ts
+++ b/src/hooks/useItemPageSocket.ts
@@ -1,14 +1,8 @@
 'use client'
 
 import { useSocketEvent } from '@/contexts/SocketContext'
-import type { BookLibraryItem, PodcastEpisodeDownload, PodcastLibraryItem, RssFeed } from '@/types/api'
+import type { BookLibraryItem, MediaItemShare, PodcastEpisodeDownload, PodcastLibraryItem, RssFeed } from '@/types/api'
 import { useCallback, useState } from 'react'
-
-export interface MediaItemShare {
-  id: string
-  mediaItemId: string
-  slug: string
-}
 
 interface UseItemPageSocketOptions {
   libraryItemId: string

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,7 +33,9 @@ import {
   Library,
   LibraryFilterData,
   LibraryItem,
+  MediaItemShare,
   MetadataProvidersResponse,
+  OpenMediaItemSharePayload,
   OpenRssFeedPayload,
   OpenRssFeedResponse,
   PersonalizedShelf,
@@ -514,6 +516,19 @@ export async function openItemRssFeed(itemId: string, payload: OpenRssFeedPayloa
   return apiRequest<OpenRssFeedResponse>(`/api/feeds/item/${itemId}/open`, {
     method: 'POST',
     body: JSON.stringify(payload)
+  })
+}
+
+export async function openMediaItemShare(payload: OpenMediaItemSharePayload): Promise<MediaItemShare> {
+  return apiRequest<MediaItemShare>('/api/share/mediaitem', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}
+
+export async function closeMediaItemShare(shareId: string): Promise<void> {
+  return apiRequest<void>(`/api/share/mediaitem/${shareId}`, {
+    method: 'DELETE'
   })
 }
 

--- a/src/lib/player/AudioTrack.ts
+++ b/src/lib/player/AudioTrack.ts
@@ -12,10 +12,10 @@ export class AudioTrack {
   readonly mimeType: string
   readonly metadata: Record<string, unknown>
 
-  private readonly sessionId: string
+  private readonly sessionId: string | undefined
   private readonly sessionTrackUrl: string
 
-  constructor(track: AudioTrackData, sessionId: string) {
+  constructor(track: AudioTrackData, sessionId?: string) {
     this.index = track.index ?? 0
     this.startOffset = track.startOffset ?? 0
     this.duration = track.duration ?? 0
@@ -26,8 +26,7 @@ export class AudioTrack {
 
     this.sessionId = sessionId
 
-    // HLS streams use the content URL directly, direct play uses session track URL
-    if (this.contentUrl?.startsWith('/hls')) {
+    if (this.contentUrl?.startsWith('/hls') || !sessionId) {
       this.sessionTrackUrl = this.contentUrl
     } else {
       this.sessionTrackUrl = `/public/session/${sessionId}/track/${this.index}`

--- a/src/lib/player/LocalAudioPlayer.ts
+++ b/src/lib/player/LocalAudioPlayer.ts
@@ -29,7 +29,7 @@ export class LocalAudioPlayer {
   private listeners: EventListeners = {}
 
   // Track state
-  private libraryItem: LibraryItem | null = null
+  private libraryItem: LibraryItem | null = null // null for public share pages
   private audioTracks: AudioTrack[] = []
   private currentTrackIndex = 0
   private isHlsTranscode = false
@@ -164,7 +164,7 @@ export class LocalAudioPlayer {
   /**
    * Set up the player with tracks and start time
    */
-  set(libraryItem: LibraryItem, tracks: AudioTrack[], isHlsTranscode: boolean, startTime: number, playWhenReady = false): void {
+  set(libraryItem: LibraryItem | null, tracks: AudioTrack[], isHlsTranscode: boolean, startTime: number, playWhenReady = false): void {
     this.libraryItem = libraryItem
     this.audioTracks = tracks
     this.isHlsTranscode = isHlsTranscode

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -88,6 +88,11 @@ export default async function middleware(request: NextRequest) {
     return setLanguageCookie(NextResponse.next())
   }
 
+  const isShareRoute = pathname.startsWith('/share/')
+  if (isShareRoute) {
+    return next()
+  }
+
   const isLoginRoute = pathname === '/login'
   if (isLoginRoute) {
     if (hasValidAccessToken) {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -948,6 +948,8 @@ export interface GetBackupsResponse {
 // SHELVES
 // ============================================================================
 
+export type PersonalizedShelfType = 'book' | 'podcast' | 'episode' | 'series' | 'authors'
+
 export interface PersonalizedShelf {
   id:
     | 'continue-listening'
@@ -962,7 +964,7 @@ export interface PersonalizedShelf {
     | 'newest-authors'
   label: string
   labelStringKey: string
-  type: 'book' | 'podcast' | 'episode' | 'series' | 'authors'
+  type: PersonalizedShelfType
   /** type depends on shelf type */
   entities: LibraryItem[] | Series[] | Author[]
   total: number

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -771,13 +771,29 @@ export interface MediaItemShare {
   id: string
   mediaItemId: string
   mediaItemType: 'book' | 'podcastEpisode'
-  userId: string
   slug: string
-  playbackSessionId?: string
   /** null for no expiration */
-  expiresAt?: number
-  createdAt: number
-  updatedAt: number
+  expiresAt: string | null
+  createdAt: string
+  updatedAt: string
+  isDownloadable: boolean
+}
+
+/**
+ * Response from the public share endpoint GET /public/share/:slug
+ * Includes the playback session with audio tracks for the shared item
+ */
+export interface MediaItemShareResponse extends MediaItemShare {
+  playbackSession: PlaybackSession
+}
+
+export interface OpenMediaItemSharePayload {
+  slug: string
+  mediaItemType: 'book' | 'podcastEpisode'
+  mediaItemId: string
+  /** 0 for no expiration */
+  expiresAt: number
+  isDownloadable?: boolean
 }
 
 // ============================================================================
@@ -1299,6 +1315,8 @@ export interface PlaybackSession {
   updatedAt: number
   audioTracks: AudioTrackData[]
   libraryItem: LibraryItem | null
+  /** Cover aspect ratio from library settings (included in share sessions) */
+  coverAspectRatio?: 0 | 1
 }
 
 /**


### PR DESCRIPTION
This PR depends on #90, so please wait after merging it so I can merge any additional changes from that PR and rebase to master.

It implements the Share menu item on `MediaCard` and `LibrayItemClient` context menus.

Notable changes:
- A `(public)` route was added for the share page (which has an empty layout)
- `middleware.ts` was modified to route to `/share` without requiring login or tokens
- `ShareModal` was implemented to display open/close share
- `SharePlayer` was introduced to display the share player
- `share_open`/`share_closed` socket event handlers introduced where needed