### PR TITLE
Add custom metadata provider in metadata utils

### DIFF
--- a/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/AddCustomMetadataProviderModal.tsx
+++ b/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/AddCustomMetadataProviderModal.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import Modal from '@/components/modals/Modal'
+import Btn from '@/components/ui/Btn'
+import TextInput from '@/components/ui/TextInput'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { CreateCustomMetadataProviderPayload } from '@/types/api'
+import { useState } from 'react'
+
+interface AddCustomMetadataProviderModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (payload: CreateCustomMetadataProviderPayload) => Promise<void>
+}
+
+export default function AddCustomMetadataProviderModal({ isOpen, onClose, onSubmit }: AddCustomMetadataProviderModalProps) {
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+
+  const [name, setName] = useState('')
+  const [url, setUrl] = useState('')
+  const [authHeaderValue, setAuthHeaderValue] = useState('')
+  const [processing, setProcessing] = useState(false)
+
+  const reset = () => {
+    setName('')
+    setUrl('')
+    setAuthHeaderValue('')
+    setProcessing(false)
+  }
+
+  const handleClose = () => {
+    if (processing) return
+    reset()
+    onClose()
+  }
+
+  const handleSubmit = async () => {
+    const trimmedName = name.trim()
+    const trimmedUrl = url.trim()
+
+    if (!trimmedName || !trimmedUrl) {
+      showToast(t('ToastProviderNameAndUrlRequired'), { type: 'error' })
+      return
+    }
+
+    try {
+      setProcessing(true)
+      await onSubmit({
+        name: trimmedName,
+        url: trimmedUrl,
+        mediaType: 'book',
+        authHeaderValue: authHeaderValue.trim() || undefined
+      })
+      showToast(t('ToastProviderCreatedSuccess'), { type: 'success' })
+      handleClose()
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error'
+      console.error('Failed to add provider', error)
+      showToast(`${t('ToastProviderCreatedFailed')}: ${errorMessage}`, { type: 'error' })
+      setProcessing(false)
+    }
+  }
+
+  const outerContentTitle = (
+    <div className="absolute top-0 start-0 p-4">
+      <h2 className="text-xl text-foreground">{t('HeaderAddCustomMetadataProvider')}</h2>
+    </div>
+  )
+
+  return (
+    <Modal isOpen={isOpen} processing={processing} onClose={handleClose} outerContent={outerContentTitle} className="w-[700px]">
+      <div className="flex flex-col max-h-[90vh]">
+        <div className="px-4 sm:px-6 py-6 overflow-y-auto">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 md:gap-6">
+            <div className="md:col-span-3">
+              <TextInput label={t('LabelName')} value={name} placeholder={t('LabelName')} onChange={setName} />
+            </div>
+            <div className="md:col-span-1">
+              <TextInput label={t('LabelMediaType')} value="Book" readOnly />
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <TextInput label="URL" value={url} placeholder="URL" onChange={setUrl} />
+          </div>
+
+          <div className="mt-4">
+            <TextInput
+              label={t('LabelProviderAuthorizationValue')}
+              value={authHeaderValue}
+              placeholder={t('LabelProviderAuthorizationValue')}
+              type="password"
+              onChange={setAuthHeaderValue}
+            />
+          </div>
+        </div>
+
+        <div className="border-t border-border px-4 py-3">
+          <div className="flex items-center justify-end">
+            <Btn color="bg-success" disabled={processing} onClick={handleSubmit}>
+              {t('ButtonAdd')}
+            </Btn>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/CustomMetadataProvidersClient.tsx
+++ b/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/CustomMetadataProvidersClient.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { CustomMetadataProvider } from '@/types/api'
+import { useState } from 'react'
+import SettingsContent from '../../SettingsContent'
+import { createCustomMetadataProvider, deleteCustomMetadataProvider } from './actions'
+import AddCustomMetadataProviderModal from './AddCustomMetadataProviderModal'
+import CustomMetadataProvidersTable from './CustomMetadataProvidersTable'
+
+interface CustomMetadataProvidersClientProps {
+  providers: CustomMetadataProvider[]
+}
+
+export default function CustomMetadataProvidersClient({ providers: initialProviders }: CustomMetadataProvidersClientProps) {
+  const t = useTypeSafeTranslations()
+
+  const [providers, setProviders] = useState<CustomMetadataProvider[]>(initialProviders)
+  const [processing, setProcessing] = useState(false)
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false)
+
+  const handleAddProvider = async (payload: { name: string; url: string; mediaType: 'book' | 'podcast'; authHeaderValue?: string }) => {
+    const result = await createCustomMetadataProvider(payload)
+    setProviders((prev) => [...prev, result.provider])
+  }
+
+  const handleDeleteProvider = async (providerId: string) => {
+    setProcessing(true)
+
+    try {
+      await deleteCustomMetadataProvider(providerId)
+      setProviders((prev) => prev.filter((provider) => provider.id !== providerId))
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  return (
+    <SettingsContent
+      title={t('HeaderCustomMetadataProviders')}
+      backLink="/settings/item-metadata-utils"
+      moreInfoUrl="https://www.audiobookshelf.org/guides/custom-metadata-providers"
+      addButton={{
+        label: t('ButtonAdd'),
+        onClick: () => setIsAddModalOpen(true)
+      }}
+    >
+      <div className="pt-2">
+        <CustomMetadataProvidersTable providers={providers} processing={processing} onDeleteProvider={handleDeleteProvider} />
+      </div>
+
+      <AddCustomMetadataProviderModal isOpen={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} onSubmit={handleAddProvider} />
+    </SettingsContent>
+  )
+}

--- a/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/CustomMetadataProvidersTable.tsx
+++ b/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/CustomMetadataProvidersTable.tsx
@@ -86,7 +86,7 @@ export default function CustomMetadataProvidersTable({ providers, processing = f
               borderless
               size="small"
               className="text-foreground-muted hover:not-disabled:text-error"
-              loading={deletingProviderId === provider.id || processing}
+              loading={deletingProviderId === provider.id && processing}
               onClick={() => handleDeleteClick(provider)}
             >
               delete

--- a/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/CustomMetadataProvidersTable.tsx
+++ b/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/CustomMetadataProvidersTable.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import DataTable, { DataTableColumn } from '@/components/ui/DataTable'
+import IconBtn from '@/components/ui/IconBtn'
+import ConfirmDialog from '@/components/widgets/ConfirmDialog'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { mergeClasses } from '@/lib/merge-classes'
+import { CustomMetadataProvider } from '@/types/api'
+import { useMemo, useRef, useState } from 'react'
+
+interface CustomMetadataProvidersTableProps {
+  providers: CustomMetadataProvider[]
+  processing?: boolean
+  onDeleteProvider: (providerId: string) => Promise<void>
+}
+
+function MaskedAuthValue({ authHeaderValue }: { authHeaderValue: string | null }) {
+  if (!authHeaderValue) return null
+
+  return (
+    <span
+      className={mergeClasses(
+        'inline-block rounded px-1 py-[1px] transition-all duration-300',
+        'bg-table-header-bg text-transparent hover:text-foreground hover:bg-transparent'
+      )}
+    >
+      {authHeaderValue}
+    </span>
+  )
+}
+
+export default function CustomMetadataProvidersTable({ providers, processing = false, onDeleteProvider }: CustomMetadataProvidersTableProps) {
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+
+  const deletingProviderRef = useRef<CustomMetadataProvider | null>(null)
+
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false)
+  const [deletingProviderId, setDeletingProviderId] = useState<string | null>(null)
+
+  const handleDeleteClick = (provider: CustomMetadataProvider) => {
+    deletingProviderRef.current = provider
+    setShowConfirmDialog(true)
+  }
+
+  const handleConfirmDelete = async () => {
+    const provider = deletingProviderRef.current
+    if (!provider) return
+
+    setShowConfirmDialog(false)
+    setDeletingProviderId(provider.id)
+
+    try {
+      await onDeleteProvider(provider.id)
+      showToast(t('ToastProviderRemoveSuccess'), { type: 'success' })
+    } catch (error) {
+      console.error('Failed to remove provider', error)
+      showToast(t('ToastRemoveFailed'), { type: 'error' })
+    } finally {
+      setDeletingProviderId(null)
+      deletingProviderRef.current = null
+    }
+  }
+
+  const columns = useMemo<DataTableColumn<CustomMetadataProvider>[]>(
+    () => [
+      {
+        label: t('LabelName'),
+        accessor: 'name'
+      },
+      {
+        label: 'URL',
+        accessor: 'url'
+      },
+      {
+        label: t('LabelProviderAuthorizationValue'),
+        accessor: (provider) => <MaskedAuthValue authHeaderValue={provider.authHeaderValue} />
+      },
+      {
+        label: '',
+        accessor: (provider) => (
+          <div className="flex items-center justify-end">
+            <IconBtn
+              ariaLabel={t('ButtonDelete')}
+              borderless
+              size="small"
+              className="text-foreground-muted hover:not-disabled:text-error"
+              loading={deletingProviderId === provider.id || processing}
+              onClick={() => handleDeleteClick(provider)}
+            >
+              delete
+            </IconBtn>
+          </div>
+        )
+      }
+    ],
+    [deletingProviderId, processing, t]
+  )
+
+  if (!providers.length) {
+    return (
+      <div className="text-center py-8">
+        <p className="text-lg">{t('LabelNoCustomMetadataProviders')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <DataTable
+        data={providers}
+        columns={columns}
+        getRowKey={(provider) => provider.id}
+        rowClassName="bg-table-row-bg-odd even:bg-table-row-bg-even hover:bg-table-row-bg-hover"
+      />
+
+      <ConfirmDialog
+        isOpen={showConfirmDialog}
+        message={t('MessageConfirmDeleteMetadataProvider', { 0: deletingProviderRef.current?.name || '' })}
+        yesButtonText={t('ButtonDelete')}
+        yesButtonClassName="bg-error text-white"
+        onClose={() => setShowConfirmDialog(false)}
+        onConfirm={handleConfirmDelete}
+      />
+    </>
+  )
+}

--- a/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/actions.ts
+++ b/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/actions.ts
@@ -1,0 +1,16 @@
+'use server'
+
+import * as api from '@/lib/api'
+import { CreateCustomMetadataProviderPayload, CreateCustomMetadataProviderResponse } from '@/types/api'
+import { revalidatePath } from 'next/cache'
+
+export async function createCustomMetadataProvider(payload: CreateCustomMetadataProviderPayload): Promise<CreateCustomMetadataProviderResponse> {
+  const result = await api.createCustomMetadataProvider(payload)
+  revalidatePath('/settings/item-metadata-utils/custom-metadata-providers')
+  return result
+}
+
+export async function deleteCustomMetadataProvider(providerId: string): Promise<void> {
+  await api.deleteCustomMetadataProvider(providerId)
+  revalidatePath('/settings/item-metadata-utils/custom-metadata-providers')
+}

--- a/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/page.tsx
+++ b/src/app/(main)/settings/item-metadata-utils/custom-metadata-providers/page.tsx
@@ -1,17 +1,11 @@
-import { getTypeSafeTranslations } from '@/lib/getTypeSafeTranslations'
-import SettingsContent from '../../SettingsContent'
+import { getCustomMetadataProviders, getData } from '@/lib/api'
+import CustomMetadataProvidersClient from './CustomMetadataProvidersClient'
 
 export const dynamic = 'force-dynamic'
 
 export default async function ItemMetadataUtilsCustomMetadataProvidersPage() {
-  const t = await getTypeSafeTranslations()
-  return (
-    <SettingsContent
-      title={t('HeaderCustomMetadataProviders')}
-      backLink="/settings/item-metadata-utils"
-      moreInfoUrl="https://www.audiobookshelf.org/guides/custom-metadata-providers"
-    >
-      <div></div>
-    </SettingsContent>
-  )
+  const [providersResponse] = await getData(getCustomMetadataProviders())
+  const providers = providersResponse?.providers || []
+
+  return <CustomMetadataProvidersClient providers={providers} />
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,8 @@ import {
   BookSearchResult,
   Collection,
   CreateApiKeyPayload,
+  CreateCustomMetadataProviderPayload,
+  CreateCustomMetadataProviderResponse,
   CreateUpdateApiKeyResponse,
   FetchPodcastFeedResponse,
   FFProbeData,
@@ -18,6 +20,7 @@ import {
   GetAuthorsResponse,
   GetBackupsResponse,
   GetCollectionsResponse,
+  GetCustomMetadataProvidersResponse,
   GetFilesystemPathsResponse,
   GetLibrariesResponse,
   GetLibraryItemsResponse,
@@ -472,6 +475,23 @@ export async function updateApiKey(apiKeyId: string, payload: CreateApiKeyPayloa
 export const getRssFeeds = cache(async (): Promise<GetRssFeedsResponse> => {
   return apiRequest<GetRssFeedsResponse>('/api/feeds', {})
 })
+
+export const getCustomMetadataProviders = cache(async (): Promise<GetCustomMetadataProvidersResponse> => {
+  return apiRequest<GetCustomMetadataProvidersResponse>('/api/custom-metadata-providers', {})
+})
+
+export const deleteCustomMetadataProvider = cache(async (providerId: string): Promise<void> => {
+  return apiRequest<void>(`/api/custom-metadata-providers/${providerId}`, {
+    method: 'DELETE'
+  })
+})
+
+export async function createCustomMetadataProvider(payload: CreateCustomMetadataProviderPayload): Promise<CreateCustomMetadataProviderResponse> {
+  return apiRequest<CreateCustomMetadataProviderResponse>('/api/custom-metadata-providers', {
+    method: 'POST',
+    body: JSON.stringify(payload)
+  })
+}
 
 export const closeRssFeed = cache(async (feedId: string): Promise<void> => {
   return apiRequest<void>(`/api/feeds/${feedId}/close`, {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -880,6 +880,31 @@ export interface CreateUpdateApiKeyResponse {
   apiKey: ApiKey
 }
 
+export interface CustomMetadataProvider {
+  id: string
+  name: string
+  mediaType: 'book' | 'podcast'
+  url: string
+  authHeaderValue: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export interface GetCustomMetadataProvidersResponse {
+  providers: CustomMetadataProvider[]
+}
+
+export interface CreateCustomMetadataProviderPayload {
+  name: string
+  url: string
+  mediaType: 'book' | 'podcast'
+  authHeaderValue?: string
+}
+
+export interface CreateCustomMetadataProviderResponse {
+  provider: CustomMetadataProvider
+}
+
 // ============================================================================
 // BACKUPS
 // ============================================================================


### PR DESCRIPTION
As this is my first contribution and there is no contribution file, I would be happy to get feedback, as I plan to add a few more views that are not main views to help bring the client to a state where it has feature parity with the old Vue client. If the contribution is not accepted at the moment, please say so.

> [!NOTE]
> prettier was not run globally, but it should be applied to the changed fieles, as there are multiple files that would have been changed outside of this PR. Maybe it would make sense to have a seperate PR that fixes all outstanding prettier issues

This pull request introduces a complete implementation for managing custom metadata providers in the settings UI. The changes add a new CRUD interface for listing, creating, and deleting custom metadata providers, including all necessary API integration, UI components, and type definitions.

* Added new API methods to fetch, create, and delete custom metadata providers
* Created files needed for CustomMetadataProviders
* Implemented server actions in `actions.ts` to wrap API calls and trigger cache revalidation after provider changes.