### PR TITLE
add byte details to upload and fix upload x button showing

### DIFF
--- a/src/app/(main)/upload/UploadClient.tsx
+++ b/src/app/(main)/upload/UploadClient.tsx
@@ -209,6 +209,10 @@ export default function UploadClient({ libraries }: LibraryClientProps) {
   }
 
   function handleRemoveStagedItem(itemIndex: number): void {
+    if (uploadProcessing || uploadItems[itemIndex]?.isUploading) {
+      return
+    }
+
     if (uploadItems.length === 1) {
       resetUpload()
       return
@@ -401,9 +405,14 @@ export default function UploadClient({ libraries }: LibraryClientProps) {
                       <p className="text-base">{'#' + (index + 1)}</p>
                     </div>
                     {/* floating x on right */}
-                    <IconBtn className="absolute -top-3 -right-3 w-8 h-8 bg-bg border border-border rounded-full" onClick={() => handleRemoveStagedItem(index)}>
-                      close
-                    </IconBtn>
+                    {!uploadProcessing && !item.isUploading && (
+                      <IconBtn
+                        className="absolute -top-3 -right-3 w-8 h-8 bg-bg border border-border rounded-full"
+                        onClick={() => handleRemoveStagedItem(index)}
+                      >
+                        close
+                      </IconBtn>
+                    )}
                     {item.metadataError && (
                       <Alert type="error" autoFocus={false}>
                         <p>{item.metadataError}</p>

--- a/src/app/(main)/upload/UploadClient.tsx
+++ b/src/app/(main)/upload/UploadClient.tsx
@@ -21,7 +21,7 @@ import { sanitizeFileName, SupportedFileTypes } from '@/lib/fileUtils'
 import { bytesPretty } from '@/lib/string'
 import { Library } from '@/types/api'
 import path from 'path'
-import { CleanedItem, FileWithMetadata, getItemsFromFilelist, upload } from './UploadHelper'
+import { CleanedItem, FileWithMetadata, getItemsFromFilelist, upload, UploadProgressInfo } from './UploadHelper'
 import { fetchBookMetadata, fetchPodcastMetadata, getCookie } from './actions'
 
 export interface ItemToUpload extends CleanedItem {
@@ -29,6 +29,8 @@ export interface ItemToUpload extends CleanedItem {
   isFetchingMetadata?: boolean
   isUploading?: boolean
   uploadProgress?: number
+  uploadBytesLoaded?: number
+  uploadBytesTotal?: number
   uploadError?: string
   uploadComplete?: boolean
   uploadFailed?: boolean
@@ -223,10 +225,14 @@ export default function UploadClient({ libraries }: LibraryClientProps) {
     for (const item of uploadItems) {
       item.isUploading = true
       item.uploadProgress = 0
+      item.uploadBytesLoaded = 0
+      item.uploadBytesTotal = item.itemFiles.reduce((sum, file) => sum + file.size, 0)
 
       try {
-        await upload(item, selectedLibrary!, selectedFolder!, currentLibraryMediaType!, cookie, (progress) => {
-          item.uploadProgress = progress
+        await upload(item, selectedLibrary!, selectedFolder!, currentLibraryMediaType!, cookie, (progress: UploadProgressInfo) => {
+          item.uploadProgress = progress.percent
+          item.uploadBytesLoaded = progress.loaded
+          item.uploadBytesTotal = progress.total
           const updatedItemsForProgress = [...uploadItems]
           setUploadItems(updatedItemsForProgress)
         })
@@ -384,6 +390,9 @@ export default function UploadClient({ libraries }: LibraryClientProps) {
                     {item.isUploading && (
                       <LoadingIndicator label={'MessageUploading'}>
                         <ProgressIndicator progress={item.uploadProgress || 0} />
+                        <p className="text-xs text-foreground-muted mt-2 text-center">
+                          ({bytesPretty(item.uploadBytesLoaded || 0)}/{bytesPretty(item.uploadBytesTotal || 0)})
+                        </p>
                       </LoadingIndicator>
                     )}
                     {item.isFetchingMetadata && <LoadingIndicator label="LabelFetchingMetadata" />}

--- a/src/app/(main)/upload/UploadHelper.ts
+++ b/src/app/(main)/upload/UploadHelper.ts
@@ -27,6 +27,12 @@ export interface ProcessedItems {
   error?: string
 }
 
+export interface UploadProgressInfo {
+  percent: number
+  loaded: number
+  total: number
+}
+
 /**
  * Check file type based on extension
  */
@@ -188,7 +194,7 @@ export async function upload(
   folderId: string,
   mediaType: Library['mediaType'],
   cookie: string,
-  onProgress?: (progress: number) => void
+  onProgress?: (progress: UploadProgressInfo) => void
 ): Promise<void> {
   const form = new FormData()
   form.set('title', item.title)
@@ -213,14 +219,24 @@ export async function upload(
     // Track upload progress
     xhr.upload.onprogress = (event) => {
       if (event.lengthComputable && onProgress) {
-        const progress = Math.round((event.loaded / event.total) * 100)
-        onProgress(progress)
+        onProgress({
+          percent: Math.round((event.loaded / event.total) * 100),
+          loaded: event.loaded,
+          total: event.total
+        })
       }
     }
 
     xhr.onload = () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        if (onProgress) onProgress(100)
+        if (onProgress) {
+          const totalSize = item.itemFiles.reduce((sum, file) => sum + file.size, 0)
+          onProgress({
+            percent: 100,
+            loaded: totalSize,
+            total: totalSize
+          })
+        }
         resolve()
       } else {
         reject(new Error(`Upload failed with status ${xhr.status}`))


### PR DESCRIPTION
Adds a byte-level progress. This also shows a direct feedback to the user even if the percentage did not move for a while and adds parity with the old client. It's a small QoL

<img width="163" height="152" alt="image" src="https://github.com/user-attachments/assets/f80a3efe-b840-4292-9f45-2c45f15995e7" />


Also removes the x button when the upload process started, like the current client does. Currently one can click the x button, but it will not actually remove it, but the upload state is overwritten and allowing the same upload again, while uploading the other file.


<img width="1146" height="372" alt="image" src="https://github.com/user-attachments/assets/5e19cf96-9c9a-4fad-96b6-618587501ac2" />


