### PR TITLE
Add token refresh logic to download routes

### DIFF
--- a/src/app/internal-api/items/[id]/download/route.ts
+++ b/src/app/internal-api/items/[id]/download/route.ts
@@ -1,4 +1,5 @@
 import { getServerBaseUrl } from '@/lib/api'
+import { attachRefreshedSessionCookies, fetchBackendDownloadWithCookieRefresh, respondDownloadProxyFailure } from '@/lib/serverDownloadProxy'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -7,50 +8,44 @@ import { NextRequest, NextResponse } from 'next/server'
  *
  * This forwards requests to the backend `/api/items/:id/download` endpoint
  * and authenticates using the httpOnly `access_token` cookie.
+ * If the access token is expired, refreshes using `refresh_token` and retries
+ * so plain `<a href>` downloads keep working.
  */
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const cookieStore = await cookies()
-  const accessToken = cookieStore.get('access_token')?.value
-
-  if (!accessToken) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
 
   try {
     const baseUrl = getServerBaseUrl()
     const backendUrl = `${baseUrl}/api/items/${id}/download`
 
-    const response = await fetch(backendUrl, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`
-      }
-    })
-
-    if (!response.ok) {
-      if (response.status === 401) {
-        return NextResponse.json({ error: 'Unauthorized - token may be expired' }, { status: 401 })
-      }
-      return NextResponse.json({ error: `Backend error: ${response.statusText}` }, { status: response.status })
+    const result = await fetchBackendDownloadWithCookieRefresh(backendUrl, cookieStore)
+    if (!result.ok) {
+      return respondDownloadProxyFailure(request, result)
     }
 
+    const { upstream: response, refreshedTokens } = result
+
     if (!response.body) {
-      return NextResponse.json({ error: 'Backend returned empty download stream' }, { status: 502 })
+      return attachRefreshedSessionCookies(NextResponse.json({ error: 'Backend returned empty download stream' }, { status: 502 }), refreshedTokens)
     }
 
     const contentType = response.headers.get('content-type') || 'application/octet-stream'
     const contentDisposition = response.headers.get('content-disposition') || 'attachment'
     const contentLength = response.headers.get('content-length')
 
-    return new NextResponse(response.body, {
-      status: 200,
-      headers: {
-        'Content-Type': contentType,
-        'Content-Disposition': contentDisposition,
-        ...(contentLength ? { 'Content-Length': contentLength } : {}),
-        'Cache-Control': 'no-cache'
-      }
-    })
+    return attachRefreshedSessionCookies(
+      new NextResponse(response.body, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Content-Disposition': contentDisposition,
+          ...(contentLength ? { 'Content-Length': contentLength } : {}),
+          'Cache-Control': 'no-cache'
+        }
+      }),
+      refreshedTokens
+    )
   } catch (error) {
     console.error('[LibraryItemDownload] Error fetching item download:', error)
     return NextResponse.json({ error: 'Failed to fetch library item download' }, { status: 500 })

--- a/src/app/internal-api/items/[id]/file/[fileId]/download/route.ts
+++ b/src/app/internal-api/items/[id]/file/[fileId]/download/route.ts
@@ -1,4 +1,5 @@
 import { getServerBaseUrl } from '@/lib/api'
+import { attachRefreshedSessionCookies, fetchBackendDownloadWithCookieRefresh, respondDownloadProxyFailure } from '@/lib/serverDownloadProxy'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -7,6 +8,7 @@ import { NextRequest, NextResponse } from 'next/server'
  *
  * This route acts as a proxy to the backend server for file downloads,
  * using the httpOnly access_token cookie for authentication.
+ * Refreshes the session when the access token is expired so `<a href>` downloads work.
  *
  * The Content-Disposition header forces the browser to download the file
  * instead of displaying it.
@@ -14,28 +16,17 @@ import { NextRequest, NextResponse } from 'next/server'
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string; fileId: string }> }) {
   const { id, fileId } = await params
   const cookieStore = await cookies()
-  const accessToken = cookieStore.get('access_token')?.value
-
-  if (!accessToken) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
 
   try {
     const baseUrl = getServerBaseUrl()
     const backendUrl = `${baseUrl}/api/items/${id}/file/${fileId}/download`
 
-    const response = await fetch(backendUrl, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`
-      }
-    })
-
-    if (!response.ok) {
-      if (response.status === 401) {
-        return NextResponse.json({ error: 'Unauthorized - token may be expired' }, { status: 401 })
-      }
-      return NextResponse.json({ error: `Backend error: ${response.statusText}` }, { status: response.status })
+    const result = await fetchBackendDownloadWithCookieRefresh(backendUrl, cookieStore)
+    if (!result.ok) {
+      return respondDownloadProxyFailure(request, result)
     }
+
+    const { upstream: response, refreshedTokens } = result
 
     // Get the file data
     const fileBuffer = await response.arrayBuffer()
@@ -43,14 +34,17 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     const contentDisposition = response.headers.get('content-disposition') || 'attachment'
 
     // Return the file with appropriate headers
-    return new NextResponse(fileBuffer, {
-      status: 200,
-      headers: {
-        'Content-Type': contentType,
-        'Content-Disposition': contentDisposition,
-        'Cache-Control': 'no-cache'
-      }
-    })
+    return attachRefreshedSessionCookies(
+      new NextResponse(fileBuffer, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Content-Disposition': contentDisposition,
+          'Cache-Control': 'no-cache'
+        }
+      }),
+      refreshedTokens
+    )
   } catch (error) {
     console.error('[FileDownload] Error fetching file:', error)
     return NextResponse.json({ error: 'Failed to fetch file' }, { status: 500 })

--- a/src/app/internal-api/refresh/route.ts
+++ b/src/app/internal-api/refresh/route.ts
@@ -1,4 +1,4 @@
-import { getClientBaseUrlFromRequest, getUserDefaultUrlPath, refreshSessionWithToken, setTokenCookies } from '@/lib/api'
+import { getClientBaseUrlFromRequest, getUserDefaultUrlPath, redirectToLogin, refreshSessionWithToken, setTokenCookies } from '@/lib/api'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
@@ -42,12 +42,7 @@ async function handleRefresh(request: Request) {
     const session = await refreshSessionWithToken(refreshToken)
 
     if (!session) {
-      // Refresh failed, redirect to login page and delete refresh token cookie
-      const redirectUrl = new URL('/login', clientBaseUrl)
-      redirectUrl.searchParams.set('error', 'Token refresh failed')
-      const response = NextResponse.redirect(redirectUrl)
-      response.cookies.delete('refresh_token')
-      return response
+      return redirectToLogin(request, 'Token refresh failed')
     }
 
     const { accessToken: newAccessToken, refreshToken: newRefreshToken } = session
@@ -69,11 +64,6 @@ async function handleRefresh(request: Request) {
     return response
   } catch (error) {
     console.error('Token refresh error:', error)
-    // Redirect to login page and delete refresh token cookie
-    const redirectUrl = new URL('/login', clientBaseUrl)
-    redirectUrl.searchParams.set('error', 'Internal server error')
-    const response = NextResponse.redirect(redirectUrl)
-    response.cookies.delete('refresh_token')
-    return response
+    return redirectToLogin(request, 'Internal server error')
   }
 }

--- a/src/app/internal-api/refresh/route.ts
+++ b/src/app/internal-api/refresh/route.ts
@@ -1,20 +1,8 @@
-import { getServerBaseUrl, getUserDefaultUrlPath, setTokenCookies } from '@/lib/api'
+import { getClientBaseUrlFromRequest, getUserDefaultUrlPath, refreshSessionWithToken, setTokenCookies } from '@/lib/api'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 const rscMap = new Map<string, boolean>()
-
-/**
- * Get the client-facing base URL from request headers.
- * This is needed for redirects since the server's internal URL (localhost)
- * differs from the URL the client used to reach the server.
- */
-function getClientBaseUrl(request: Request): string {
-  const headers = new Headers(request.headers)
-  const host = headers.get('x-forwarded-host') || headers.get('host') || 'localhost'
-  const protocol = headers.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
-  return `${protocol}://${host}`
-}
 
 export async function GET(request: Request) {
   return handleRefresh(request)
@@ -25,10 +13,8 @@ export async function POST(request: Request) {
 }
 
 async function handleRefresh(request: Request) {
-  // Server URL for backend API calls (internal network)
-  const audiobookshelfServerUrl = getServerBaseUrl()
   // Client URL for browser redirects (what the user sees)
-  const clientBaseUrl = getClientBaseUrl(request)
+  const clientBaseUrl = getClientBaseUrlFromRequest(request)
 
   try {
     const cookieStore = await cookies()
@@ -53,17 +39,9 @@ async function handleRefresh(request: Request) {
       }
     }
 
-    // Make refresh request to the Audiobookshelf server
-    const refreshResponse = await fetch(`${audiobookshelfServerUrl}/auth/refresh`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        // Passing the refresh token in header is an alternative to using the Abs server cookie
-        'x-refresh-token': refreshToken
-      }
-    })
+    const session = await refreshSessionWithToken(refreshToken)
 
-    if (!refreshResponse.ok) {
+    if (!session) {
       // Refresh failed, redirect to login page and delete refresh token cookie
       const redirectUrl = new URL('/login', clientBaseUrl)
       redirectUrl.searchParams.set('error', 'Token refresh failed')
@@ -72,13 +50,7 @@ async function handleRefresh(request: Request) {
       return response
     }
 
-    const data = await refreshResponse.json()
-    const newAccessToken = data.user.accessToken
-    const newRefreshToken = data.user.refreshToken
-
-    if (!newAccessToken) {
-      return NextResponse.json({ error: 'No new access token received' }, { status: 500 })
-    }
+    const { accessToken: newAccessToken, refreshToken: newRefreshToken } = session
 
     // If the request is an API request, dont redirect (used in socket auth_failed handler)
     if (request.headers.get('accept') === 'application/json') {
@@ -88,7 +60,7 @@ async function handleRefresh(request: Request) {
     }
 
     // Get redirect URL from query parameters or default to user default path
-    const redirectUrlPath = url.searchParams.get('redirect') || getUserDefaultUrlPath(data.userDefaultLibraryId, data.user.type)
+    const redirectUrlPath = url.searchParams.get('redirect') || getUserDefaultUrlPath(session.userDefaultLibraryId, session.userType)
     const redirectUrl = new URL(redirectUrlPath, clientBaseUrl)
 
     const response = NextResponse.redirect(redirectUrl)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -104,9 +104,19 @@ export function getServerBaseUrl() {
 export function getClientBaseUrlFromRequest(request: Request): string {
   const headers = new Headers(request.headers)
   const host = headers.get('x-forwarded-host') || headers.get('host') || 'localhost'
-  const protocol =
-    headers.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
+  const protocol = headers.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
   return `${protocol}://${host}`
+}
+
+/**
+ * Send the browser to /login with an error hint and drop refresh cookie (session cannot continue).
+ */
+export function redirectToLogin(request: Request, errorMessage: string): NextResponse {
+  const login = new URL('/login', getClientBaseUrlFromRequest(request))
+  login.searchParams.set('error', errorMessage)
+  const response = NextResponse.redirect(login)
+  response.cookies.delete('refresh_token')
+  return response
 }
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,6 +98,18 @@ export function getServerBaseUrl() {
 }
 
 /**
+ * Client-facing origin from request headers (for redirects out of internal API routes).
+ * The server may use an internal hostname; the browser must be sent to the URL it used.
+ */
+export function getClientBaseUrlFromRequest(request: Request): string {
+  const headers = new Headers(request.headers)
+  const host = headers.get('x-forwarded-host') || headers.get('host') || 'localhost'
+  const protocol =
+    headers.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
+  return `${protocol}://${host}`
+}
+
+/**
  * User "Home" page is the default library page, or settings/account page if no libraries are set yet
  */
 export function getUserDefaultUrlPath(userDefaultLibraryId: string | null, userType: string) {
@@ -128,6 +140,54 @@ export function setTokenCookies(response: NextResponse, accessToken: string, ref
       // Ensure the cookie is not expired before the refresh token expires (5 second buffer)
       maxAge: Math.max(RefreshTokenExpiry - 5, 5)
     })
+  }
+}
+
+/** New tokens from POST /auth/refresh (same shape as internal-api/refresh). */
+export type SessionRefreshTokens = {
+  accessToken: string
+  refreshToken: string | null
+}
+
+/** Full `/auth/refresh` payload used by internal-api/refresh for redirects. */
+export type SessionRefreshResult = SessionRefreshTokens & {
+  userDefaultLibraryId: string | null
+  userType: string
+}
+
+/**
+ * Exchange a refresh token for new session tokens (server-side).
+ * Used by internal-api/refresh and download proxies that cannot rely on a redirect.
+ */
+export async function refreshSessionWithToken(refreshToken: string): Promise<SessionRefreshResult | null> {
+  const baseUrl = getServerBaseUrl()
+  const refreshResponse = await fetch(`${baseUrl}/auth/refresh`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-refresh-token': refreshToken
+    }
+  })
+
+  if (!refreshResponse.ok) {
+    return null
+  }
+
+  const data = (await refreshResponse.json()) as {
+    userDefaultLibraryId?: string | null
+    user?: { accessToken?: string; refreshToken?: string; type?: string }
+  }
+
+  const accessToken = data.user?.accessToken
+  if (!accessToken) {
+    return null
+  }
+
+  return {
+    accessToken,
+    refreshToken: data.user?.refreshToken ?? null,
+    userDefaultLibraryId: data.userDefaultLibraryId ?? null,
+    userType: data.user?.type ?? 'user'
   }
 }
 

--- a/src/lib/serverDownloadProxy.ts
+++ b/src/lib/serverDownloadProxy.ts
@@ -1,0 +1,119 @@
+import { getClientBaseUrlFromRequest, refreshSessionWithToken, SessionRefreshResult, SessionRefreshTokens, setTokenCookies } from '@/lib/api'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+import Logger from './Logger'
+
+export function attachRefreshedSessionCookies(response: NextResponse, refreshedTokens: SessionRefreshTokens | null): NextResponse {
+  if (refreshedTokens) {
+    setTokenCookies(response, refreshedTokens.accessToken, refreshedTokens.refreshToken)
+  }
+  return response
+}
+
+export type BackendDownloadFetchResult =
+  | {
+      ok: true
+      upstream: Response
+      /** When set, access/refresh changed this request — call setTokenCookies on the NextResponse. */
+      refreshedTokens: SessionRefreshTokens | null
+    }
+  | {
+      ok: false
+      status: number
+      error: string
+      refreshedTokens: SessionRefreshTokens | null
+    }
+
+/**
+ * For browser navigation (`<a href>` downloads), 401 → redirect to login like internal-api/refresh.
+ * Clients that send `Accept: application/json` keep a JSON body (e.g. programmatic use).
+ */
+export function respondDownloadProxyFailure(
+  request: NextRequest,
+  result: Extract<BackendDownloadFetchResult, { ok: false }>
+): NextResponse {
+  if (result.status === 401 && request.headers.get('accept') !== 'application/json') {
+    const login = new URL('/login', getClientBaseUrlFromRequest(request))
+    login.searchParams.set('error', 'Session expired')
+    const response = NextResponse.redirect(login)
+    response.cookies.delete('refresh_token')
+    return response
+  }
+  return attachRefreshedSessionCookies(NextResponse.json({ error: result.error }, { status: result.status }), result.refreshedTokens)
+}
+
+/**
+ * GET a backend download URL using cookies, refreshing tokens once if the access token expired.
+ */
+export async function fetchBackendDownloadWithCookieRefresh(
+  backendUrl: string,
+  cookieStore: Awaited<ReturnType<typeof cookies>>
+): Promise<BackendDownloadFetchResult> {
+  const tokens = {
+    access: cookieStore.get('access_token')?.value ?? null,
+    refresh: cookieStore.get('refresh_token')?.value ?? null
+  }
+  const initial = { access: tokens.access, refresh: tokens.refresh }
+  Logger.info(`[fetchBackendDownloadWithCookieRefresh] tokens: has access: ${tokens.access !== null}, has refresh: ${tokens.refresh !== null}`)
+
+  const cookiesToSetIfDirty = (): SessionRefreshTokens | null => {
+    if (!tokens.access) return null
+    if (tokens.access === initial.access && tokens.refresh === initial.refresh) return null
+    return { accessToken: tokens.access, refreshToken: tokens.refresh }
+  }
+
+  if (!tokens.access && !tokens.refresh) {
+    return { ok: false, status: 401, error: 'Unauthorized', refreshedTokens: null }
+  }
+
+  const applySession = (session: SessionRefreshResult) => {
+    tokens.access = session.accessToken
+    if (session.refreshToken) {
+      tokens.refresh = session.refreshToken
+    }
+  }
+
+  if (!tokens.access && tokens.refresh) {
+    const session = await refreshSessionWithToken(tokens.refresh)
+    Logger.info(`[fetchBackendDownloadWithCookieRefresh] refreshSessionWithToken: session: ${session !== null}`)
+    if (!session) {
+      return { ok: false, status: 401, error: 'Unauthorized', refreshedTokens: null }
+    }
+    applySession(session)
+  }
+
+  let upstream = await fetch(backendUrl, {
+    headers: { Authorization: `Bearer ${tokens.access!}` }
+  })
+  Logger.info(`[fetchBackendDownloadWithCookieRefresh] fetch: upstream: ${upstream.status}`)
+
+  if (upstream.status === 401 && tokens.refresh) {
+    const session = await refreshSessionWithToken(tokens.refresh)
+    if (session) {
+      applySession(session)
+      upstream = await fetch(backendUrl, {
+        headers: { Authorization: `Bearer ${tokens.access!}` }
+      })
+    }
+  }
+
+  if (upstream.status === 401) {
+    return {
+      ok: false,
+      status: 401,
+      error: 'Unauthorized - token may be expired',
+      refreshedTokens: cookiesToSetIfDirty()
+    }
+  }
+
+  if (!upstream.ok) {
+    return {
+      ok: false,
+      status: upstream.status,
+      error: `Backend error: ${upstream.statusText}`,
+      refreshedTokens: cookiesToSetIfDirty()
+    }
+  }
+
+  return { ok: true, upstream, refreshedTokens: cookiesToSetIfDirty() }
+}

--- a/src/lib/serverDownloadProxy.ts
+++ b/src/lib/serverDownloadProxy.ts
@@ -1,4 +1,4 @@
-import { getClientBaseUrlFromRequest, refreshSessionWithToken, SessionRefreshResult, SessionRefreshTokens, setTokenCookies } from '@/lib/api'
+import { redirectToLogin, refreshSessionWithToken, SessionRefreshResult, SessionRefreshTokens, setTokenCookies } from '@/lib/api'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
 import Logger from './Logger'
@@ -30,11 +30,7 @@ export type BackendDownloadFetchResult =
  */
 export function respondDownloadProxyFailure(request: NextRequest, result: Extract<BackendDownloadFetchResult, { ok: false }>): NextResponse {
   if (result.status === 401 && request.headers.get('accept') !== 'application/json') {
-    const login = new URL('/login', getClientBaseUrlFromRequest(request))
-    login.searchParams.set('error', 'Session expired')
-    const response = NextResponse.redirect(login)
-    response.cookies.delete('refresh_token')
-    return response
+    return redirectToLogin(request, 'Session expired')
   }
   return attachRefreshedSessionCookies(NextResponse.json({ error: result.error }, { status: result.status }), result.refreshedTokens)
 }

--- a/src/lib/serverDownloadProxy.ts
+++ b/src/lib/serverDownloadProxy.ts
@@ -28,10 +28,7 @@ export type BackendDownloadFetchResult =
  * For browser navigation (`<a href>` downloads), 401 → redirect to login like internal-api/refresh.
  * Clients that send `Accept: application/json` keep a JSON body (e.g. programmatic use).
  */
-export function respondDownloadProxyFailure(
-  request: NextRequest,
-  result: Extract<BackendDownloadFetchResult, { ok: false }>
-): NextResponse {
+export function respondDownloadProxyFailure(request: NextRequest, result: Extract<BackendDownloadFetchResult, { ok: false }>): NextResponse {
   if (result.status === 401 && request.headers.get('accept') !== 'application/json') {
     const login = new URL('/login', getClientBaseUrlFromRequest(request))
     login.searchParams.set('error', 'Session expired')
@@ -54,7 +51,7 @@ export async function fetchBackendDownloadWithCookieRefresh(
     refresh: cookieStore.get('refresh_token')?.value ?? null
   }
   const initial = { access: tokens.access, refresh: tokens.refresh }
-  Logger.info(`[fetchBackendDownloadWithCookieRefresh] tokens: has access: ${tokens.access !== null}, has refresh: ${tokens.refresh !== null}`)
+  Logger.debug(`[fetchBackendDownloadWithCookieRefresh] tokens: has access: ${tokens.access !== null}, has refresh: ${tokens.refresh !== null}`)
 
   const cookiesToSetIfDirty = (): SessionRefreshTokens | null => {
     if (!tokens.access) return null
@@ -75,7 +72,7 @@ export async function fetchBackendDownloadWithCookieRefresh(
 
   if (!tokens.access && tokens.refresh) {
     const session = await refreshSessionWithToken(tokens.refresh)
-    Logger.info(`[fetchBackendDownloadWithCookieRefresh] refreshSessionWithToken: session: ${session !== null}`)
+    Logger.debug(`[fetchBackendDownloadWithCookieRefresh] refreshSessionWithToken: session: ${session !== null}`)
     if (!session) {
       return { ok: false, status: 401, error: 'Unauthorized', refreshedTokens: null }
     }
@@ -85,7 +82,7 @@ export async function fetchBackendDownloadWithCookieRefresh(
   let upstream = await fetch(backendUrl, {
     headers: { Authorization: `Bearer ${tokens.access!}` }
   })
-  Logger.info(`[fetchBackendDownloadWithCookieRefresh] fetch: upstream: ${upstream.status}`)
+  Logger.debug(`[fetchBackendDownloadWithCookieRefresh] fetch: upstream: ${upstream.status}`)
 
   if (upstream.status === 401 && tokens.refresh) {
     const session = await refreshSessionWithToken(tokens.refresh)


### PR DESCRIPTION
This fixes the issue reported in the review for #90.

Main changes:
- A slight refactor of `/internal-api/refresh/route.ts` to carve out `refreshSessionWithToken` and move `getClientBaseUrl` into `lib/api.ts'
- Created `lib/serverDownlodProxy.ts` containing `fetchBackendDownloadWithCookieRefresh`, which applies token refresh to backend URL requests if required, using `refreshSessionWithToken`
- Modifed both download routes to call `fetchBackendDownloadWithCookieRefresh`
- If token refresh fails for download requests with 401, we trigger a redirect to the login page

I tested this by:
1. expired access token
   - Set a short ACCESS_TOKEN_EXPIRY env variable
   - Loaded an item page
   - Waited until access token expired
   - Downloaded the item or one of its files 
   The access token was refreshed and the download succeded as expected
2. expired access and refresh tokens
   - Loaded an item page
   - Deleted both access token and refresh token using the browser dev tools
   - Tried to download the item or one of its files
   Got redirected to the login page as expected