### PR TITLE
Add bookshelf updates listeners

### DIFF
--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -5,6 +5,7 @@ import { useLibrary } from '@/contexts/LibraryContext'
 import { useUser } from '@/contexts/UserContext'
 import { useBookshelfData } from '@/hooks/useBookshelfData'
 import { useBookshelfQuery } from '@/hooks/useBookshelfQuery'
+import { useBookshelfUpdater } from '@/hooks/useBookshelfUpdater'
 import { useBookshelfVirtualizer } from '@/hooks/useBookshelfVirtualizer'
 import { usePersistentScroll } from '@/hooks/usePersistentScroll'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
@@ -119,14 +120,16 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
 
   // Virtualizer
   const hasMeasuredCard = cardSize.width > 0
-  const { columns, shelfHeight, totalShelves, shelvesPerPage, visibleShelfStart, visibleShelfEnd, handleScroll } = useBookshelfVirtualizer({
-    totalEntities,
-    itemWidth: hasMeasuredCard ? totalEntityCardWidth : 0,
-    itemHeight: hasMeasuredCard ? shelfRowHeight : 0,
-    containerWidth: dimensions.width,
-    containerHeight: dimensions.height,
-    padding: shelfPadding / 2
-  })
+  const { columns, shelfHeight, totalShelves, shelvesPerPage, visibleShelfStart, visibleShelfEnd, handleScroll, getVisiblePageRange } = useBookshelfVirtualizer(
+    {
+      totalEntities,
+      itemWidth: hasMeasuredCard ? totalEntityCardWidth : 0,
+      itemHeight: hasMeasuredCard ? shelfRowHeight : 0,
+      containerWidth: dimensions.width,
+      containerHeight: dimensions.height,
+      padding: shelfPadding / 2
+    }
+  )
 
   // Use custom hook for persistent scroll logic
   const { handleScroll: handlePersistentScroll } = usePersistentScroll({
@@ -139,6 +142,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
 
   const bookshelfMarginLeft = Math.max(0, (dimensions.width - columns * totalEntityCardWidth) / 2)
   const itemsPerPage = columns * shelvesPerPage
+  const bookshelfLayoutReady = hasMeasuredCard && columns > 0 && Number.isFinite(itemsPerPage) && itemsPerPage > 0
 
   // Data hook
   const {
@@ -147,17 +151,37 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
     totalEntities: fetchedTotal,
     isLoading,
     isInitialized,
-    error
+    error,
+    reconcilePagesAfterUpdate
   } = useBookshelfData({
     entityType,
     query,
     itemsPerPage
   })
 
-  // Sync total count from data hook
+  useBookshelfUpdater({
+    entityType,
+    libraryId: library.id,
+    containerRef,
+    visibleShelfStart,
+    visibleShelfEnd,
+    columns,
+    itemsPerPage,
+    bookshelfLayoutReady,
+    fetchedTotal,
+    items,
+    shelfHeight,
+    containerHeight: dimensions.height,
+    reconcilePagesAfterUpdate,
+    handleScroll
+  })
+
+  // Sync total count from data hook (reset to 0 while revalidating so loadPage runs for page 0)
   useEffect(() => {
     if (isInitialized) {
       setTotalEntities(fetchedTotal)
+    } else {
+      setTotalEntities(0)
     }
   }, [fetchedTotal, isInitialized])
 
@@ -170,21 +194,17 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
     }
   }, [fetchedTotal, isInitialized, setItemCount])
 
-  // Data Fetching Trigger
+  // Data Fetching Trigger — chain promises so list requests are not fired in parallel
   useEffect(() => {
-    if (!hasMeasuredCard || columns === 0 || itemsPerPage === 0) return
+    if (!bookshelfLayoutReady) return
 
-    const itemsPerShelf = columns
-    const startItem = visibleShelfStart * itemsPerShelf
-    const endItem = Math.min(totalEntities, visibleShelfEnd * itemsPerShelf)
+    const { startPage, endPage } = getVisiblePageRange(itemsPerPage, totalEntities)
 
-    const startPage = Math.floor(startItem / itemsPerPage)
-    const endPage = Math.floor(endItem / itemsPerPage)
-
+    let loadPageQueue: Promise<void> = Promise.resolve()
     for (let p = startPage; p <= endPage; p++) {
-      loadPage(p)
+      loadPageQueue = loadPageQueue.then(() => loadPage(p))
     }
-  }, [hasMeasuredCard, visibleShelfStart, visibleShelfEnd, columns, totalEntities, itemsPerPage, loadPage])
+  }, [bookshelfLayoutReady, getVisiblePageRange, totalEntities, itemsPerPage, loadPage])
 
   const bookProgressMap = useMemo(() => {
     const map = new Map<string, MediaProgress>()

--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -23,10 +23,18 @@ interface BookshelfClientProps {
 
 export default function BookshelfClient({ entityType }: BookshelfClientProps) {
   const t = useTypeSafeTranslations()
-  const { library, setItemCount, orderBy, collapseSeries, showSubtitles, seriesSortBy, updateSetting, filterBy, boundModal, bookshelfView } = useLibrary()
+  const { library, setItemCount, orderBy, collapseSeries, showSubtitles, seriesSortBy, authorSortBy, updateSetting, filterBy, boundModal, bookshelfView } =
+    useLibrary()
   const { user } = useUser()
 
   const { query } = useBookshelfQuery(entityType)
+
+  const isRandomSort = useMemo(() => {
+    if (entityType === 'items') return orderBy === 'random'
+    if (entityType === 'series') return seriesSortBy === 'random'
+    if (entityType === 'authors') return authorSortBy === 'random'
+    return false
+  }, [entityType, orderBy, seriesSortBy, authorSortBy])
 
   const isPodcastLibrary = library.mediaType === 'podcast'
 
@@ -173,7 +181,8 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
     shelfHeight,
     containerHeight: dimensions.height,
     reconcilePagesAfterUpdate,
-    handleScroll
+    handleScroll,
+    isRandomSort
   })
 
   // Sync total count from data hook (reset to 0 while revalidating so loadPage runs for page 0)
@@ -256,8 +265,8 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
 
   if (!validEntities.includes(entityType as string) || !config) {
     return (
-      <div className="flex flex-col items-center justify-center h-full text-foreground-muted">
-        <h2 className="text-2xl font-bold mb-2">{t('LabelPageNotFound')}</h2>
+      <div className="text-foreground-muted flex h-full flex-col items-center justify-center">
+        <h2 className="mb-2 text-2xl font-bold">{t('LabelPageNotFound')}</h2>
         <p>{t('MessagePageNotFoundForLibraryType')}</p>
       </div>
     )
@@ -266,7 +275,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
   return (
     <div
       ref={containerRef}
-      className={isAlternativeBookshelfView ? 'h-full overflow-y-auto relative py-8' : 'h-full overflow-y-auto relative'}
+      className={isAlternativeBookshelfView ? 'relative h-full overflow-y-auto py-8' : 'relative h-full overflow-y-auto'}
       style={{ fontSize: sizeMultiplier + 'rem' }}
       onScroll={(e) => {
         const scrollTop = e.currentTarget.scrollTop
@@ -288,9 +297,9 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
       {/* Error State */}
       {error && (
         <div className="flex h-full flex-col items-center justify-center p-10 text-center">
-          <p className="text-red-500 mb-2">{t('MessageFailedToLoadData')}</p>
-          <p className="text-sm text-gray-500 mb-4">{error.message}</p>
-          <button onClick={() => loadPage(0)} className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
+          <p className="mb-2 text-red-500">{t('MessageFailedToLoadData')}</p>
+          <p className="mb-4 text-sm text-gray-500">{error.message}</p>
+          <button onClick={() => loadPage(0)} className="rounded bg-blue-500 px-4 py-2 text-white transition-colors hover:bg-blue-600">
             {t('ButtonRetry')}
           </button>
         </div>
@@ -314,7 +323,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
             return (
               <div
                 key={shelfIndex}
-                className={`absolute left-0 w-full flex ${!isAlternativeBookshelfView ? 'bookshelfRow' : ''}`}
+                className={`absolute left-0 flex w-full ${!isAlternativeBookshelfView ? 'bookshelfRow' : ''}`}
                 style={{
                   top: `${shelfIndex * shelfHeight}px`,
                   height: `${shelfHeight}px`,
@@ -358,7 +367,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
                     />
                   )
                 })}
-                {!isAlternativeBookshelfView && <div className="bookshelfDivider w-full absolute bottom-0 left-0 right-0 z-20 h-6e" />}
+                {!isAlternativeBookshelfView && <div className="bookshelfDivider h-6e absolute right-0 bottom-0 left-0 z-20 w-full" />}
               </div>
             )
           })}

--- a/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
@@ -16,7 +16,11 @@ import { UpdateSettingFn } from '@/contexts/LibraryContext'
 import { useUser } from '@/contexts/UserContext'
 import { Author, BookshelfEntity, BookshelfView, Collection, EntityType, Library, LibraryItem, MediaProgress, Playlist, Series, User } from '@/types/api'
 import { TranslationKey } from '@/types/translations'
-import React, { ReactNode } from 'react'
+import React, { type MouseEvent, type ReactNode } from 'react'
+
+/** Selection is unused on the bookshelf; stable identity so memo(MediaCard) can skip unchanged cards. */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function bookshelfCardNoopSelect(_event: MouseEvent) {}
 
 export interface SkeletonComponentProps {
   bookshelfView: BookshelfView
@@ -118,7 +122,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
               mediaProgress={entityProgress}
               isSelectionMode={false}
               selected={false}
-              onSelect={() => {}}
+              onSelect={bookshelfCardNoopSelect}
               dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
               timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
               showSubtitles={showSubtitles ?? false}
@@ -137,7 +141,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             mediaProgress={entityProgress}
             isSelectionMode={false}
             selected={false}
-            onSelect={() => {}}
+            onSelect={bookshelfCardNoopSelect}
             dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
             timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
             userPermissions={user.permissions}

--- a/src/hooks/useBookshelfData.ts
+++ b/src/hooks/useBookshelfData.ts
@@ -52,6 +52,25 @@ function getResultsFromResponse(entityType: EntityType, data: unknown): Bookshel
   }
 }
 
+function buildPageQueryParams(entityType: EntityType, query: string, page: number, limit: number): string {
+  const fullQuery = query ? `${query}&` : ''
+  let queryParams = `${fullQuery}limit=${limit}&page=${page}&minified=1`
+  if (entityType === 'items') {
+    queryParams += '&include=rssfeed,numEpisodesIncomplete,share'
+  }
+  return queryParams
+}
+
+type BookshelfPageResults = { results: BookshelfEntity[]; total: number }
+
+/** One bookshelf list API page: shared by `loadPage` and `reconcilePagesAfterUpdate`. */
+async function fetchBookshelfPageData(entityType: EntityType, libraryId: string, query: string, page: number, limit: number): Promise<BookshelfPageResults> {
+  const data = await fetchEntityData(entityType, libraryId, buildPageQueryParams(entityType, query, page, limit))
+  const results = getResultsFromResponse(entityType, data)
+  const total = (data as { total?: number }).total ?? results.length
+  return { results, total }
+}
+
 export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshelfDataProps) {
   const { library } = useLibrary()
   const libraryId = library.id
@@ -68,9 +87,9 @@ export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshe
   const itemsPerPageRef = useRef(itemsPerPage)
   const activeQueryRef = useRef(query)
 
-  // Reset when query or entityType changes
-  useEffect(() => {
-    activeQueryRef.current = query
+  const invalidate = useCallback(() => {
+    pagesLoadedRef.current.clear()
+    loadingPagesRef.current.clear()
     setState({
       items: [],
       totalEntities: 0,
@@ -78,9 +97,13 @@ export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshe
       isLoading: true,
       error: null
     })
-    pagesLoadedRef.current.clear()
-    loadingPagesRef.current.clear()
-  }, [libraryId, entityType, query])
+  }, [])
+
+  // Reset when query or entityType changes
+  useEffect(() => {
+    activeQueryRef.current = query
+    invalidate()
+  }, [libraryId, entityType, query, invalidate])
 
   // Handle itemsPerPage changes - invalidate cache but keep items
   // Only clear cache when itemsPerPage changes AFTER initial data load is complete
@@ -97,20 +120,119 @@ export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshe
     }
   }, [itemsPerPage, state.isInitialized])
 
-  // Remove a single item from the items array by ID
-  // Clears page tracking since indices shift after removal
-  const removeItem = useCallback((id: string) => {
-    // Clear page tracking - indices shift after filter, so we need to
-    // allow re-fetching if user scrolls to areas that had loaded data
-    pagesLoadedRef.current.clear()
-    loadingPagesRef.current.clear()
+  /**
+   * Side-fetch pages and merge into the existing sparse array without clearing the shelf.
+   * After a reorder/filter shift or total change, `pagesLoadedRef` is replaced with only these pages
+   * so other regions refetch. If every reconciled slot keeps the same id (metadata-only touch),
+   * other loaded pages stay marked valid — only ids in `changedIds` get new object references.
+   * Omit `changedIds` when every reconciled cell is filled or replaced by id (e.g. add/remove).
+   */
+  const reconcilePagesAfterUpdate = useCallback(
+    async (pageNumbers: number[], changedIds?: Set<string>): Promise<{ total: number } | null> => {
+      const limit = itemsPerPageRef.current
+      if (limit <= 0 || pageNumbers.length === 0) return null
 
-    setState((prev) => ({
-      ...prev,
-      items: prev.items.filter((item) => item?.id !== id),
-      totalEntities: Math.max(0, prev.totalEntities - 1)
-    }))
-  }, [])
+      const sortedPages = [...new Set(pageNumbers)].filter((p) => p >= 0).sort((a, b) => a - b)
+
+      let newPageResults: BookshelfPageResults[]
+      try {
+        newPageResults = []
+        for (const page of sortedPages) {
+          newPageResults.push(await fetchBookshelfPageData(entityType, libraryId, query, page, limit))
+        }
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error('Failed to reconcile bookshelf')
+        console.error('reconcilePagesAfterUpdate', error)
+        setState((prev) => ({ ...prev, error }))
+        return null
+      }
+
+      if (query !== activeQueryRef.current) return null
+
+      const total = newPageResults[0]?.total ?? 0
+
+      let pagesToMark: number[] | null = null
+
+      setState((prev) => {
+        let nextItems: (BookshelfEntity | null)[]
+        const structureChanged = total !== prev.totalEntities
+
+        if (structureChanged) {
+          nextItems = new Array(total).fill(null)
+          for (let i = 0; i < Math.min(prev.items.length, total); i++) {
+            nextItems[i] = prev.items[i] ?? null
+          }
+        } else {
+          nextItems = [...prev.items]
+        }
+
+        // When true, list order/membership for reconciled pages matches what we already had (same id
+        // per slot, same total, no holes cleared). Only touched items need new references — safe to
+        // keep other pages in `pagesLoadedRef` instead of invalidating the whole cache.
+        let keepOtherPagesLoaded = !structureChanged
+
+        let cellChanged = false
+
+        for (let pi = 0; pi < sortedPages.length; pi++) {
+          const page = sortedPages[pi]
+          const { results } = newPageResults[pi]
+          const startIndex = page * limit
+          const endIndex = Math.min(startIndex + limit, total)
+
+          for (let i = startIndex; i < endIndex; i++) {
+            const j = i - startIndex
+            if (j < results.length) {
+              const newItem = results[j]
+              const old = nextItems[i]
+
+              let assigned: BookshelfEntity
+              if (!old) {
+                assigned = newItem
+                keepOtherPagesLoaded = false
+              } else if (old.id !== newItem.id) {
+                assigned = newItem
+                keepOtherPagesLoaded = false
+              } else if (changedIds?.has(old.id)) {
+                assigned = newItem
+              } else {
+                assigned = old
+              }
+
+              if (assigned !== old) {
+                nextItems[i] = assigned
+                cellChanged = true
+              }
+            } else if (nextItems[i] != null) {
+              console.log('This should not happen: index', i, 'item', nextItems[i])
+              nextItems[i] = null
+              cellChanged = true
+              keepOtherPagesLoaded = false
+            }
+          }
+        }
+
+        if (!structureChanged && !cellChanged) return prev
+
+        pagesToMark = keepOtherPagesLoaded ? null : sortedPages
+
+        return {
+          ...prev,
+          items: nextItems,
+          totalEntities: total,
+          isInitialized: true,
+          isLoading: false,
+          error: null
+        }
+      })
+
+      if (pagesToMark) {
+        pagesLoadedRef.current = new Set(pagesToMark)
+      }
+
+      return { total }
+    },
+    [entityType, libraryId, query]
+  )
 
   const loadPage = useCallback(
     async (page: number) => {
@@ -128,22 +250,9 @@ export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshe
       loadingPagesRef.current.add(page)
 
       try {
-        const fullQuery = query ? `${query}&` : ''
-        // Build query params - include common params and entity-specific ones
-        let queryParams = `${fullQuery}limit=${currentItemsPerPage}&page=${page}&minified=1`
+        const { results, total } = await fetchBookshelfPageData(entityType, libraryId, query, page, currentItemsPerPage)
 
-        // Add entity-specific includes
-        if (entityType === 'items') {
-          queryParams += '&include=rssfeed,numEpisodesIncomplete,share'
-        }
-
-        const data = await fetchEntityData(entityType, libraryId, queryParams)
-
-        // Check if query changed while fetching
         if (query !== activeQueryRef.current) return
-
-        const results = getResultsFromResponse(entityType, data)
-        const total = (data as { total?: number }).total ?? results.length
 
         setState((prev) => {
           let newItems = [...prev.items]
@@ -203,59 +312,6 @@ export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshe
       }
     })
   }, [])
-
-  // Socket listeners for Author updates
-  // Only active when viewing authors
-  const handleAuthorAdded = useCallback(
-    (author: Author) => {
-      if (author.libraryId !== libraryId || entityType !== 'authors') return
-
-      // Since an author was added, the sort order might change completely
-      // We must invalidate the current data and refetch
-      pagesLoadedRef.current.clear()
-      loadingPagesRef.current.clear()
-
-      setState((prev) => ({
-        ...prev,
-        items: [],
-        totalEntities: 0,
-        isInitialized: false,
-        isLoading: true,
-        error: null
-      }))
-    },
-    [entityType, libraryId]
-  )
-
-  const handleAuthorUpdated = useCallback(
-    (author: Author) => {
-      if (author.libraryId !== libraryId || entityType !== 'authors') return
-
-      updateItems((item) => {
-        if (item.id !== author.id) return item
-        return author
-      })
-    },
-    [entityType, libraryId, updateItems]
-  )
-
-  const handleAuthorRemoved = useCallback(
-    (data: { id: string; libraryId: string } | Author) => {
-      // data might be the author object or { id, libraryId } depending on server event
-      const libId = 'libraryId' in data ? data.libraryId : (data as Author).libraryId
-      const id = 'id' in data ? data.id : (data as Author).id
-
-      if (libId !== libraryId) return
-
-      if (entityType !== 'authors') return
-      removeItem(id)
-    },
-    [entityType, libraryId, removeItem]
-  )
-
-  useSocketEvent<Author>('author_added', handleAuthorAdded)
-  useSocketEvent<Author>('author_updated', handleAuthorUpdated)
-  useSocketEvent<Author | { id: string; libraryId: string }>('author_removed', handleAuthorRemoved)
 
   // Socket listeners for share updates
   // Shares only apply to book library items
@@ -319,6 +375,7 @@ export function useBookshelfData({ entityType, query, itemsPerPage }: UseBookshe
 
   return {
     ...state,
-    loadPage
+    loadPage,
+    reconcilePagesAfterUpdate
   }
 }

--- a/src/hooks/useBookshelfUpdater.ts
+++ b/src/hooks/useBookshelfUpdater.ts
@@ -32,6 +32,8 @@ type BookshelfUpdaterRuntime = {
   libraryId: string
   entityType: EntityType
   bookshelfLayoutReady: boolean
+  /** Random sort refetches change the shelf order; skip socket-driven reconcile until server-side stable ordering exists. */
+  isRandomSort: boolean
   reconcilePagesAfterUpdate: (pageIndices: number[], changedIds?: Set<string>) => Promise<{ total: number } | null>
   containerRef: RefObject<HTMLDivElement | null>
   layoutForReconcileRef: RefBox<BookshelfReconcileLayout>
@@ -40,6 +42,7 @@ type BookshelfUpdaterRuntime = {
 
 function reconcileThenClamp(rt: BookshelfUpdaterRuntime, pageIndices: number[], changedIds?: Set<string>) {
   if (!rt.bookshelfLayoutReady) return
+  if (rt.isRandomSort) return
 
   const layout = rt.layoutForReconcileRef.current
 
@@ -99,6 +102,8 @@ export type UseBookshelfUpdaterParams = {
   containerHeight: number
   reconcilePagesAfterUpdate: (pageIndices: number[], changedIds?: Set<string>) => Promise<{ total: number } | null>
   handleScroll: (scrollTop: number) => void
+  /** When true, socket events do not refetch pages (random order is non-deterministic per request). */
+  isRandomSort: boolean
 }
 
 /**
@@ -119,7 +124,8 @@ export function useBookshelfUpdater({
   shelfHeight,
   containerHeight,
   reconcilePagesAfterUpdate,
-  handleScroll
+  handleScroll,
+  isRandomSort
 }: UseBookshelfUpdaterParams): void {
   const layoutForReconcileRef = useRef<BookshelfReconcileLayout>({
     visibleShelfStart: 0,
@@ -166,6 +172,7 @@ export function useBookshelfUpdater({
     libraryId,
     entityType,
     bookshelfLayoutReady,
+    isRandomSort,
     reconcilePagesAfterUpdate,
     containerRef,
     layoutForReconcileRef,

--- a/src/hooks/useBookshelfUpdater.ts
+++ b/src/hooks/useBookshelfUpdater.ts
@@ -1,0 +1,232 @@
+// Imported only from client modules — omitting "use client" avoids Next TS 71007 on hook option types (not suppressible via eslint-disable).
+
+import { useSocketEvent } from '@/contexts/SocketContext'
+import { getVisibleBookshelfPageRange, type VisibleBookshelfPageRangeInput } from '@/hooks/useBookshelfVirtualizer'
+import { Author, AuthorRemovedPayload, BookshelfEntity, EntityType, LibraryItem, LibraryItemRemovedPayload } from '@/types/api'
+import { type RefObject, useCallback, useLayoutEffect, useRef } from 'react'
+
+/** Like refs from `useRef` with a writable `current` (avoids deprecated `MutableRefObject` in newer `@types/react`). */
+type RefBox<T> = { current: T }
+
+type BookshelfReconcileLayout = VisibleBookshelfPageRangeInput & {
+  items: (BookshelfEntity | null)[]
+  shelfHeight: number
+  containerHeight: number
+}
+
+function getPagesForReconcile(layout: BookshelfReconcileLayout, entityIds?: Iterable<string>): number[] {
+  const { itemsPerPage, items } = layout
+  const { startPage, endPage } = getVisibleBookshelfPageRange(layout)
+  const pages = new Set<number>()
+  for (let p = startPage; p <= endPage; p++) pages.add(p)
+  for (const entityId of entityIds ?? []) {
+    const indexInSparseList = items.findIndex((entity) => entity?.id === entityId)
+    if (indexInSparseList >= 0) {
+      pages.add(Math.floor(indexInSparseList / itemsPerPage))
+    }
+  }
+  return [...pages].sort((a, b) => a - b)
+}
+
+type BookshelfUpdaterRuntime = {
+  libraryId: string
+  entityType: EntityType
+  bookshelfLayoutReady: boolean
+  reconcilePagesAfterUpdate: (pageIndices: number[], changedIds?: Set<string>) => Promise<{ total: number } | null>
+  containerRef: RefObject<HTMLDivElement | null>
+  layoutForReconcileRef: RefBox<BookshelfReconcileLayout>
+  runScrollClampAfterReconcile: (reconcileResult: { total: number } | null, layoutWhenStarted: BookshelfReconcileLayout) => void
+}
+
+function reconcileThenClamp(rt: BookshelfUpdaterRuntime, pageIndices: number[], changedIds?: Set<string>) {
+  if (!rt.bookshelfLayoutReady) return
+
+  const layout = rt.layoutForReconcileRef.current
+
+  const layoutWhenStarted = { ...layout }
+
+  void rt
+    .reconcilePagesAfterUpdate(pageIndices, changedIds)
+    .then((reconcileResult) => rt.runScrollClampAfterReconcile(reconcileResult, layoutWhenStarted))
+    .catch((err) => {
+      const error = err instanceof Error ? err : new Error(String(err))
+      console.error('useBookshelfUpdater: reconcile after update', error)
+    })
+}
+
+function isEntityOnBookshelf(layout: BookshelfReconcileLayout, entityId: string): boolean {
+  return layout.items.some((entity) => entity?.id === entityId)
+}
+
+/**
+ * After updates: always at least visible pages (sort/total may change even when payload ids are
+ * not in the sparse list). When any payload id is on shelf, also refetch those pages and pass `changedIds`
+ * so same-slot same-id cells get fresh refs (see useBookshelfData).
+ */
+function reconcileUpdatedEntities(rt: BookshelfUpdaterRuntime, entities: { id: string }[]) {
+  const layout = rt.layoutForReconcileRef.current
+  const onShelf = entities.filter((e) => isEntityOnBookshelf(layout, e.id))
+  const changedIds = onShelf.length > 0 ? new Set(onShelf.map((e) => e.id)) : undefined
+  const pages = getPagesForReconcile(layout, changedIds)
+  if (pages.length === 0) return
+  reconcileThenClamp(rt, pages, changedIds)
+}
+
+/**
+ * After add/remove: refetch visible pages only (total/order may change). Off-screen slots invalidate via
+ * `pagesLoadedRef` when structure changes; they refetch on scroll. Omits `changedIds`; see useBookshelfData.
+ */
+function reconcileVisiblePages(rt: BookshelfUpdaterRuntime) {
+  if (!rt.bookshelfLayoutReady) return
+  const layout = rt.layoutForReconcileRef.current
+  const pages = getPagesForReconcile(layout)
+  if (pages.length === 0) return
+  reconcileThenClamp(rt, pages)
+}
+
+export type UseBookshelfUpdaterParams = {
+  entityType: EntityType
+  libraryId: string
+  containerRef: RefObject<HTMLDivElement | null>
+  visibleShelfStart: number
+  visibleShelfEnd: number
+  columns: number
+  itemsPerPage: number
+  bookshelfLayoutReady: boolean
+  fetchedTotal: number
+  items: (BookshelfEntity | null)[]
+  shelfHeight: number
+  containerHeight: number
+  reconcilePagesAfterUpdate: (pageIndices: number[], changedIds?: Set<string>) => Promise<{ total: number } | null>
+  handleScroll: (scrollTop: number) => void
+}
+
+/**
+ * Socket-driven bookshelf refresh: reconcile visible pages on list membership changes; visible + touched
+ * pages on metadata updates.
+ */
+export function useBookshelfUpdater({
+  entityType,
+  libraryId,
+  containerRef,
+  visibleShelfStart,
+  visibleShelfEnd,
+  columns,
+  itemsPerPage,
+  bookshelfLayoutReady,
+  fetchedTotal,
+  items,
+  shelfHeight,
+  containerHeight,
+  reconcilePagesAfterUpdate,
+  handleScroll
+}: UseBookshelfUpdaterParams): void {
+  const layoutForReconcileRef = useRef<BookshelfReconcileLayout>({
+    visibleShelfStart: 0,
+    visibleShelfEnd: 0,
+    columns: 0,
+    itemsPerPage: 0,
+    totalEntities: 0,
+    items: [],
+    shelfHeight: 0,
+    containerHeight: 0
+  })
+
+  // Layout before socket listeners (useEffect) so the ref is never stale on the first event tick.
+  useLayoutEffect(() => {
+    layoutForReconcileRef.current = {
+      visibleShelfStart,
+      visibleShelfEnd,
+      columns,
+      itemsPerPage,
+      totalEntities: fetchedTotal,
+      items,
+      shelfHeight,
+      containerHeight
+    }
+  }, [visibleShelfStart, visibleShelfEnd, columns, itemsPerPage, fetchedTotal, items, shelfHeight, containerHeight])
+
+  const runScrollClampAfterReconcile = useCallback(
+    (reconcileResult: { total: number } | null, layoutWhenStarted: BookshelfReconcileLayout) => {
+      if (!reconcileResult) return
+      const scrollEl = containerRef.current
+      if (!scrollEl || layoutWhenStarted.columns <= 0 || layoutWhenStarted.shelfHeight <= 0) return
+      const totalShelvesAfter = Math.ceil(reconcileResult.total / layoutWhenStarted.columns)
+      const maxScrollTop = Math.max(0, totalShelvesAfter * layoutWhenStarted.shelfHeight - layoutWhenStarted.containerHeight)
+      if (scrollEl.scrollTop > maxScrollTop) {
+        scrollEl.scrollTop = maxScrollTop
+        handleScroll(maxScrollTop)
+      }
+    },
+    [containerRef, handleScroll]
+  )
+
+  const runtimeRef = useRef<BookshelfUpdaterRuntime>({} as BookshelfUpdaterRuntime)
+  runtimeRef.current = {
+    libraryId,
+    entityType,
+    bookshelfLayoutReady,
+    reconcilePagesAfterUpdate,
+    containerRef,
+    layoutForReconcileRef,
+    runScrollClampAfterReconcile
+  }
+
+  const onLibraryItemUpdated = useCallback((libraryItem: LibraryItem) => {
+    const rt = runtimeRef.current
+    if (libraryItem.libraryId !== rt.libraryId || rt.entityType !== 'items') return
+    reconcileUpdatedEntities(rt, [libraryItem])
+  }, [])
+
+  const onLibraryItemsUpdated = useCallback((libraryItems: LibraryItem[]) => {
+    const rt = runtimeRef.current
+    const inLibrary = libraryItems.filter((li) => li.libraryId === rt.libraryId)
+    if (inLibrary.length === 0 || rt.entityType !== 'items') return
+    reconcileUpdatedEntities(rt, inLibrary)
+  }, [])
+
+  const onLibraryItemAdded = useCallback((libraryItem: LibraryItem) => {
+    const rt = runtimeRef.current
+    if (libraryItem.libraryId !== rt.libraryId || rt.entityType !== 'items') return
+    reconcileVisiblePages(rt)
+  }, [])
+
+  const onLibraryItemsAdded = useCallback((libraryItems: LibraryItem[]) => {
+    const rt = runtimeRef.current
+    if (!libraryItems.some((li) => li.libraryId === rt.libraryId) || rt.entityType !== 'items') return
+    reconcileVisiblePages(rt)
+  }, [])
+
+  const onLibraryItemRemoved = useCallback((payload: LibraryItemRemovedPayload) => {
+    const rt = runtimeRef.current
+    if (payload.libraryId !== rt.libraryId || rt.entityType !== 'items') return
+    reconcileVisiblePages(rt)
+  }, [])
+
+  const onAuthorUpdated = useCallback((author: Author) => {
+    const rt = runtimeRef.current
+    if ((author.libraryId !== undefined && author.libraryId !== rt.libraryId) || rt.entityType !== 'authors') return
+    reconcileUpdatedEntities(rt, [author])
+  }, [])
+
+  const onAuthorAdded = useCallback((author: Author) => {
+    const rt = runtimeRef.current
+    if ((author.libraryId !== undefined && author.libraryId !== rt.libraryId) || rt.entityType !== 'authors') return
+    reconcileVisiblePages(rt)
+  }, [])
+
+  const onAuthorRemoved = useCallback((payload: AuthorRemovedPayload) => {
+    const rt = runtimeRef.current
+    if (payload.libraryId !== rt.libraryId || rt.entityType !== 'authors') return
+    reconcileVisiblePages(rt)
+  }, [])
+
+  useSocketEvent<LibraryItem>('item_updated', onLibraryItemUpdated, [onLibraryItemUpdated])
+  useSocketEvent<LibraryItem[]>('items_updated', onLibraryItemsUpdated, [onLibraryItemsUpdated])
+  useSocketEvent<LibraryItem>('item_added', onLibraryItemAdded, [onLibraryItemAdded])
+  useSocketEvent<LibraryItem[]>('items_added', onLibraryItemsAdded, [onLibraryItemsAdded])
+  useSocketEvent<LibraryItemRemovedPayload>('item_removed', onLibraryItemRemoved, [onLibraryItemRemoved])
+  useSocketEvent<Author>('author_added', onAuthorAdded, [onAuthorAdded])
+  useSocketEvent<Author>('author_updated', onAuthorUpdated, [onAuthorUpdated])
+  useSocketEvent<AuthorRemovedPayload>('author_removed', onAuthorRemoved, [onAuthorRemoved])
+}

--- a/src/hooks/useBookshelfVirtualizer.ts
+++ b/src/hooks/useBookshelfVirtualizer.ts
@@ -9,6 +9,45 @@ export interface UseBookshelfVirtualizerProps {
   padding?: number
 }
 
+/**
+ * Full layout record for {@link getVisibleBookshelfPageRange}. Shelf callers can use
+ * {@link useBookshelfVirtualizer}'s `getVisiblePageRange(itemsPerPage, totalEntities)` instead.
+ */
+export type VisibleBookshelfPageRangeInput = {
+  visibleShelfStart: number
+  visibleShelfEnd: number
+  columns: number
+  itemsPerPage: number
+  totalEntities: number
+}
+
+/**
+ * Inclusive API page indices `[startPage, endPage]` for the visible virtual shelf window.
+ * `itemsPerPage` is typically `columns * shelvesPerPage` from the same layout as the virtualizer.
+ */
+export function getVisibleBookshelfPageRange({
+  visibleShelfStart,
+  visibleShelfEnd,
+  columns,
+  itemsPerPage,
+  totalEntities
+}: VisibleBookshelfPageRangeInput): { startPage: number; endPage: number } {
+  const itemsPerShelf = columns
+  const startItem = visibleShelfStart * itemsPerShelf
+  const endItem = Math.min(totalEntities, visibleShelfEnd * itemsPerShelf)
+
+  let startPage = Math.floor(startItem / itemsPerPage)
+  let endPage = Math.floor(endItem / itemsPerPage)
+
+  // After refetch, totalEntities is 0 until the first page loads; stale visible indices can make startPage > endPage.
+  if (totalEntities === 0) {
+    startPage = 0
+    endPage = 0
+  }
+
+  return { startPage, endPage }
+}
+
 // Buffer of shelves to render above/below viewport
 const VISIBILITY_BUFFER = 2
 
@@ -71,6 +110,11 @@ export function useBookshelfVirtualizer({ totalEntities, itemWidth, itemHeight, 
       if (layout.shelfHeight === 0) {
         lastScrollTopRef.current = 0
       }
+      // While there are no shelves (e.g. bookshelf refetch reset total to 0), clear stale visible
+      // indices. Otherwise data-loading may compute startPage > endPage and never call loadPage(0).
+      if (layout.totalShelves === 0) {
+        setVisibleRange({ visibleShelfStart: 0, visibleShelfEnd: 0 })
+      }
       return
     }
 
@@ -100,9 +144,25 @@ export function useBookshelfVirtualizer({ totalEntities, itemWidth, itemHeight, 
     [layout.shelfHeight, calculateVisibleRange]
   )
 
+  const { visibleShelfStart, visibleShelfEnd } = visibleRange
+
+  /** Maps the current visible shelf window to API list page indices (see {@link getVisibleBookshelfPageRange}). */
+  const getVisiblePageRange = useCallback(
+    (itemsPerPage: number, totalEntities: number) =>
+      getVisibleBookshelfPageRange({
+        visibleShelfStart,
+        visibleShelfEnd,
+        columns: layout.columns,
+        itemsPerPage,
+        totalEntities
+      }),
+    [visibleShelfStart, visibleShelfEnd, layout.columns]
+  )
+
   return {
     ...layout,
     ...visibleRange,
-    handleScroll
+    handleScroll,
+    getVisiblePageRange
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -253,6 +253,18 @@ export interface Author {
   series?: Series[]
 }
 
+/** Payload for the `author_removed` socket event (full author JSON or `{ id, libraryId }`). */
+export interface AuthorRemovedPayload {
+  id: string
+  libraryId: string
+}
+
+/** Payload for the `item_removed` socket event. */
+export interface LibraryItemRemovedPayload {
+  id: string
+  libraryId: string
+}
+
 export interface AuthorQuickMatchPayload {
   asin?: string
   q?: string


### PR DESCRIPTION
This PR adds `useBookshelfUpdater`, a custom hook for bookshelf update socket listeners. I added listeners for all `author_x` and `item_x` events.

The listeners use a new capability of `useBookshelfData`, `reconcilePagesAfterUpdate`. This function side-loads affected pages (which include visible pages and pages containing an updated entity), and reconciles them with the current pages, so that only affected items are modified. It also *potentially* invalidates other pages, if needed, so they get re-loaded later.

The logic optimizes for a minimal number of changes to data items: 
- when the update is metadata-only and does not afffect sort/filter, only that item is modified. 
- When  the change has no effect on the bookshelf, (e.g. updated item is not in the filter), then no items are modified.
- When the update causes a reorder/deletion/addition, page items are reconciled with the new pages, and other pages are invalidated.

This is supposed to fix all current bookshelf update issues that exist in the vue implementation.

I haven't yet implemented listeners for collection and playlist updates.