### PR TITLE
Modal prev/next navigation and MatchModal integration

### DIFF
--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -170,7 +170,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
 
         return (
           <Wrapper key={shelf.id} title={shelf.label}>
-            {shelf.entities.map((entity) => {
+            {shelf.entities.map((entity, entityIndex) => {
               if (shelf.type === 'book' || shelf.type === 'podcast') {
                 const EntityMediaCard = shelf.type === 'book' ? BookMediaCard : PodcastMediaCard
                 const libraryItem = entity as LibraryItem
@@ -187,6 +187,8 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
                       ereaderDevices={ereaderDevices}
                       showSubtitles={true}
                       mediaProgress={mediaProgress}
+                      shelfEntities={shelf.entities}
+                      entityIndex={entityIndex}
                     />
                   </div>
                 )

--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -335,6 +335,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
                     )
                   }
 
+                  const entityIndex = startIndex + k
                   return (
                     <config.CardComponent
                       key={`card-wrapper-${item.id}`}
@@ -347,6 +348,8 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
                       orderBy={orderBy}
                       seriesSortBy={seriesSortBy}
                       bookProgressMap={bookProgressMap}
+                      shelfEntities={entityType === 'items' ? items : undefined}
+                      entityIndex={entityType === 'items' ? entityIndex : undefined}
                     />
                   )
                 })}

--- a/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
@@ -39,6 +39,8 @@ export interface CardComponentProps {
   orderBy?: string
   seriesSortBy?: string
   bookProgressMap: Map<string, MediaProgress>
+  shelfEntities?: (BookshelfEntity | null)[]
+  entityIndex?: number
 }
 
 export interface EntityConfig {
@@ -103,7 +105,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     SkeletonComponent: ({ bookshelfView, showSubtitles, orderBy }) => (
       <MediaCardSkeleton bookshelfView={bookshelfView} showSubtitles={showSubtitles} orderBy={orderBy} />
     ),
-    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, showSubtitles, orderBy, bookProgressMap }) => {
+    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, showSubtitles, orderBy, bookProgressMap, shelfEntities, entityIndex }) => {
       const { user, serverSettings, ereaderDevices } = useUser()
       const item = entity as LibraryItem
       const isCollapsedSeries = !!item.collapsedSeries
@@ -144,6 +146,8 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             ereaderDevices={ereaderDevices}
             showSubtitles={showSubtitles ?? false}
             orderBy={orderBy ?? ''}
+            shelfEntities={shelfEntities}
+            entityIndex={entityIndex}
           />
         </div>
       )

--- a/src/components/modals/MatchModal.tsx
+++ b/src/components/modals/MatchModal.tsx
@@ -2,67 +2,100 @@
 
 import { getExpandedLibraryItemAction } from '@/app/actions/mediaActions'
 import Modal from '@/components/modals/Modal'
-import LoadingIndicator from '@/components/ui/LoadingIndicator'
+import ModalSideNavigation from '@/components/modals/ModalSideNavigation'
 import Match from '@/components/widgets/Match'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import { useEntityNavigationContext } from '@/hooks/useEntityNavigationContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
 import { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
-import { useLayoutEffect, useState, useTransition } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState, useTransition } from 'react'
 
 export type MatchModalProps = {
   isOpen: boolean
   onClose: () => void
-} & ({ libraryItem: BookLibraryItem | PodcastLibraryItem } | { libraryItemId: string })
+} & ({ libraryItem: BookLibraryItem | PodcastLibraryItem } | { navCtx: EntityNavigationContext })
 
 export default function MatchModal(props: MatchModalProps) {
   const { isOpen, onClose } = props
+  const navCtxMode = 'navCtx' in props
+  const navCtx = navCtxMode ? props.navCtx : undefined
+  const entityIds = navCtx?.entityIds ?? []
 
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
   const [fetchedItem, setFetchedItem] = useState<BookLibraryItem | PodcastLibraryItem | null>(null)
   const [isPending, startTransition] = useTransition()
+  const [navFetchPending, setNavFetchPending] = useState(false)
+  const fetchGenRef = useRef(0)
 
-  const fetchMode = 'libraryItemId' in props
-  const libraryItemId = fetchMode ? (props.libraryItemId as string) : undefined
+  const { currentEntityId, canGoPrev, canGoNext, goPrev, goNext } = useEntityNavigationContext(navCtx, isOpen)
 
   useLayoutEffect(() => {
-    if (!isOpen || !fetchMode) return
+    if (!isOpen || !navCtxMode) return
+    if (!currentEntityId) {
+      setFetchedItem(null)
+      return
+    }
 
-    let cancelled = false
+    const gen = ++fetchGenRef.current
+    setNavFetchPending(true)
+    setFetchedItem(null)
+
     startTransition(async () => {
       try {
-        const full = await getExpandedLibraryItemAction(libraryItemId!)
-        if (cancelled) return
+        const full = await getExpandedLibraryItemAction(currentEntityId)
+        if (fetchGenRef.current !== gen) return
         setFetchedItem(full as BookLibraryItem | PodcastLibraryItem)
       } catch (error) {
         console.error('Failed to load library item for match', error)
-        if (!cancelled) {
+        if (fetchGenRef.current === gen) {
           showToast(t('ToastFailedToLoadData'), { type: 'error' })
           onClose()
         }
+      } finally {
+        if (fetchGenRef.current === gen) {
+          setNavFetchPending(false)
+        }
       }
     })
-    return () => {
-      cancelled = true
-    }
-  }, [isOpen, onClose, showToast, startTransition, t, fetchMode, libraryItemId])
+  }, [isOpen, navCtxMode, navCtx, currentEntityId, onClose, showToast, startTransition, t])
+
+  const blurActiveElement = () => {
+    const el = document.activeElement
+    if (el instanceof HTMLElement) el.blur()
+  }
+
+  const handleGoPrev = useCallback(() => {
+    blurActiveElement()
+    goPrev()
+  }, [goPrev])
+
+  const handleGoNext = useCallback(() => {
+    blurActiveElement()
+    goNext()
+  }, [goNext])
 
   if (!isOpen) return null
 
-  const resolvedItem = fetchMode ? fetchedItem : props.libraryItem
-  const loading = fetchMode && isPending && !fetchedItem
+  const resolvedItem = navCtxMode ? fetchedItem : props.libraryItem
+  const showRails = navCtxMode && entityIds.length > 1
+  const navigationProcessing = navCtxMode && (navFetchPending || isPending)
+
+  const sideNavigation =
+    showRails && isOpen ? (
+      <ModalSideNavigation canGoPrev={canGoPrev} canGoNext={canGoNext} onPrevAction={handleGoPrev} onNextAction={handleGoNext} />
+    ) : undefined
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
-      <div className="flex h-[80vh] flex-col overflow-hidden">
-        {loading && !resolvedItem ? (
-          <div className="relative min-h-0 flex-1">
-            <LoadingIndicator />
-          </div>
-        ) : resolvedItem ? (
-          <Match libraryItem={resolvedItem} />
-        ) : null}
-      </div>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      processing={navigationProcessing}
+      sideNavigation={sideNavigation}
+      className="md:max-w-[min(90vw,56rem)] lg:max-w-[min(90vw,56rem)]"
+    >
+      <div className="flex h-[80vh] flex-col overflow-hidden">{resolvedItem ? <Match libraryItem={resolvedItem} /> : null}</div>
     </Modal>
   )
 }

--- a/src/components/modals/MatchModal.tsx
+++ b/src/components/modals/MatchModal.tsx
@@ -79,6 +79,14 @@ export default function MatchModal(props: MatchModalProps) {
   if (!isOpen) return null
 
   const resolvedItem = navCtxMode ? fetchedItem : props.libraryItem
+  const mediaTitle = resolvedItem?.media.metadata.title ?? ''
+  const outerContent = mediaTitle ? (
+    <div className="absolute start-0 top-0 p-4">
+      <h2 className="max-w-[calc(100vw-4rem)] truncate text-lg text-white" title={mediaTitle}>
+        {mediaTitle}
+      </h2>
+    </div>
+  ) : undefined
   const showRails = navCtxMode && entityIds.length > 1
   const navigationProcessing = navCtxMode && (navFetchPending || isPending)
 
@@ -93,6 +101,7 @@ export default function MatchModal(props: MatchModalProps) {
       onClose={onClose}
       processing={navigationProcessing}
       sideNavigation={sideNavigation}
+      outerContent={outerContent}
       className="md:max-w-[min(90vw,56rem)] lg:max-w-[min(90vw,56rem)]"
     >
       <div className="flex h-[80vh] flex-col overflow-hidden">{resolvedItem ? <Match libraryItem={resolvedItem} /> : null}</div>

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -16,6 +16,7 @@ export interface ModalProps {
   bgOpacityClass?: string
   children?: ReactNode
   outerContent?: ReactNode
+  sideNavigation?: ReactNode
   onClose?: () => void
   className?: string
   style?: React.CSSProperties
@@ -29,6 +30,7 @@ export default function Modal({
   bgOpacityClass = 'bg-primary/75',
   children,
   outerContent,
+  sideNavigation,
   onClose,
   className,
   style
@@ -168,29 +170,34 @@ export default function Modal({
       {/* Outer content slot */}
       {outerContent}
 
-      {/* Main modal content */}
+      {/* Focus trap + optional side rails + panel */}
       <div
         ref={contentRef}
         tabIndex={0}
-        style={style}
-        className={mergeClasses(
-          'text-foreground shadow-modal-content bg-bg relative rounded-lg outline-none focus:outline-none',
-          // Responsive width: full width with margin on mobile, fixed width on larger screens
-          'w-[calc(100vw-1rem)] max-w-[90vw] sm:max-w-[600px] md:max-w-[700px] lg:max-w-[800px]',
-          'mt-[50px]',
-          className
-        )}
+        className="relative mt-[50px] outline-none focus:outline-none"
         cy-id="modal-content"
         onClick={(e) => e.stopPropagation()}
       >
-        <ModalProvider modalRef={wrapperRef as React.RefObject<HTMLDivElement>}>{children}</ModalProvider>
+        {sideNavigation}
+        <div
+          style={style}
+          className={mergeClasses(
+            'text-foreground shadow-modal-content bg-bg relative rounded-lg',
+            // Responsive width: full width with margin on mobile, fixed width on larger screens
+            'w-[calc(100vw-1rem)] max-w-[90vw] sm:max-w-[600px] md:max-w-[700px] lg:max-w-[800px]',
+            className
+          )}
+          cy-id="modal-panel"
+        >
+          <ModalProvider modalRef={wrapperRef as React.RefObject<HTMLDivElement>}>{children}</ModalProvider>
 
-        {/* Processing overlay */}
-        {processing && (
-          <div className="absolute inset-0 flex h-full w-full items-center justify-center rounded-lg bg-gray-900/60" cy-id="modal-processing-overlay">
-            <LoadingIndicator />
-          </div>
-        )}
+          {/* Processing overlay */}
+          {processing && (
+            <div className="absolute inset-0 flex h-full w-full items-center justify-center rounded-lg bg-gray-900/60" cy-id="modal-processing-overlay">
+              <LoadingIndicator />
+            </div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/modals/ModalSideNavigation.tsx
+++ b/src/components/modals/ModalSideNavigation.tsx
@@ -21,7 +21,7 @@ export default function ModalSideNavigation({ canGoPrev, canGoNext, onPrevAction
         <div className="pointer-events-none absolute start-[-6rem] top-0 bottom-0 z-[1] flex h-full items-center px-6">
           <button
             type="button"
-            className="material-symbols text-5xl text-white/50 hover:text-white/90 pointer-events-auto cursor-pointer"
+            className="material-symbols pointer-events-auto cursor-pointer text-5xl text-white/50 hover:text-white/90"
             aria-label={t('ButtonPrevious')}
             onClick={(e) => {
               e.stopPropagation()
@@ -38,7 +38,7 @@ export default function ModalSideNavigation({ canGoPrev, canGoNext, onPrevAction
         <div className="pointer-events-none absolute end-[-6rem] top-0 bottom-0 z-[1] flex h-full items-center px-6">
           <button
             type="button"
-            className="material-symbols text-5xl text-white/50 hover:text-white/90 pointer-events-auto cursor-pointer"
+            className="material-symbols pointer-events-auto cursor-pointer text-5xl text-white/50 hover:text-white/90"
             aria-label={t('ButtonNext')}
             onClick={(e) => {
               e.stopPropagation()

--- a/src/components/modals/ModalSideNavigation.tsx
+++ b/src/components/modals/ModalSideNavigation.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+
+export type ModalSideNavigationProps = {
+  canGoPrev: boolean
+  canGoNext: boolean
+  onPrevAction: () => void
+  onNextAction: () => void
+}
+
+/**
+ * Left/right chevrons outside the modal panel (Vue EditModal-style).
+ */
+export default function ModalSideNavigation({ canGoPrev, canGoNext, onPrevAction, onNextAction }: ModalSideNavigationProps) {
+  const t = useTypeSafeTranslations()
+
+  return (
+    <>
+      {canGoPrev ? (
+        <div className="pointer-events-none absolute start-[-6rem] top-0 bottom-0 z-[1] flex h-full items-center px-6">
+          <button
+            type="button"
+            className="material-symbols text-5xl text-white/50 hover:text-white/90 pointer-events-auto cursor-pointer"
+            aria-label={t('ButtonPrevious')}
+            onClick={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              onPrevAction()
+            }}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            arrow_back_ios
+          </button>
+        </div>
+      ) : null}
+      {canGoNext ? (
+        <div className="pointer-events-none absolute end-[-6rem] top-0 bottom-0 z-[1] flex h-full items-center px-6">
+          <button
+            type="button"
+            className="material-symbols text-5xl text-white/50 hover:text-white/90 pointer-events-auto cursor-pointer"
+            aria-label={t('ButtonNext')}
+            onClick={(e) => {
+              e.stopPropagation()
+              e.preventDefault()
+              onNextAction()
+            }}
+            onMouseDown={(e) => e.preventDefault()}
+          >
+            arrow_forward_ios
+          </button>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/components/widgets/match/SlateEditorMatchFieldEditor.tsx
+++ b/src/components/widgets/match/SlateEditorMatchFieldEditor.tsx
@@ -24,7 +24,7 @@ function SlateEditorMatchFieldEditor({ usageChecked, onUsageChange, value, onCha
     }
   }, [currentValue, onChange])
 
-  const hasCurrentValue = currentValue !== undefined && currentValue !== ''
+  const hasCurrentValue = currentValue !== undefined && currentValue !== null && currentValue !== ''
 
   const formattedValue = currentValue ? String(currentValue).substring(0, 100) + (String(currentValue).length > 100 ? '...' : '') : ''
 

--- a/src/components/widgets/match/TextInputMatchFieldEditor.tsx
+++ b/src/components/widgets/match/TextInputMatchFieldEditor.tsx
@@ -38,7 +38,7 @@ function TextInputMatchFieldEditor({
     }
   }, [currentValue, onChange])
 
-  const hasCurrentValue = currentValue !== undefined && currentValue !== ''
+  const hasCurrentValue = currentValue !== undefined && currentValue !== null && currentValue !== ''
 
   const currentValueDisplay = hasCurrentValue ? (
     <>

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -13,9 +13,10 @@ import { useCardSize } from '@/contexts/CardSizeContext'
 import { useBookCoverAspectRatio, useLibrary } from '@/contexts/LibraryContext'
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { getEntityNavigationContext, type EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
 import { getPlaceholderCoverUrl } from '@/lib/coverUtils'
 import { computeProgress } from '@/lib/mediaProgress'
-import type { BookMedia, EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode, PodcastMedia, UserPermissions } from '@/types/api'
+import type { BookMedia, BookshelfEntity, EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode, PodcastMedia, UserPermissions } from '@/types/api'
 import { BookshelfView, isBookMedia, isBookMetadata, isPodcastLibraryItem } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { memo, useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react'
@@ -68,6 +69,11 @@ export interface MediaCardProps {
    * Callback when the select button is clicked
    */
   onSelect?: (event: React.MouseEvent) => void
+  /**
+   * When both are set, modal prev/next scope is built lazily on open from this shelf snapshot (sparse bookshelf grid or dense home row).
+   */
+  shelfEntities?: (BookshelfEntity | null)[]
+  entityIndex?: number
 }
 
 function MediaCard(props: MediaCardProps) {
@@ -90,7 +96,9 @@ function MediaCard(props: MediaCardProps) {
     episode,
     isSelectionMode = false,
     selected = false,
-    onSelect
+    onSelect,
+    shelfEntities,
+    entityIndex
   } = props
 
   const router = useRouter()
@@ -109,12 +117,15 @@ function MediaCard(props: MediaCardProps) {
 
   const clearBoundModal = useCallback(() => setBoundModal(null), [setBoundModal])
 
-  const handleOpenMatch = useCallback(
-    (libraryItemId: string) => {
-      setBoundModal(<MatchModal key={libraryItemId} isOpen libraryItemId={libraryItemId} onClose={clearBoundModal} />)
-    },
-    [clearBoundModal, setBoundModal]
-  )
+  const handleOpenMatch = useCallback(() => {
+    const defaultNavigationContext: EntityNavigationContext = { entityIds: [libraryItem.id], initialIndex: 0 }
+    let navigationContext: EntityNavigationContext = defaultNavigationContext
+    if (shelfEntities !== undefined && entityIndex !== undefined) {
+      const computedNavigationContext = getEntityNavigationContext(shelfEntities, entityIndex)
+      if (computedNavigationContext) navigationContext = computedNavigationContext
+    }
+    setBoundModal(<MatchModal key="match-modal" isOpen navCtx={navigationContext} onClose={clearBoundModal} />)
+  }, [clearBoundModal, libraryItem.id, shelfEntities, entityIndex, setBoundModal])
 
   const handleMoreMenuOpenChange = (isOpen: boolean) => {
     setIsMoreMenuOpen(isOpen)

--- a/src/components/widgets/media-card/PodcastEpisodeCard.tsx
+++ b/src/components/widgets/media-card/PodcastEpisodeCard.tsx
@@ -5,7 +5,7 @@ import type { PodcastEpisode } from '@/types/api'
 import { useMemo } from 'react'
 import MediaCard, { type MediaCardProps } from './MediaCard'
 
-export type PodcastEpisodeCardProps = MediaCardProps
+export type PodcastEpisodeCardProps = Omit<MediaCardProps, 'shelfEntities' | 'entityIndex'>
 
 /**
  * Podcast episode card.

--- a/src/components/widgets/media-card/useMediaCardActions.ts
+++ b/src/components/widgets/media-card/useMediaCardActions.ts
@@ -39,7 +39,7 @@ interface UseMediaCardActionsProps {
   onShareChange?: (share: MediaItemShare | null) => void
   onDeleteSuccess?: () => void
   /** Invoked for the Match menu action. Host owns modal state (card, page, bookshelf, etc.). */
-  onOpenMatch?: (libraryItemId: string) => void
+  onOpenMatch?: () => void
   playerControls: PlayerHandlerControls
 }
 
@@ -215,7 +215,7 @@ export function useMediaCardActions({
       } else if (action === 'openRssFeed') {
         setRssFeedModalOpen(true)
       } else if (action === 'showMatchModal') {
-        onOpenMatch?.(libraryItem.id)
+        onOpenMatch?.()
       } else if (action === 'download') {
         downloadLibraryItem(libraryItem.id)
       } else if (action === 'sendToDevice') {
@@ -381,7 +381,7 @@ export function useMediaCardActions({
       }
     }
 
-    if (userCanUpdate && onOpenMatch) {
+    if (userCanUpdate && onOpenMatch && !episodeForQueue) {
       items.push({
         text: t('HeaderMatch'),
         func: 'showMatchModal'

--- a/src/hooks/useEntityNavigationContext.ts
+++ b/src/hooks/useEntityNavigationContext.ts
@@ -1,0 +1,35 @@
+import type { EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
+import { useCallback, useLayoutEffect, useState } from 'react'
+
+/**
+ * Tracks index into `navigation.entityIds` for modal prev/next; resets when the modal opens.
+ * Reset runs in a layout effect so consumers' layout effects see the correct index on open.
+ * Pass `null` when there is no sequential scope (e.g. single-entity modal).
+ */
+export function useEntityNavigationContext(navigationContext: EntityNavigationContext | undefined, isOpen: boolean) {
+  const entityIds = navigationContext?.entityIds ?? []
+  const initialIndex = navigationContext?.initialIndex ?? 0
+
+  const [navIndex, setNavIndex] = useState(initialIndex)
+
+  useLayoutEffect(() => {
+    if (isOpen) {
+      setNavIndex(initialIndex)
+    }
+  }, [isOpen, initialIndex])
+
+  const safeIndex = Math.min(Math.max(0, navIndex), Math.max(0, entityIds.length - 1))
+  const currentEntityId = entityIds.length > 0 ? entityIds[safeIndex]! : null
+  const canGoPrev = entityIds.length > 0 && safeIndex > 0
+  const canGoNext = entityIds.length > 0 && safeIndex < entityIds.length - 1
+
+  const goPrev = useCallback(() => {
+    setNavIndex((i) => (i > 0 ? i - 1 : i))
+  }, [])
+
+  const goNext = useCallback(() => {
+    setNavIndex((i) => (i < entityIds.length - 1 ? i + 1 : i))
+  }, [entityIds.length])
+
+  return { currentEntityId, canGoPrev, canGoNext, goPrev, goNext }
+}

--- a/src/lib/bookshelfNavigationContext.ts
+++ b/src/lib/bookshelfNavigationContext.ts
@@ -1,0 +1,47 @@
+import type { BookshelfEntity } from '@/types/api'
+
+/**
+ * Generic prev/next scope for modals.
+ * `entityIds` is ordered; `initialIndex` selects the active entity when the modal opens.
+ */
+export type EntityNavigationContext = {
+  entityIds: string[]
+  initialIndex: number
+}
+
+/**
+ * Prev/next entity scope for one bookshelf entity slot: contiguous non-null run around `entityIndex`, in array order.
+ * Call when opening a modal (lazy). Returns a fresh `entityIds` array; safe to pass through to the modal.
+ */
+export function getEntityNavigationContext(entities: (BookshelfEntity | null)[], entityIndex: number): EntityNavigationContext | null {
+  if (entityIndex < 0 || entityIndex >= entities.length) return null
+
+  const at = entities[entityIndex]
+  if (at === null) return null
+
+  let start = entityIndex
+  while (start > 0 && entities[start - 1] !== null) {
+    start--
+  }
+
+  let end = entityIndex
+  while (end < entities.length - 1 && entities[end + 1] !== null) {
+    end++
+  }
+
+  const entityIds: string[] = []
+  let initialIndex = -1
+
+  for (let j = start; j <= end; j++) {
+    const e = entities[j]
+    if (e === null) continue
+    if (j === entityIndex) {
+      initialIndex = entityIds.length
+    }
+    entityIds.push(e.id)
+  }
+
+  if (initialIndex < 0) return null
+
+  return { entityIds, initialIndex }
+}


### PR DESCRIPTION
This adds prev/next navigation buttons to `MatchModal`, in a way that can be reused for other modals (e.g. Edit, AuthorEdit) in the future.

- In the case of `LibraryClient,` the matched card's shelf is used as navigation context.
- In the case of `BookshelfClient`, the surrounding contiguous non-null items block is used as navigation context.

The navigation context is frozen when the modal is opened, so if anything changes underneath (items updated/added/reomved), the context remains the same and navigation is predictable.

This also removes Match from podcast episode cards, as discussed on Discord.
