### PR TITLE
Switch to using mediaItemId in progress maps

### DIFF
--- a/cypress/tests/components/widgets/ChaptersTable.cy.tsx
+++ b/cypress/tests/components/widgets/ChaptersTable.cy.tsx
@@ -41,8 +41,7 @@ const mockUserContextValue: UserContextType = {
   userDefaultLibraryId: 'test-library-id',
   ereaderDevices: [],
   Source: 'test',
-  getLibraryItemProgress: () => undefined,
-  getEpisodeProgress: () => undefined
+  getMediaItemProgress: () => undefined
 }
 
 const mockLibraryItem: BookLibraryItem = {

--- a/src/app/(main)/components_catalog/examples/media-card/SeriesCardExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/media-card/SeriesCardExamples.tsx
@@ -69,7 +69,7 @@ export function SeriesCardExamples({ seriesData, libraryId }: SeriesCardExamples
               <Code>orderBy</Code>: Sort field (addedAt, totalDuration, lastBookUpdated, lastBookAdded).
             </li>
             <li>
-              <Code>bookProgressMap</Code>: Map of book progress by library item ID for calculating series progress.
+              <Code>bookProgressMap</Code>: Map of book progress by media item ID for calculating series progress.
             </li>
           </ul>
         </div>
@@ -127,11 +127,21 @@ export function SeriesCardExamples({ seriesData, libraryId }: SeriesCardExamples
                 libraryId={libraryId}
                 bookshelfView={BookshelfView.DETAIL}
                 dateFormat={defaultDateFormat}
-                bookProgressMap={
+                mediaItemProgressMap={
                   new Map(
-                    seriesData.books
-                      ?.slice(0, Math.ceil((seriesData.books?.length || 0) / 2))
-                      .map((book) => [book.id, { id: `progress-${book.id}`, libraryItemId: book.id, isFinished: false, progress: 0.5 } as MediaProgress]) || []
+                    seriesData.books?.slice(0, Math.ceil((seriesData.books?.length || 0) / 2)).map((book) => {
+                      const mediaItemId = book.media?.id ?? book.id
+                      return [
+                        mediaItemId,
+                        {
+                          id: `progress-${book.id}`,
+                          libraryItemId: book.id,
+                          mediaItemId,
+                          isFinished: false,
+                          progress: 0.5
+                        } as MediaProgress
+                      ] as [string, MediaProgress]
+                    }) || []
                   )
                 }
               />
@@ -143,12 +153,15 @@ export function SeriesCardExamples({ seriesData, libraryId }: SeriesCardExamples
                 libraryId={libraryId}
                 bookshelfView={BookshelfView.DETAIL}
                 dateFormat={defaultDateFormat}
-                bookProgressMap={
+                mediaItemProgressMap={
                   new Map(
-                    seriesData.books?.map((book) => [
-                      book.id,
-                      { id: `finished-${book.id}`, libraryItemId: book.id, isFinished: true, progress: 1 } as MediaProgress
-                    ]) || []
+                    seriesData.books?.map((book) => {
+                      const mediaItemId = book.media?.id ?? book.id
+                      return [
+                        mediaItemId,
+                        { id: `finished-${book.id}`, libraryItemId: book.id, mediaItemId, isFinished: true, progress: 1 } as MediaProgress
+                      ] as [string, MediaProgress]
+                    }) || []
                   )
                 }
               />

--- a/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
@@ -26,7 +26,7 @@ interface AuthorClientProps {
 export default function AuthorClient({ author: authorProp }: AuthorClientProps) {
   const t = useTypeSafeTranslations()
   const { library, showSubtitles } = useLibrary()
-  const { user, serverSettings, ereaderDevices, getLibraryItemProgress } = useUser()
+  const { user, serverSettings, ereaderDevices, getMediaItemProgress } = useUser()
   const { sizeMultiplier } = useCardSize()
   const router = useRouter()
 
@@ -103,7 +103,7 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
             className="!ps-0"
           >
             {libraryItems.map((libraryItem) => {
-              const mediaProgress = getLibraryItemProgress(libraryItem.id)
+              const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
               return (
                 <div key={libraryItem.id} className="mx-2e shrink-0">
                   <BookMediaCard
@@ -136,7 +136,7 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
           <div key={bookSeries.id} className="-ms-2e shrink-0">
             <ItemSlider title={seriesTitle} className="!ps-0">
               {bookSeries.items?.map((libraryItem) => {
-                const mediaProgress = getLibraryItemProgress(libraryItem.id)
+                const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
                 return (
                   <div key={libraryItem.id} className="mx-2e shrink-0">
                     <BookMediaCard

--- a/src/app/(main)/library/[library]/(book)/series/[series]/SeriesClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/series/[series]/SeriesClient.tsx
@@ -9,12 +9,12 @@ interface SeriesClientProps {
 }
 
 export default function SeriesClient({ libraryItems }: SeriesClientProps) {
-  const { user, serverSettings, ereaderDevices, getLibraryItemProgress } = useUser()
+  const { user, serverSettings, ereaderDevices, getMediaItemProgress } = useUser()
   return (
     <div>
       <div className="flex flex-wrap gap-4">
         {libraryItems.results.map((libraryItem) => {
-          const entityProgress = getLibraryItemProgress(libraryItem.id)
+          const entityProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
           return (
             <BookMediaCard
               key={libraryItem.id}

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -25,7 +25,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   const t = useTypeSafeTranslations()
   const [, startScanTransition] = useTransition()
   const { sizeMultiplier } = useCardSize()
-  const { user, serverSettings, ereaderDevices, userIsAdminOrUp, getLibraryItemProgress, getEpisodeProgress } = useUser()
+  const { user, serverSettings, ereaderDevices, userIsAdminOrUp, getMediaItemProgress } = useUser()
   const { library, setContextMenuItems, setContextMenuActionHandler, homeBookshelfView } = useLibrary()
 
   const [shelves, setShelves] = useState(personalized)
@@ -174,7 +174,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
               if (shelf.type === 'book' || shelf.type === 'podcast') {
                 const EntityMediaCard = shelf.type === 'book' ? BookMediaCard : PodcastMediaCard
                 const libraryItem = entity as LibraryItem
-                const mediaProgress = getLibraryItemProgress(libraryItem.id)
+                const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
 
                 return (
                   <div key={entity.id + '-' + shelf.id} className="mx-2e shrink-0">
@@ -195,11 +195,12 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
               } else if (shelf.type === 'series') {
                 const series = entity as Series
                 const libraryItems = series.books || []
-                const bookProgressMap = new Map<string, MediaProgress>()
+                const mediaItemProgressMap = new Map<string, MediaProgress>()
                 libraryItems.forEach((libraryItem) => {
-                  const mediaProgress = getLibraryItemProgress(libraryItem.id)
+                  const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
                   if (mediaProgress) {
-                    bookProgressMap.set(libraryItem.id, mediaProgress)
+                    const key = mediaProgress.mediaItemId ?? libraryItem.media?.id
+                    if (key) mediaItemProgressMap.set(key, mediaProgress)
                   }
                 })
                 return (
@@ -209,7 +210,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
                       libraryId={library.id}
                       bookshelfView={homeBookshelfView}
                       dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
-                      bookProgressMap={bookProgressMap}
+                      mediaItemProgressMap={mediaItemProgressMap}
                     />
                   </div>
                 )
@@ -219,7 +220,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
                 if (!episode) {
                   return null
                 }
-                const mediaProgress = getEpisodeProgress(episode.id)
+                const mediaProgress = getMediaItemProgress(episode.id)
                 return (
                   <div key={episode.id + '-' + shelf.id} className="mx-2e shrink-0">
                     <PodcastEpisodeCard

--- a/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/BookshelfClient.tsx
@@ -9,7 +9,8 @@ import { useBookshelfUpdater } from '@/hooks/useBookshelfUpdater'
 import { useBookshelfVirtualizer } from '@/hooks/useBookshelfVirtualizer'
 import { usePersistentScroll } from '@/hooks/usePersistentScroll'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { BookshelfEntity, BookshelfView, EntityType, MediaProgress } from '@/types/api'
+import { buildMediaItemProgressMap } from '@/lib/mediaProgress'
+import { BookshelfEntity, BookshelfView, EntityType } from '@/types/api'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import LibraryEmptyState from '../LibraryEmptyState'
 import { ENTITY_CONFIGS } from './entity-config'
@@ -211,18 +212,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
     }
   }, [bookshelfLayoutReady, getVisiblePageRange, totalEntities, itemsPerPage, loadPage])
 
-  const bookProgressMap = useMemo(() => {
-    const map = new Map<string, MediaProgress>()
-    user.mediaProgress.forEach((p) => {
-      if (p.episodeId) {
-        map.set(p.episodeId, p)
-        return
-      }
-
-      map.set(p.libraryItemId, p)
-    })
-    return map
-  }, [user.mediaProgress])
+  const mediaItemProgressMap = useMemo(() => buildMediaItemProgressMap(user.mediaProgress), [user.mediaProgress])
 
   // Inject Toolbar Controls and Menu Items
   const { setToolbarExtras, setContextMenuItems, setContextMenuActionHandler } = useLibrary()
@@ -350,7 +340,7 @@ export default function BookshelfClient({ entityType }: BookshelfClientProps) {
                       showSubtitles={showSubtitles}
                       orderBy={orderBy}
                       seriesSortBy={seriesSortBy}
-                      bookProgressMap={bookProgressMap}
+                      mediaItemProgressMap={mediaItemProgressMap}
                       shelfEntities={entityType === 'items' ? items : undefined}
                       entityIndex={entityType === 'items' ? entityIndex : undefined}
                     />

--- a/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
@@ -38,7 +38,7 @@ export interface CardComponentProps {
   showSubtitles?: boolean
   orderBy?: string
   seriesSortBy?: string
-  bookProgressMap: Map<string, MediaProgress>
+  mediaItemProgressMap: Map<string, MediaProgress>
   shelfEntities?: (BookshelfEntity | null)[]
   entityIndex?: number
 }
@@ -105,11 +105,11 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     SkeletonComponent: ({ bookshelfView, showSubtitles, orderBy }) => (
       <MediaCardSkeleton bookshelfView={bookshelfView} showSubtitles={showSubtitles} orderBy={orderBy} />
     ),
-    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, showSubtitles, orderBy, bookProgressMap, shelfEntities, entityIndex }) => {
+    CardComponent: ({ entity, bookshelfView, width, isPodcastLibrary, showSubtitles, orderBy, mediaItemProgressMap, shelfEntities, entityIndex }) => {
       const { user, serverSettings, ereaderDevices } = useUser()
       const item = entity as LibraryItem
       const isCollapsedSeries = !!item.collapsedSeries
-      const entityProgress = isPodcastLibrary ? null : bookProgressMap.get(item.id)
+      const entityProgress = isPodcastLibrary ? null : item.media?.id ? mediaItemProgressMap.get(item.media.id) : undefined
       const EntityMediaCard = isPodcastLibrary ? PodcastMediaCard : BookMediaCard
 
       if (isCollapsedSeries) {
@@ -164,7 +164,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
     handleContextMenuAction: () => {},
     getEmptyMessageKey: (filterBy) => (filterBy === 'all' ? 'MessageBookshelfNoSeries' : 'MessageNoSeriesFound'),
     SkeletonComponent: ({ bookshelfView, seriesSortBy }) => <SeriesCardSkeleton bookshelfView={bookshelfView} orderBy={seriesSortBy} />,
-    CardComponent: ({ entity, bookshelfView, width, libraryId, seriesSortBy, bookProgressMap }) => {
+    CardComponent: ({ entity, bookshelfView, width, libraryId, seriesSortBy, mediaItemProgressMap }) => {
       const { serverSettings } = useUser()
       const series = entity as Series
       return (
@@ -175,7 +175,7 @@ export const ENTITY_CONFIGS: Record<EntityType, EntityConfig> = {
             bookshelfView={bookshelfView}
             dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
             orderBy={seriesSortBy}
-            bookProgressMap={bookProgressMap}
+            mediaItemProgressMap={mediaItemProgressMap}
           />
         </div>
       )

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
@@ -24,7 +24,7 @@ interface LibraryItemActionButtonsProps {
 }
 
 export default function LibraryItemActionButtons({ libraryItem, onEdit, rssFeed = null }: LibraryItemActionButtonsProps) {
-  const { userCanUpdate, getLibraryItemProgress, ereaderDevices } = useUser()
+  const { userCanUpdate, getMediaItemProgress, ereaderDevices } = useUser()
   const {
     playItem,
     libraryItemIdStreaming,
@@ -43,7 +43,7 @@ export default function LibraryItemActionButtons({ libraryItem, onEdit, rssFeed 
     setMatchModalOpen(true)
   }, [])
 
-  const mediaProgress = getLibraryItemProgress(libraryItem.id)
+  const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
   const isRead = mediaProgress?.isFinished ?? false
 
   const isPodcast = libraryItem.mediaType === 'podcast'

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -26,7 +26,7 @@ interface LibraryItemClientProps {
 
 export default function LibraryItemClient({ libraryItem: initialLibraryItem }: LibraryItemClientProps) {
   const { library } = useLibrary()
-  const { serverSettings, getLibraryItemProgress, userCanUpdate, userIsAdminOrUp } = useUser()
+  const { serverSettings, getMediaItemProgress, userCanUpdate, userIsAdminOrUp } = useUser()
   const { showToast } = useGlobalToast()
   const t = useTypeSafeTranslations()
 
@@ -46,7 +46,7 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
   const bookSeries = 'series' in metadata ? metadata.series || [] : []
   const description = 'description' in metadata ? metadata.description : undefined
 
-  const userProgress = getLibraryItemProgress(libraryItem.id)
+  const userProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
 
   const handleOpenEditModal = () => {
     setIsEditModalOpen(true)

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -15,7 +15,8 @@ import { useEpisodeFilterAndSort } from '@/hooks/useEpisodeFilterAndSort'
 import { useEpisodeTableVirtualizer } from '@/hooks/useEpisodeTableVirtualizer'
 import { useLibraryFileActions } from '@/hooks/useLibraryFileActions'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { MediaProgress, PodcastEpisode, PodcastEpisodeDownload, PodcastLibraryItem, RssPodcastEpisode } from '@/types/api'
+import { buildPodcastEpisodeProgressMap } from '@/lib/mediaProgress'
+import { PodcastEpisode, PodcastEpisodeDownload, PodcastLibraryItem, RssPodcastEpisode } from '@/types/api'
 import { useCallback, useMemo, useState, useTransition } from 'react'
 
 interface EpisodeTableProps {
@@ -40,20 +41,12 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   const [podcastFeedEpisodes, setPodcastFeedEpisodes] = useState<RssPodcastEpisode[]>([])
   const [fetchingRSSFeed, startFetchingRSSTransition] = useTransition()
 
-  // Create a dictionary of progress entries for this library item for O(1) lookup
-  const episodeProgressMap = useMemo(() => {
-    const map = new Map<string, MediaProgress>()
-    for (const p of user.mediaProgress) {
-      if (p.libraryItemId === libraryItem.id && p.episodeId) {
-        map.set(p.episodeId, p)
-      }
-    }
-    return map
-  }, [user, libraryItem.id])
+  // Create a dictionary of progress entries for this library item for O(1) lookup (media item id keys)
+  const episodeProgressMap = useMemo(() => buildPodcastEpisodeProgressMap(libraryItem.id, user.mediaProgress), [user.mediaProgress, libraryItem.id])
 
-  const getEpisodeProgress = useCallback(
-    (episodeId: string) => {
-      return episodeProgressMap.get(episodeId) || null
+  const getMediaItemProgress = useCallback(
+    (mediaItemId: string) => {
+      return episodeProgressMap.get(mediaItemId) || null
     },
     [episodeProgressMap]
   )
@@ -66,7 +59,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   const episodes = useMemo(() => libraryItem.media.episodes || [], [libraryItem.media.episodes])
 
   const { filterKey, setFilterKey, sortKey, setSortKey, sortDesc, setSortDesc, search, setSearch, isSearching, filteredEpisodes, hasMounted } =
-    useEpisodeFilterAndSort({ libraryItemId: libraryItem.id, episodes, getEpisodeProgress })
+    useEpisodeFilterAndSort({ libraryItemId: libraryItem.id, episodes, getMediaItemProgress })
 
   const handleCloseViewModal = useCallback(() => {
     if (viewedEpisode) {
@@ -89,10 +82,10 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
 
   const allEpisodesFinished = useMemo(() => {
     return !filteredEpisodes.some((episode) => {
-      const itemProgress = getEpisodeProgress?.(episode.id)
+      const itemProgress = getMediaItemProgress?.(episode.id)
       return !itemProgress?.isFinished
     })
-  }, [filteredEpisodes, getEpisodeProgress])
+  }, [filteredEpisodes, getMediaItemProgress])
 
   const handleSelectEpisode = useCallback((episode: PodcastEpisode, isSelected: boolean) => {
     setSelectedEpisodes((prev) => {
@@ -129,7 +122,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
 
   const handleToggleFinished = useCallback(
     (episode: PodcastEpisode) => {
-      const progress = getEpisodeProgress(episode.id)
+      const progress = getMediaItemProgress(episode.id)
       const isFinished = progress ? !progress.isFinished : true
 
       startTransition(async () => {
@@ -144,7 +137,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
         }
       })
     },
-    [libraryItem.id, getEpisodeProgress, showToast, t]
+    [libraryItem.id, getMediaItemProgress, showToast, t]
   )
 
   const handleViewEpisode = useCallback((episode: PodcastEpisode) => {
@@ -257,10 +250,10 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   const allSelectedEpisodesFinished = useMemo(() => {
     if (selectedEpisodes.size === 0) return false
     return Array.from(selectedEpisodes).every((episodeId) => {
-      const itemProgress = getEpisodeProgress?.(episodeId)
+      const itemProgress = getMediaItemProgress?.(episodeId)
       return itemProgress?.isFinished
     })
-  }, [selectedEpisodes, getEpisodeProgress])
+  }, [selectedEpisodes, getMediaItemProgress])
 
   const headerActions = useMemo(
     () => (
@@ -364,7 +357,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
                     episode={episode}
                     libraryItemId={libraryItem.id}
                     sortKey={sortKey}
-                    progress={getEpisodeProgress?.(episode.id) || null}
+                    progress={getMediaItemProgress?.(episode.id) || null}
                     isSelected={selectedEpisodes.has(episode.id)}
                     isSelectionMode={isSelectionMode}
                     dateFormat={dateFormat}

--- a/src/components/widgets/media-card/SeriesCard.tsx
+++ b/src/components/widgets/media-card/SeriesCard.tsx
@@ -31,10 +31,10 @@ export interface SeriesCardProps {
   /** Date format from server settings */
   dateFormat: string
   /**
-   * Map of book progress by library item ID
-   * Used to calculate series progress
+   * Map of progress keyed by book `mediaItemId`
+   * Used to calculate series progress.
    */
-  bookProgressMap?: Map<string, MediaProgress>
+  mediaItemProgressMap?: Map<string, MediaProgress>
   /** Whether the card is in selection mode */
   isSelectionMode?: boolean
   /** Whether the card is currently selected */
@@ -54,7 +54,7 @@ function SeriesCard(props: SeriesCardProps) {
     sortingIgnorePrefix = false,
     sizeMultiplier,
     dateFormat,
-    bookProgressMap,
+    mediaItemProgressMap,
     isSelectionMode = false,
     selected = false,
     onSelect,
@@ -86,7 +86,7 @@ function SeriesCard(props: SeriesCardProps) {
   // Calculate series progress from book progress
   const { seriesProgressPercent, isSeriesFinished } = useMemo(() => {
     const books = series.books || []
-    if (!books.length || !bookProgressMap) {
+    if (!books.length || !mediaItemProgressMap) {
       return { seriesProgressPercent: 0, isSeriesFinished: false }
     }
 
@@ -94,7 +94,7 @@ function SeriesCard(props: SeriesCardProps) {
     let finishedCount = 0
 
     books.forEach((book) => {
-      const progress = bookProgressMap.get(book.id)
+      const progress = book.media?.id ? mediaItemProgressMap.get(book.media.id) : undefined
       if (progress) {
         if (progress.isFinished) {
           progressPercent += 1
@@ -112,7 +112,7 @@ function SeriesCard(props: SeriesCardProps) {
       seriesProgressPercent: progressPercent,
       isSeriesFinished: finishedCount === books.length
     }
-  }, [series.books, bookProgressMap])
+  }, [series.books, mediaItemProgressMap])
 
   // Check if any books have valid covers
   const hasValidCovers = useMemo(() => {

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -22,8 +22,8 @@ export interface UserContextType {
   userDefaultLibraryId?: string
   ereaderDevices: EReaderDevice[]
   Source: string
-  getLibraryItemProgress: (libraryItemId: string) => MediaProgress | undefined
-  getEpisodeProgress: (episodeId: string) => MediaProgress | undefined
+  /** Book media id or podcast episode id matches `MediaProgress.mediaItemId` */
+  getMediaItemProgress: (mediaItemId: string) => MediaProgress | undefined
 }
 
 export const UserContext = createContext<UserContextType | undefined>(undefined)
@@ -85,9 +85,7 @@ export function UserProvider({ children, initialUser }: { children: ReactNode; i
     userDefaultLibraryId: currentUserData.userDefaultLibraryId,
     ereaderDevices: currentUserData.ereaderDevices,
     Source: currentUserData.Source,
-    getLibraryItemProgress: (libraryItemId: string) =>
-      user.mediaProgress.find((p) => p.libraryItemId === libraryItemId && !p.episodeId && p.mediaItemType !== 'podcastEpisode'),
-    getEpisodeProgress: (episodeId: string) => user.mediaProgress.find((p) => p.episodeId === episodeId)
+    getMediaItemProgress: (mediaItemId: string) => user.mediaProgress.find((p) => p.mediaItemId === mediaItemId)
   }
 
   return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>

--- a/src/hooks/useEpisodeFilterAndSort.ts
+++ b/src/hooks/useEpisodeFilterAndSort.ts
@@ -5,10 +5,10 @@ import { useEffect, useMemo, useState } from 'react'
 interface UseEpisodeFilterAndSortReturn {
   libraryItemId: string
   episodes: PodcastEpisode[]
-  getEpisodeProgress?: (episodeId: string) => MediaProgress | null
+  getMediaItemProgress?: (mediaItemId: string) => MediaProgress | null
 }
 
-export function useEpisodeFilterAndSort({ libraryItemId, episodes, getEpisodeProgress }: UseEpisodeFilterAndSortReturn) {
+export function useEpisodeFilterAndSort({ libraryItemId, episodes, getMediaItemProgress }: UseEpisodeFilterAndSortReturn) {
   const storageKey = `episodeTable:${libraryItemId}`
 
   const [filterKey, setFilterKey] = useState<string>('incomplete')
@@ -62,7 +62,7 @@ export function useEpisodeFilterAndSort({ libraryItemId, episodes, getEpisodePro
     // Apply filter
     if (filterKey !== 'all') {
       result = result.filter((ep) => {
-        const progress = getEpisodeProgress?.(ep.id)
+        const progress = getMediaItemProgress?.(ep.id)
         if (filterKey === 'incomplete') return !progress || !progress.isFinished
         if (filterKey === 'complete') return progress?.isFinished
         return progress && !progress.isFinished && progress.currentTime > 0 // in_progress
@@ -111,7 +111,7 @@ export function useEpisodeFilterAndSort({ libraryItemId, episodes, getEpisodePro
     })
 
     return result
-  }, [episodes, filterKey, sortKey, sortDesc, searchText, getEpisodeProgress])
+  }, [episodes, filterKey, sortKey, sortDesc, searchText, getMediaItemProgress])
 
   return {
     filterKey,

--- a/src/lib/mediaProgress.ts
+++ b/src/lib/mediaProgress.ts
@@ -1,5 +1,26 @@
 import type { MediaProgress } from '@/types/api'
 
+export function buildMediaItemProgressMap(mediaProgress: MediaProgress[]): Map<string, MediaProgress> {
+  const map = new Map<string, MediaProgress>()
+  for (const p of mediaProgress) {
+    const key = p.mediaItemId ?? p.episodeId ?? p.libraryItemId
+    map.set(key, p)
+  }
+  return map
+}
+
+/** Progress rows for one podcast library item, keyed by podcast episode id (mediaItemId) */
+export function buildPodcastEpisodeProgressMap(podcastLibraryItemId: string, mediaProgress: MediaProgress[]): Map<string, MediaProgress> {
+  const map = new Map<string, MediaProgress>()
+  for (const p of mediaProgress) {
+    if (p.libraryItemId !== podcastLibraryItemId) continue
+    const key = p.mediaItemId ?? p.episodeId
+    if (!key) continue
+    map.set(key, p)
+  }
+  return map
+}
+
 export interface ProgressComputationOptions {
   progress: MediaProgress | null | undefined
   /**


### PR DESCRIPTION
`mediaItemId` is better to use when working with media progress records. 
The media item id is either the book id (at `libraryItem.media.id`) or the podcast episode id.

this includes two changes:

- switched all `bookProgressMap` to `mediaItemProgressMap` that uses media item id instead of library item id
- `getLibraryItemProgress` / `getEpisodeProgress` merged into `getMediaItemProgress`, which matches on mediaItemId