### PR TITLE
Integrate edit modal in media card

### DIFF
--- a/src/components/modals/LibraryItemEditModal.tsx
+++ b/src/components/modals/LibraryItemEditModal.tsx
@@ -1,42 +1,111 @@
 'use client'
 
 import { updateLibraryItemMediaAction } from '@/app/actions/mediaActions'
-import Modal from '@/components/modals/Modal'
+import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource } from '@/components/modals/LibraryItemModal'
 import Btn from '@/components/ui/Btn'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import BookDetailsEdit, { BookDetailsEditRef, BookUpdatePayload } from '@/components/widgets/BookDetailsEdit'
 import PodcastDetailsEdit, { PodcastDetailsEditRef, PodcastUpdatePayload } from '@/components/widgets/PodcastDetailsEdit'
 import { useLibrary } from '@/contexts/LibraryContext'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { BookMedia, BookMetadata, PodcastMedia, PodcastMetadata } from '@/types/api'
 import { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
-import { useCallback, useEffect, useRef, useState, useTransition } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useTransition, type TransitionStartFunction } from 'react'
 
-interface LibraryItemEditModalProps {
-  isOpen: boolean
-  libraryItem: BookLibraryItem | PodcastLibraryItem
-  onClose: () => void
-  onSaved?: (libraryItem: BookLibraryItem | PodcastLibraryItem) => void
+function createPlaceholderBookLibraryItem(id: string, libraryId: string): BookLibraryItem {
+  const metadata: BookMetadata = {
+    authors: [],
+    narrators: [],
+    series: [],
+    genres: [],
+    explicit: false,
+    abridged: false
+  }
+  const media: BookMedia = { metadata, tags: [] }
+  return {
+    id,
+    ino: '',
+    libraryId,
+    path: '',
+    relPath: '',
+    isFile: false,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    addedAt: 0,
+    updatedAt: 0,
+    isMissing: false,
+    isInvalid: false,
+    mediaType: 'book',
+    media
+  }
 }
 
-/**
- * Modal for editing library item metadata.
- * Renders BookDetailsEdit for books and PodcastDetailsEdit for podcasts.
- * Uses filter data from LibraryContext for autocomplete options.
- */
-export default function LibraryItemEditModal({ isOpen, libraryItem, onClose, onSaved }: LibraryItemEditModalProps) {
+function createPlaceholderPodcastLibraryItem(id: string, libraryId: string): PodcastLibraryItem {
+  const metadata: PodcastMetadata = {
+    genres: [],
+    explicit: false,
+    type: 'episodic'
+  }
+  const media: PodcastMedia = { metadata, tags: [] }
+  return {
+    id,
+    ino: '',
+    libraryId,
+    path: '',
+    relPath: '',
+    isFile: false,
+    mtimeMs: 0,
+    ctimeMs: 0,
+    birthtimeMs: 0,
+    addedAt: 0,
+    updatedAt: 0,
+    isMissing: false,
+    isInvalid: false,
+    mediaType: 'podcast',
+    media
+  }
+}
+
+export type LibraryItemEditModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  onSaved?: (libraryItem: BookLibraryItem | PodcastLibraryItem) => void
+} & LibraryItemModalItemSource
+
+type LibraryItemEditModalContentProps = {
+  isOpen: boolean
+  startSaveTransition: TransitionStartFunction
+  isSavePending: boolean
+  onClose: () => void
+  onSaved?: (libraryItem: BookLibraryItem | PodcastLibraryItem) => void
+  /** When true (navCtx), body height stays fixed so prev/next does not resize the panel. */
+  stableBodyHeight: boolean
+}
+
+function LibraryItemEditModalContent({
+  isOpen,
+  startSaveTransition,
+  isSavePending,
+  onClose,
+  onSaved,
+  stableBodyHeight
+}: LibraryItemEditModalContentProps) {
+  const { resolvedItem, fetchPending, pendingEntityId, syncResolvedItem } = useLibraryItemModal()
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
-  const { filterData, filterDataLoading } = useLibrary()
-  const [isPending, startTransition] = useTransition()
+  const { filterData, library } = useLibrary()
   const [hasChanges, setHasChanges] = useState(false)
   const saveAndCloseRef = useRef(false)
 
   const bookDetailsRef = useRef<BookDetailsEditRef>(null)
   const podcastDetailsRef = useRef<PodcastDetailsEditRef>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [footerShadow, setFooterShadow] = useState(false)
 
-  const isPodcast = libraryItem.mediaType === 'podcast'
+  const resolvedItemId = resolvedItem?.id
 
-  // Reset state when modal closes
   useEffect(() => {
     if (!isOpen) {
       setHasChanges(false)
@@ -44,7 +113,48 @@ export default function LibraryItemEditModal({ isOpen, libraryItem, onClose, onS
     }
   }, [isOpen])
 
-  // Convert filter data to MultiSelect item format
+  useEffect(() => {
+    if (!resolvedItemId) return
+    setHasChanges(false)
+    saveAndCloseRef.current = false
+  }, [resolvedItemId])
+
+  useEffect(() => {
+    setHasChanges(false)
+    saveAndCloseRef.current = false
+  }, [pendingEntityId])
+
+  const updateFooterShadow = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    const isScrollable = container.scrollHeight > container.clientHeight
+    const isAtBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 1
+    setFooterShadow(isScrollable && !isAtBottom)
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const container = scrollContainerRef.current
+    if (!container) return
+
+    updateFooterShadow()
+    container.addEventListener('scroll', updateFooterShadow)
+    const resizeObserver = new ResizeObserver(updateFooterShadow)
+    resizeObserver.observe(container)
+
+    return () => {
+      container.removeEventListener('scroll', updateFooterShadow)
+      resizeObserver.disconnect()
+    }
+  }, [isOpen, updateFooterShadow])
+
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    updateFooterShadow()
+  }, [isOpen, resolvedItemId, pendingEntityId, fetchPending, library.mediaType, updateFooterShadow])
+
   const availableAuthors = (filterData?.authors || []).map((a) => ({ value: a.id, content: a.name }))
   const availableNarrators = (filterData?.narrators || []).map((n) => ({ value: n, content: n }))
   const availableGenres = (filterData?.genres || []).map((g) => ({ value: g, content: g }))
@@ -57,6 +167,9 @@ export default function LibraryItemEditModal({ isOpen, libraryItem, onClose, onS
 
   const handleSubmit = useCallback(
     (details: { updatePayload: BookUpdatePayload | PodcastUpdatePayload; hasChanges: boolean }) => {
+      const itemId = resolvedItem?.id
+      if (!itemId) return
+
       if (!details.hasChanges) {
         if (saveAndCloseRef.current) {
           onClose()
@@ -64,14 +177,16 @@ export default function LibraryItemEditModal({ isOpen, libraryItem, onClose, onS
         return
       }
 
-      startTransition(async () => {
+      startSaveTransition(async () => {
         try {
-          const updatedItem = await updateLibraryItemMediaAction(libraryItem.id, {
+          const updatedItem = await updateLibraryItemMediaAction(itemId, {
             metadata: details.updatePayload.metadata,
             tags: details.updatePayload.tags
           })
+          const next = updatedItem.libraryItem as BookLibraryItem | PodcastLibraryItem
           showToast(t('ToastItemUpdateSuccess'), { type: 'success' })
-          onSaved?.(updatedItem.libraryItem as BookLibraryItem | PodcastLibraryItem)
+          syncResolvedItem(next)
+          onSaved?.(next)
           if (saveAndCloseRef.current) {
             onClose()
           }
@@ -81,65 +196,153 @@ export default function LibraryItemEditModal({ isOpen, libraryItem, onClose, onS
         }
       })
     },
-    [libraryItem.id, onClose, onSaved, showToast, t]
+    [onClose, onSaved, resolvedItem?.id, showToast, startSaveTransition, syncResolvedItem, t]
   )
 
   const handleSave = (close: boolean = false) => {
     saveAndCloseRef.current = close
-    if (isPodcast) {
+    if (!resolvedItem) return
+    if (resolvedItem.mediaType === 'podcast') {
       podcastDetailsRef.current?.submit()
     } else {
       bookDetailsRef.current?.submit()
     }
   }
 
-  const isProcessing = isPending || filterDataLoading
+  const isPodcast = resolvedItem?.mediaType === 'podcast'
+  const saveDisabled = !hasChanges || isSavePending || !resolvedItem || fetchPending
 
-  const outerContentTitle = (
-    <div className="absolute start-0 top-0 p-4">
-      <h2 className="text-lg text-white">{libraryItem.media.metadata.title}</h2>
+  const libraryId = library.id
+  const showPlaceholderShell = fetchPending && !resolvedItem && pendingEntityId !== null
+  const placeholderItem = useMemo(() => {
+    if (!showPlaceholderShell || pendingEntityId === null) return null
+    return library.mediaType === 'podcast'
+      ? createPlaceholderPodcastLibraryItem(pendingEntityId, libraryId)
+      : createPlaceholderBookLibraryItem(pendingEntityId, libraryId)
+  }, [library.mediaType, libraryId, pendingEntityId, showPlaceholderShell])
+
+  const fetchLoadingOverlay = (
+    <div className="absolute inset-0 z-10 flex items-center justify-center bg-bg/50">
+      <LoadingIndicator variant="inline" />
     </div>
   )
 
-  return (
-    <Modal isOpen={isOpen} onClose={onClose} outerContent={outerContentTitle} processing={isProcessing} className="sm:max-w-screen md:max-w-[800px]">
-      <div className="max-h-[85vh] w-full overflow-x-hidden overflow-y-auto rounded-lg">
-        {/* Content */}
-        <div className="min-h-[400px]">
-          {isPodcast ? (
-            <PodcastDetailsEdit
-              ref={podcastDetailsRef}
-              libraryItem={libraryItem as PodcastLibraryItem}
-              availableGenres={availableGenres}
-              availableTags={availableTags}
-              onChange={handleChange}
-              onSubmit={handleSubmit}
-            />
-          ) : (
-            <BookDetailsEdit
-              ref={bookDetailsRef}
-              libraryItem={libraryItem as BookLibraryItem}
-              availableAuthors={availableAuthors}
-              availableNarrators={availableNarrators}
-              availableGenres={availableGenres}
-              availableTags={availableTags}
-              availableSeries={availableSeries}
-              onChange={handleChange}
-              onSubmit={handleSubmit}
-            />
-          )}
+  const formInner =
+    resolvedItem && isPodcast ? (
+      <PodcastDetailsEdit
+        key={resolvedItem.id}
+        ref={podcastDetailsRef}
+        libraryItem={resolvedItem as PodcastLibraryItem}
+        availableGenres={availableGenres}
+        availableTags={availableTags}
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+      />
+    ) : resolvedItem ? (
+      <BookDetailsEdit
+        key={resolvedItem.id}
+        ref={bookDetailsRef}
+        libraryItem={resolvedItem as BookLibraryItem}
+        availableAuthors={availableAuthors}
+        availableNarrators={availableNarrators}
+        availableGenres={availableGenres}
+        availableTags={availableTags}
+        availableSeries={availableSeries}
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+      />
+    ) : showPlaceholderShell && placeholderItem ? (
+      library.mediaType === 'podcast' ? (
+        <div className="relative">
+          <PodcastDetailsEdit
+            key={`placeholder-podcast-${pendingEntityId}`}
+            ref={podcastDetailsRef}
+            libraryItem={placeholderItem as PodcastLibraryItem}
+            availableGenres={availableGenres}
+            availableTags={availableTags}
+            onChange={handleChange}
+            onSubmit={handleSubmit}
+          />
+          {fetchLoadingOverlay}
         </div>
-
-        {/* Footer */}
-        <div className="bg-bg border-border sticky bottom-0 z-10 flex justify-end gap-3 border-t px-4 py-3">
-          <Btn onClick={() => handleSave(false)} disabled={!hasChanges || isPending}>
-            {t('ButtonSave')}
-          </Btn>
-          <Btn onClick={() => handleSave(true)} disabled={!hasChanges || isPending}>
-            {t('ButtonSaveAndClose')}
-          </Btn>
+      ) : (
+        <div className="relative">
+          <BookDetailsEdit
+            key={`placeholder-book-${pendingEntityId}`}
+            ref={bookDetailsRef}
+            libraryItem={placeholderItem as BookLibraryItem}
+            availableAuthors={availableAuthors}
+            availableNarrators={availableNarrators}
+            availableGenres={availableGenres}
+            availableTags={availableTags}
+            availableSeries={availableSeries}
+            onChange={handleChange}
+            onSubmit={handleSubmit}
+          />
+          {fetchLoadingOverlay}
         </div>
+      )
+    ) : fetchPending && !resolvedItem ? (
+      <div className="flex min-h-[24rem] items-center justify-center">
+        <LoadingIndicator variant="inline" />
       </div>
-    </Modal>
+    ) : null
+
+  return (
+    <div
+      className={
+        stableBodyHeight
+          ? /* Slightly above empty book placeholder; extra content scrolls in the inner region. */
+            'flex h-[min(50rem,85vh)] max-h-[85vh] w-full flex-col rounded-lg'
+          : 'flex max-h-[85vh] w-full flex-col rounded-lg'
+      }
+    >
+      <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+        {formInner}
+      </div>
+
+      <div
+        className={`bg-bg border-border flex shrink-0 justify-end gap-3 border-t px-4 py-3 transition-shadow duration-200 ${footerShadow ? 'box-shadow-md-up' : ''}`}
+      >
+        <Btn onClick={() => handleSave(false)} disabled={saveDisabled}>
+          {t('ButtonSave')}
+        </Btn>
+        <Btn onClick={() => handleSave(true)} disabled={saveDisabled}>
+          {t('ButtonSaveAndClose')}
+        </Btn>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Modal for editing library item metadata.
+ * Renders BookDetailsEdit for books and PodcastDetailsEdit for podcasts.
+ * Uses filter data from LibraryContext for autocomplete options.
+ * Pass `navCtx` to load expanded items and enable prev/next like MatchModal.
+ */
+export default function LibraryItemEditModal(props: LibraryItemEditModalProps) {
+  const { isOpen, onClose, onSaved } = props
+  const navCtxMode = 'navCtx' in props
+  const { filterDataLoading } = useLibrary()
+  const [isSavePending, startSaveTransition] = useTransition()
+
+  return (
+    <LibraryItemModal
+      isOpen={isOpen}
+      onClose={onClose}
+      {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem })}
+      additionalProcessing={isSavePending || filterDataLoading}
+      className="sm:max-w-screen md:max-w-[800px]"
+    >
+      <LibraryItemEditModalContent
+        isOpen={isOpen}
+        startSaveTransition={startSaveTransition}
+        isSavePending={isSavePending}
+        onClose={onClose}
+        onSaved={onSaved}
+        stableBodyHeight={navCtxMode}
+      />
+    </LibraryItemModal>
   )
 }

--- a/src/components/modals/LibraryItemEditModal.tsx
+++ b/src/components/modals/LibraryItemEditModal.tsx
@@ -84,14 +84,7 @@ type LibraryItemEditModalContentProps = {
   stableBodyHeight: boolean
 }
 
-function LibraryItemEditModalContent({
-  isOpen,
-  startSaveTransition,
-  isSavePending,
-  onClose,
-  onSaved,
-  stableBodyHeight
-}: LibraryItemEditModalContentProps) {
+function LibraryItemEditModalContent({ isOpen, startSaveTransition, isSavePending, onClose, onSaved, stableBodyHeight }: LibraryItemEditModalContentProps) {
   const { resolvedItem, fetchPending, pendingEntityId, syncResolvedItem } = useLibraryItemModal()
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
@@ -222,7 +215,7 @@ function LibraryItemEditModalContent({
   }, [library.mediaType, libraryId, pendingEntityId, showPlaceholderShell])
 
   const fetchLoadingOverlay = (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-bg/50">
+    <div className="bg-bg/50 absolute inset-0 z-10 flex items-center justify-center">
       <LoadingIndicator variant="inline" />
     </div>
   )

--- a/src/components/modals/LibraryItemModal.tsx
+++ b/src/components/modals/LibraryItemModal.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { getExpandedLibraryItemAction } from '@/app/actions/mediaActions'
+import type { ModalProps } from '@/components/modals/Modal'
+import Modal from '@/components/modals/Modal'
+import ModalSideNavigation from '@/components/modals/ModalSideNavigation'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useEntityNavigationContext } from '@/hooks/useEntityNavigationContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
+import type { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
+import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState, useTransition, type ReactNode } from 'react'
+
+export type LibraryItemModalContextValue = {
+  resolvedItem: BookLibraryItem | PodcastLibraryItem | null
+  /** True while the expanded library item is loading in `navCtx` mode; always false when using `libraryItem`. */
+  fetchPending: boolean
+  /**
+   * In `navCtx` mode, the entity id currently being fetched while `resolvedItem` is still null.
+   * Use to build placeholder edit shells; null when not applicable.
+   */
+  pendingEntityId: string | null
+  /** Updates the fetched item in nav mode (e.g. after save). No-op in `directLibraryItem` mode. */
+  syncResolvedItem: (item: BookLibraryItem | PodcastLibraryItem) => void
+}
+
+const LibraryItemModalContext = createContext<LibraryItemModalContextValue | null>(null)
+
+export function useLibraryItemModal(): LibraryItemModalContextValue {
+  const ctx = useContext(LibraryItemModalContext)
+  if (!ctx) {
+    throw new Error('useLibraryItemModal must be used within LibraryItemModal')
+  }
+  return ctx
+}
+
+/** Either `navCtx` (fetch + prev/next) or `libraryItem` (no fetch); object literals cannot include both. */
+export type LibraryItemModalItemSource = { navCtx: EntityNavigationContext } | { libraryItem: BookLibraryItem | PodcastLibraryItem }
+
+export type LibraryItemModalProps = Omit<ModalProps, 'outerContent' | 'sideNavigation' | 'processing' | 'children'> &
+  LibraryItemModalItemSource & {
+    additionalProcessing?: boolean
+    children: ReactNode
+  }
+
+/**
+ * `Modal` shell for library-item flows: `navCtx` (fetch + prev/next) or `directLibraryItem` (no fetch),
+ * title chrome, side rails, and optional `additionalProcessing` overlay on `Modal`.
+ * Descendants read `resolvedItem` / `fetchPending` / `pendingEntityId` / `syncResolvedItem` via {@link useLibraryItemModal}.
+ */
+export default function LibraryItemModal(props: LibraryItemModalProps) {
+  const { additionalProcessing = false, children, isOpen, onClose, persistent, zIndexClass, bgOpacityClass, className, style } = props
+
+  const navCtxMode = 'navCtx' in props
+  const navCtx = navCtxMode ? props.navCtx : undefined
+  const libraryItem = 'libraryItem' in props ? props.libraryItem : undefined
+
+  const entityIds = navCtx?.entityIds ?? []
+
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+  const [fetchedItem, setFetchedItem] = useState<BookLibraryItem | PodcastLibraryItem | null>(null)
+  const [isNavPending, startNavTransition] = useTransition()
+  const [navFetchPending, setNavFetchPending] = useState(false)
+  const fetchGenRef = useRef(0)
+
+  const { currentEntityId, canGoPrev, canGoNext, goPrev, goNext } = useEntityNavigationContext(navCtx, isOpen)
+
+  useLayoutEffect(() => {
+    if (!isOpen || !navCtxMode) return
+    if (!currentEntityId) {
+      setFetchedItem(null)
+      return
+    }
+
+    const gen = ++fetchGenRef.current
+    setNavFetchPending(true)
+    setFetchedItem(null)
+
+    startNavTransition(async () => {
+      try {
+        const full = await getExpandedLibraryItemAction(currentEntityId)
+        if (fetchGenRef.current !== gen) return
+        setFetchedItem(full as BookLibraryItem | PodcastLibraryItem)
+      } catch (error) {
+        console.error('Failed to load expanded library item', error)
+        if (fetchGenRef.current === gen) {
+          showToast(t('ToastFailedToLoadData'), { type: 'error' })
+          onClose?.()
+        }
+      } finally {
+        if (fetchGenRef.current === gen) {
+          setNavFetchPending(false)
+        }
+      }
+    })
+  }, [isOpen, navCtxMode, navCtx, currentEntityId, onClose, showToast, startNavTransition, t])
+
+  const resolvedItem = navCtxMode ? fetchedItem : (libraryItem ?? null)
+
+  const syncResolvedItem = useCallback(
+    (item: BookLibraryItem | PodcastLibraryItem) => {
+      if (navCtxMode) setFetchedItem(item)
+    },
+    [navCtxMode]
+  )
+
+  const blurActiveElement = useCallback(() => {
+    const el = document.activeElement
+    if (el instanceof HTMLElement) el.blur()
+  }, [])
+
+  const handleGoPrev = useCallback(() => {
+    blurActiveElement()
+    goPrev()
+  }, [blurActiveElement, goPrev])
+
+  const handleGoNext = useCallback(() => {
+    blurActiveElement()
+    goNext()
+  }, [blurActiveElement, goNext])
+
+  const mediaTitle = resolvedItem?.media.metadata.title ?? ''
+  const outerContent = useMemo(() => {
+    if (!mediaTitle) return undefined
+    return (
+      <div className="absolute start-0 top-0 p-4">
+        <h2 className="max-w-[calc(100vw-4rem)] truncate text-lg text-white" title={mediaTitle}>
+          {mediaTitle}
+        </h2>
+      </div>
+    )
+  }, [mediaTitle])
+
+  const showRails = navCtxMode && entityIds.length > 1
+  const fetchPending = navCtxMode && (navFetchPending || isNavPending)
+  const pendingEntityId = navCtxMode && fetchPending && !resolvedItem ? (currentEntityId ?? null) : null
+  const modalProcessing = additionalProcessing
+
+  const sideNavigation = useMemo(() => {
+    if (!showRails || !isOpen) return undefined
+    return <ModalSideNavigation canGoPrev={canGoPrev} canGoNext={canGoNext} onPrevAction={handleGoPrev} onNextAction={handleGoNext} />
+  }, [showRails, isOpen, canGoPrev, canGoNext, handleGoPrev, handleGoNext])
+
+  const modalItemCtx = useMemo(
+    () => ({
+      resolvedItem,
+      fetchPending,
+      pendingEntityId,
+      syncResolvedItem
+    }),
+    [resolvedItem, fetchPending, pendingEntityId, syncResolvedItem]
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      persistent={persistent}
+      zIndexClass={zIndexClass}
+      bgOpacityClass={bgOpacityClass}
+      className={className}
+      style={style}
+      outerContent={outerContent}
+      sideNavigation={sideNavigation}
+      processing={modalProcessing}
+    >
+      <LibraryItemModalContext.Provider value={modalItemCtx}>{children}</LibraryItemModalContext.Provider>
+    </Modal>
+  )
+}

--- a/src/components/modals/MatchModal.tsx
+++ b/src/components/modals/MatchModal.tsx
@@ -1,110 +1,41 @@
 'use client'
 
-import { getExpandedLibraryItemAction } from '@/app/actions/mediaActions'
-import Modal from '@/components/modals/Modal'
-import ModalSideNavigation from '@/components/modals/ModalSideNavigation'
+import LibraryItemModal, { type LibraryItemModalItemSource, useLibraryItemModal } from '@/components/modals/LibraryItemModal'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import Match from '@/components/widgets/Match'
-import { useGlobalToast } from '@/contexts/ToastContext'
-import { useEntityNavigationContext } from '@/hooks/useEntityNavigationContext'
-import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
-import { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
-import { useCallback, useLayoutEffect, useRef, useState, useTransition } from 'react'
 
 export type MatchModalProps = {
   isOpen: boolean
   onClose: () => void
-} & ({ libraryItem: BookLibraryItem | PodcastLibraryItem } | { navCtx: EntityNavigationContext })
+} & LibraryItemModalItemSource
+
+function MatchModalBody() {
+  const { resolvedItem, fetchPending } = useLibraryItemModal()
+  return (
+    <div className="flex h-[80vh] flex-col overflow-hidden">
+      {fetchPending && !resolvedItem ? (
+        <div className="flex flex-1 items-center justify-center">
+          <LoadingIndicator variant="inline" />
+        </div>
+      ) : resolvedItem ? (
+        <Match libraryItem={resolvedItem} />
+      ) : null}
+    </div>
+  )
+}
 
 export default function MatchModal(props: MatchModalProps) {
   const { isOpen, onClose } = props
   const navCtxMode = 'navCtx' in props
-  const navCtx = navCtxMode ? props.navCtx : undefined
-  const entityIds = navCtx?.entityIds ?? []
-
-  const t = useTypeSafeTranslations()
-  const { showToast } = useGlobalToast()
-  const [fetchedItem, setFetchedItem] = useState<BookLibraryItem | PodcastLibraryItem | null>(null)
-  const [isPending, startTransition] = useTransition()
-  const [navFetchPending, setNavFetchPending] = useState(false)
-  const fetchGenRef = useRef(0)
-
-  const { currentEntityId, canGoPrev, canGoNext, goPrev, goNext } = useEntityNavigationContext(navCtx, isOpen)
-
-  useLayoutEffect(() => {
-    if (!isOpen || !navCtxMode) return
-    if (!currentEntityId) {
-      setFetchedItem(null)
-      return
-    }
-
-    const gen = ++fetchGenRef.current
-    setNavFetchPending(true)
-    setFetchedItem(null)
-
-    startTransition(async () => {
-      try {
-        const full = await getExpandedLibraryItemAction(currentEntityId)
-        if (fetchGenRef.current !== gen) return
-        setFetchedItem(full as BookLibraryItem | PodcastLibraryItem)
-      } catch (error) {
-        console.error('Failed to load library item for match', error)
-        if (fetchGenRef.current === gen) {
-          showToast(t('ToastFailedToLoadData'), { type: 'error' })
-          onClose()
-        }
-      } finally {
-        if (fetchGenRef.current === gen) {
-          setNavFetchPending(false)
-        }
-      }
-    })
-  }, [isOpen, navCtxMode, navCtx, currentEntityId, onClose, showToast, startTransition, t])
-
-  const blurActiveElement = () => {
-    const el = document.activeElement
-    if (el instanceof HTMLElement) el.blur()
-  }
-
-  const handleGoPrev = useCallback(() => {
-    blurActiveElement()
-    goPrev()
-  }, [goPrev])
-
-  const handleGoNext = useCallback(() => {
-    blurActiveElement()
-    goNext()
-  }, [goNext])
-
-  if (!isOpen) return null
-
-  const resolvedItem = navCtxMode ? fetchedItem : props.libraryItem
-  const mediaTitle = resolvedItem?.media.metadata.title ?? ''
-  const outerContent = mediaTitle ? (
-    <div className="absolute start-0 top-0 p-4">
-      <h2 className="max-w-[calc(100vw-4rem)] truncate text-lg text-white" title={mediaTitle}>
-        {mediaTitle}
-      </h2>
-    </div>
-  ) : undefined
-  const showRails = navCtxMode && entityIds.length > 1
-  const navigationProcessing = navCtxMode && (navFetchPending || isPending)
-
-  const sideNavigation =
-    showRails && isOpen ? (
-      <ModalSideNavigation canGoPrev={canGoPrev} canGoNext={canGoNext} onPrevAction={handleGoPrev} onNextAction={handleGoNext} />
-    ) : undefined
 
   return (
-    <Modal
+    <LibraryItemModal
       isOpen={isOpen}
       onClose={onClose}
-      processing={navigationProcessing}
-      sideNavigation={sideNavigation}
-      outerContent={outerContent}
+      {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem })}
       className="md:max-w-[min(90vw,56rem)] lg:max-w-[min(90vw,56rem)]"
     >
-      <div className="flex h-[80vh] flex-col overflow-hidden">{resolvedItem ? <Match libraryItem={resolvedItem} /> : null}</div>
-    </Modal>
+      <MatchModalBody />
+    </LibraryItemModal>
   )
 }

--- a/src/components/modals/ModalSideNavigation.tsx
+++ b/src/components/modals/ModalSideNavigation.tsx
@@ -21,7 +21,7 @@ export default function ModalSideNavigation({ canGoPrev, canGoNext, onPrevAction
         <div className="pointer-events-none absolute start-[-6rem] top-0 bottom-0 z-[1] flex h-full items-center px-6">
           <button
             type="button"
-            className="material-symbols pointer-events-auto cursor-pointer text-5xl text-white/50 hover:text-white/90"
+            className="material-symbols text-foreground-muted hover:text-foreground pointer-events-auto cursor-pointer text-5xl transition-colors"
             aria-label={t('ButtonPrevious')}
             onClick={(e) => {
               e.stopPropagation()
@@ -38,7 +38,7 @@ export default function ModalSideNavigation({ canGoPrev, canGoNext, onPrevAction
         <div className="pointer-events-none absolute end-[-6rem] top-0 bottom-0 z-[1] flex h-full items-center px-6">
           <button
             type="button"
-            className="material-symbols pointer-events-auto cursor-pointer text-5xl text-white/50 hover:text-white/90"
+            className="material-symbols text-foreground-muted hover:text-foreground pointer-events-auto cursor-pointer text-5xl transition-colors"
             aria-label={t('ButtonNext')}
             onClick={(e) => {
               e.stopPropagation()

--- a/src/components/ui/LoadingIndicator.tsx
+++ b/src/components/ui/LoadingIndicator.tsx
@@ -21,10 +21,7 @@ export default function LoadingIndicator({ label, children, variant = 'overlay' 
   }
   const displayLabel = t(label)
 
-  const rootClass =
-    variant === 'inline'
-      ? 'flex items-center justify-center'
-      : 'absolute inset-0 z-50 flex items-center justify-center bg-black/50'
+  const rootClass = variant === 'inline' ? 'flex items-center justify-center' : 'absolute inset-0 z-50 flex items-center justify-center bg-black/50'
 
   return (
     <div className={rootClass} role="status" aria-live="polite" aria-label={label}>

--- a/src/components/ui/LoadingIndicator.tsx
+++ b/src/components/ui/LoadingIndicator.tsx
@@ -7,17 +7,27 @@ import styles from './LoadingIndicator.module.css'
 interface LoadingIndicatorProps {
   label?: TranslationKey
   children?: React.ReactNode
+  /**
+   * `overlay` — full-bleed dimmed layer (`absolute inset-0 bg-black/50`), for covering a `relative` parent.
+   * `inline` — centered loader card only; use inside modals or regions that already define size/background.
+   */
+  variant?: 'overlay' | 'inline'
 }
 
-export default function LoadingIndicator({ label, children }: LoadingIndicatorProps) {
+export default function LoadingIndicator({ label, children, variant = 'overlay' }: LoadingIndicatorProps) {
   const t = useTypeSafeTranslations()
   if (!label) {
     label = 'LabelLoadingIndicator'
   }
   const displayLabel = t(label)
 
+  const rootClass =
+    variant === 'inline'
+      ? 'flex items-center justify-center'
+      : 'absolute inset-0 z-50 flex items-center justify-center bg-black/50'
+
   return (
-    <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/50" role="status" aria-live="polite" aria-label={label}>
+    <div className={rootClass} role="status" aria-live="polite" aria-label={label}>
       <div className="w-40">
         <div className="bg-bg shadow-modal-content flex flex-col items-center rounded-lg border border-gray-500 px-5 py-2">
           <div cy-id="loading-indicator" className={`${styles['loader-dots']} relative mt-2 block h-5 w-20`} aria-hidden="true">

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import MatchModal from '@/components/modals/MatchModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
 import ShareModal from '@/components/modals/ShareModal'
@@ -13,7 +14,7 @@ import { useCardSize } from '@/contexts/CardSizeContext'
 import { useBookCoverAspectRatio, useLibrary } from '@/contexts/LibraryContext'
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { getEntityNavigationContext, type EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
+import { getMediaCardModalNavigationContext } from '@/lib/bookshelfNavigationContext'
 import { getPlaceholderCoverUrl } from '@/lib/coverUtils'
 import { computeProgress } from '@/lib/mediaProgress'
 import type { BookMedia, BookshelfEntity, EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode, PodcastMedia, UserPermissions } from '@/types/api'
@@ -113,13 +114,13 @@ function MediaCard(props: MediaCardProps) {
   const clearBoundModal = useCallback(() => setBoundModal(null), [setBoundModal])
 
   const handleOpenMatch = useCallback(() => {
-    const defaultNavigationContext: EntityNavigationContext = { entityIds: [libraryItem.id], initialIndex: 0 }
-    let navigationContext: EntityNavigationContext = defaultNavigationContext
-    if (shelfEntities !== undefined && entityIndex !== undefined) {
-      const computedNavigationContext = getEntityNavigationContext(shelfEntities, entityIndex)
-      if (computedNavigationContext) navigationContext = computedNavigationContext
-    }
-    setBoundModal(<MatchModal key="match-modal" isOpen navCtx={navigationContext} onClose={clearBoundModal} />)
+    const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
+    setBoundModal(<MatchModal key="match-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+  }, [clearBoundModal, libraryItem.id, shelfEntities, entityIndex, setBoundModal])
+
+  const handleOpenEdit = useCallback(() => {
+    const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
+    setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
   }, [clearBoundModal, libraryItem.id, shelfEntities, entityIndex, setBoundModal])
 
   const handleMoreMenuOpenChange = (isOpen: boolean) => {
@@ -282,11 +283,6 @@ function MediaCard(props: MediaCardProps) {
     router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}`)
   }
 
-  const handleEdit = () => {
-    // TODO: wire up edit modal when available
-    console.log('handleEdit', libraryItem.id)
-  }
-
   return (
     <>
       <MediaCardFrame
@@ -353,7 +349,7 @@ function MediaCard(props: MediaCardProps) {
             renderSeriesNameOverlay={renderSeriesNameOverlay}
             onPlay={handlePlay}
             onRead={handleReadEBook}
-            onEdit={handleEdit}
+            onEdit={handleOpenEdit}
             onMoreAction={handleMoreAction}
             onMoreMenuOpenChange={handleMoreMenuOpenChange}
             onSelect={onSelect}

--- a/src/lib/bookshelfNavigationContext.ts
+++ b/src/lib/bookshelfNavigationContext.ts
@@ -13,7 +13,7 @@ export type EntityNavigationContext = {
  * Prev/next entity scope for one bookshelf entity slot: contiguous non-null run around `entityIndex`, in array order.
  * Call when opening a modal (lazy). Returns a fresh `entityIds` array; safe to pass through to the modal.
  */
-export function getEntityNavigationContext(entities: (BookshelfEntity | null)[], entityIndex: number): EntityNavigationContext | null {
+function getEntityNavigationContext(entities: (BookshelfEntity | null)[], entityIndex: number): EntityNavigationContext | null {
   if (entityIndex < 0 || entityIndex >= entities.length) return null
 
   const at = entities[entityIndex]
@@ -44,4 +44,25 @@ export function getEntityNavigationContext(entities: (BookshelfEntity | null)[],
   if (initialIndex < 0) return null
 
   return { entityIds, initialIndex }
+}
+
+const defaultSingleEntityNavCtx = (libraryItemId: string): EntityNavigationContext => ({
+  entityIds: [libraryItemId],
+  initialIndex: 0
+})
+
+/**
+ * Navigation scope for match/edit modals opened from a media card:
+ * uses shelf row scope when `shelfEntities` + `entityIndex` are set, otherwise a single-item context.
+ */
+export function getMediaCardModalNavigationContext(
+  libraryItemId: string,
+  shelfEntities: (BookshelfEntity | null)[] | undefined,
+  entityIndex: number | undefined
+): EntityNavigationContext {
+  if (shelfEntities !== undefined && entityIndex !== undefined) {
+    const computed = getEntityNavigationContext(shelfEntities, entityIndex)
+    if (computed) return computed
+  }
+  return defaultSingleEntityNavCtx(libraryItemId)
 }


### PR DESCRIPTION
This integrates `LibraryItemEditModal` in media cards on the homepage and library (opened using the edit button on the overlay).

Some refactoring was needed to make `MatchModal` and `LibraryItemEditModal` use the same item fetching and navigation capabilities: `LibraryItemModal` was added as parent class in both modals, providing the mentioned capabilities.

The only differences between the edit modal when opened from a media card and from the item page are:
- Expanded item fetching
- Prev/Next buttons
- When opened from a media card, the height of the modal content is fixed, so that it doesn'r change when navigating to prev/next. This means that the book/podcast details may overflow if they're long, and a vertical scrollbar might be shown (this is similar to behavior of the current edit details tab).

