### PR TITLE
Remove formkit dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@floating-ui/react-dom": "^2.1.6",
-    "@formkit/drag-and-drop": "^0.5.3",
     "clsx": "^2.1.1",
     "cronstrue": "^3.3.0",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@floating-ui/react-dom':
         specifier: ^2.1.6
         version: 2.1.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@formkit/drag-and-drop':
-        specifier: ^0.5.3
-        version: 0.5.3
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -243,9 +240,6 @@ packages:
 
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
-
-  '@formkit/drag-and-drop@0.5.3':
-    resolution: {integrity: sha512-VGQsKYc350OOMbz7wYt69YqDbn49x7RJ32eqiJieNke54nGZYmx18XEqTw0lBiJmH3RaiH6V45gB1u+tvI/TNw==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2862,8 +2856,6 @@ snapshots:
   '@formatjs/intl-localematcher@0.6.1':
     dependencies:
       tslib: 2.8.1
-
-  '@formkit/drag-and-drop@0.5.3': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/src/app/(main)/components_catalog/examples/TooltipExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/TooltipExamples.tsx
@@ -21,8 +21,8 @@ export function TooltipExamples() {
           <span className="font-bold">Props:</span> <Code>text</Code>, <Code>children</Code>, <Code>position</Code>, <Code>usePortal</Code>
         </p>
         <p className="mb-2">
-          <span className="font-bold">Note:</span> If <Code>usePortal</Code> is true, or the tooltip is inside a modal, the tooltip will be rendered in a
-          portal.
+          <span className="font-bold">Note:</span> By default the tooltip is portaled to <Code>document.body</Code> (or the modal root when inside a
+          modal). Set <Code>usePortal=&#123;false&#125;</Code> to keep it in the DOM tree under the trigger.
         </p>
       </ComponentInfo>
 
@@ -75,13 +75,18 @@ export function TooltipExamples() {
           </div>
         </Example>
 
-        <Example title="Portal Tooltips">
+        <Example title="Portal (default) vs inline">
           <div className="space-y-4">
             <div className="overflow-hidden rounded-md border border-gray-600 p-4">
               <p className="mb-2 text-sm text-gray-400">This container has overflow: hidden</p>
-              <Tooltip text="This tooltip uses a portal and won't be clipped by the container" position="bottom" usePortal>
-                <Btn>Portal tooltip</Btn>
-              </Tooltip>
+              <div className="flex flex-wrap gap-4">
+                <Tooltip text="Default: portaled so this is not clipped" position="bottom">
+                  <Btn>Default (portal)</Btn>
+                </Tooltip>
+                <Tooltip text="Inline tooltip — this text is clipped by the container" position="bottom" usePortal={false}>
+                  <Btn>usePortal false</Btn>
+                </Tooltip>
+              </div>
             </div>
           </div>
         </Example>
@@ -110,7 +115,7 @@ export function TooltipExamples() {
         <Example title="Tooltip with array of elements as children">
           <div className="space-y-4">
             <p className="mb-2 text-sm text-gray-400">Not recommended due to accessibility issues</p>
-            <Tooltip text="This is a tooltip with array of elements as children" position="bottom" usePortal>
+            <Tooltip text="This is a tooltip with array of elements as children" position="bottom">
               <Btn>Tooltip</Btn>
               <Btn>Tooltip</Btn>
             </Tooltip>

--- a/src/app/(main)/components_catalog/examples/TooltipExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/TooltipExamples.tsx
@@ -21,8 +21,8 @@ export function TooltipExamples() {
           <span className="font-bold">Props:</span> <Code>text</Code>, <Code>children</Code>, <Code>position</Code>, <Code>usePortal</Code>
         </p>
         <p className="mb-2">
-          <span className="font-bold">Note:</span> By default the tooltip is portaled to <Code>document.body</Code> (or the modal root when inside a
-          modal). Set <Code>usePortal=&#123;false&#125;</Code> to keep it in the DOM tree under the trigger.
+          <span className="font-bold">Note:</span> By default the tooltip is portaled to <Code>document.body</Code> (or the modal root when inside a modal). Set{' '}
+          <Code>usePortal=&#123;false&#125;</Code> to keep it in the DOM tree under the trigger.
         </p>
       </ComponentInfo>
 

--- a/src/app/(main)/settings/libraries/LibrariesList.tsx
+++ b/src/app/(main)/settings/libraries/LibrariesList.tsx
@@ -67,16 +67,20 @@ export default function LibrariesList(props: LibrariesListProps) {
   }, [libraries, showToast, t])
 
   return (
-    <div>
+    <div className="min-w-0 overflow-x-hidden overscroll-x-contain">
       <SortableList
         items={libraries}
         itemClassName="first:rounded-t-md last:rounded-b-md border border-border"
         disabled={isPending}
         onSortEnd={handleSortChange}
-        renderItem={(item: Library) => {
-          return <LibrariesListRow item={item} key={item.id} handleDeleteLibrary={handleDeleteLibrary} handleEditLibrary={handleEditLibrary} />
-        }}
-        dragHandle=".drag-handle"
+        renderItem={(item: Library, _index, dragHandle) => (
+          <LibrariesListRow
+            item={item}
+            handleDeleteLibrary={handleDeleteLibrary}
+            handleEditLibrary={handleEditLibrary}
+            sortableDragHandleProps={dragHandle}
+          />
+        )}
       />
       <ConfirmDialog
         isOpen={showConfirmDialog}

--- a/src/app/(main)/settings/libraries/LibrariesList.tsx
+++ b/src/app/(main)/settings/libraries/LibrariesList.tsx
@@ -74,12 +74,7 @@ export default function LibrariesList(props: LibrariesListProps) {
         disabled={isPending}
         onSortEnd={handleSortChange}
         renderItem={(item: Library, _index, dragHandle) => (
-          <LibrariesListRow
-            item={item}
-            handleDeleteLibrary={handleDeleteLibrary}
-            handleEditLibrary={handleEditLibrary}
-            sortableDragHandleProps={dragHandle}
-          />
+          <LibrariesListRow item={item} handleDeleteLibrary={handleDeleteLibrary} handleEditLibrary={handleEditLibrary} sortableDragHandleProps={dragHandle} />
         )}
       />
       <ConfirmDialog

--- a/src/app/(main)/settings/libraries/LibrariesListRow.tsx
+++ b/src/app/(main)/settings/libraries/LibrariesListRow.tsx
@@ -4,8 +4,11 @@ import Btn from '@/components/ui/Btn'
 import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
 import LibraryIcon from '@/components/ui/LibraryIcon'
 import LoadingSpinner from '@/components/widgets/LoadingSpinner'
+import type { SortableListDragHandleProps } from '@/components/widgets/SortableList'
 import { useTasks } from '@/contexts/TasksContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH, DRAG_HANDLE_GRAB_CURSOR } from '@/lib/dragHandleClasses'
+import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import Link from 'next/link'
 import { useCallback, useMemo } from 'react'
@@ -15,9 +18,10 @@ interface LibrariesListRowProps {
   item: Library
   handleDeleteLibrary: (library: Library) => void
   handleEditLibrary: (library: Library) => void
+  sortableDragHandleProps?: SortableListDragHandleProps
 }
 
-export default function LibrariesListRow({ item, handleDeleteLibrary, handleEditLibrary }: LibrariesListRowProps) {
+export default function LibrariesListRow({ item, handleDeleteLibrary, handleEditLibrary, sortableDragHandleProps }: LibrariesListRowProps) {
   const t = useTypeSafeTranslations()
   const { getTasksByLibraryId } = useTasks()
 
@@ -88,8 +92,13 @@ export default function LibrariesListRow({ item, handleDeleteLibrary, handleEdit
           <ContextMenuDropdown usePortal borderless size="small" items={contextMenuItems} onAction={handleContextMenuActions} />
         </>
       )}
-      <div className="drag-handle cursor-n-resize">
-        <span className="material-symbols text-foreground/50 hover:text-foreground text-xl">reorder</span>
+      <div
+        ref={sortableDragHandleProps?.setActivatorNodeRef}
+        className={mergeClasses('drag-handle flex shrink-0 items-center justify-center', DRAG_HANDLE_GRAB_CURSOR, DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH)}
+        {...sortableDragHandleProps?.attributes}
+        {...sortableDragHandleProps?.listeners}
+      >
+        <span className="material-symbols text-foreground/50 hover:text-foreground text-xl leading-none">drag_handle</span>
       </div>
     </div>
   )

--- a/src/app/(main)/settings/libraries/LibraryScannerTab.tsx
+++ b/src/app/(main)/settings/libraries/LibraryScannerTab.tsx
@@ -2,8 +2,10 @@
 
 import Btn from '@/components/ui/Btn'
 import ToggleSwitch from '@/components/ui/ToggleSwitch'
-import SortableList from '@/components/widgets/SortableList'
+import SortableList, { type SortableListDragHandleProps } from '@/components/widgets/SortableList'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH, DRAG_HANDLE_GRAB_CURSOR } from '@/lib/dragHandleClasses'
+import { mergeClasses } from '@/lib/merge-classes'
 import { LibrarySettings } from '@/types/api'
 import { useMemo, useState } from 'react'
 import SettingsMoreInfoIcon from '../SettingsMoreInfoIcon'
@@ -95,9 +97,20 @@ export default function LibraryScannerTab({ settings, onSettingsChange }: Librar
     return activeSources.findIndex((s) => s.id === sourceId) + 1
   }
 
-  const renderItem = (source: MetadataSource, index: number) => (
+  const renderItem = (source: MetadataSource, index: number, dragHandle: SortableListDragHandleProps) => (
     <div className={`border-border flex w-full items-center border px-2 ${!source.include ? 'opacity-50' : ''}`}>
-      <span className="material-symbols drag-handle text-foreground-subdued hover:text-foreground mr-2 cursor-grab text-xl md:mr-4">reorder</span>
+      <div
+        ref={dragHandle.setActivatorNodeRef}
+        className={mergeClasses(
+          'drag-handle mr-2 flex shrink-0 items-center justify-center self-stretch md:mr-4',
+          DRAG_HANDLE_GRAB_CURSOR,
+          DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH
+        )}
+        {...dragHandle.attributes}
+        {...dragHandle.listeners}
+      >
+        <span className="material-symbols text-foreground-subdued hover:text-foreground text-xl leading-none">drag_handle</span>
+      </div>
       <div className="w-8 min-w-8 py-1 text-center">{source.include ? getSourcePriority(source.id) : ''}</div>
       <div className="inline-flex grow items-center justify-between px-2 py-3 text-sm sm:px-4 sm:text-base">
         {source.name}

--- a/src/app/(main)/settings/libraries/LibraryScannerTab.tsx
+++ b/src/app/(main)/settings/libraries/LibraryScannerTab.tsx
@@ -103,13 +103,20 @@ export default function LibraryScannerTab({ settings, onSettingsChange }: Librar
         ref={dragHandle.setActivatorNodeRef}
         className={mergeClasses(
           'drag-handle mr-2 flex shrink-0 items-center justify-center self-stretch md:mr-4',
-          DRAG_HANDLE_GRAB_CURSOR,
-          DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH
+          source.include ? DRAG_HANDLE_GRAB_CURSOR : 'cursor-default',
+          source.include ? DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH : 'pointer-events-none'
         )}
         {...dragHandle.attributes}
-        {...dragHandle.listeners}
+        {...(source.include ? dragHandle.listeners : {})}
       >
-        <span className="material-symbols text-foreground-subdued hover:text-foreground text-xl leading-none">drag_handle</span>
+        <span
+          className={mergeClasses(
+            'material-symbols text-xl leading-none',
+            source.include ? 'text-foreground-subdued hover:text-foreground' : 'text-foreground-subdued/40'
+          )}
+        >
+          drag_handle
+        </span>
       </div>
       <div className="w-8 min-w-8 py-1 text-center">{source.include ? getSourcePriority(source.id) : ''}</div>
       <div className="inline-flex grow items-center justify-between px-2 py-3 text-sm sm:px-4 sm:text-base">
@@ -140,7 +147,7 @@ export default function LibraryScannerTab({ settings, onSettingsChange }: Librar
         <SettingsMoreInfoIcon moreInfoUrl="https://www.audiobookshelf.org/guides/book-scanner" />
       </div>
 
-      <SortableList key={listKey} items={sources} onSortEnd={handleSortEnd} renderItem={renderItem} />
+      <SortableList key={listKey} items={sources} onSortEnd={handleSortEnd} renderItem={renderItem} isItemDisabled={(source) => !source.include} />
     </div>
   )
 }

--- a/src/app/(main)/settings/rss-feeds/RssFeedsClient.tsx
+++ b/src/app/(main)/settings/rss-feeds/RssFeedsClient.tsx
@@ -13,11 +13,7 @@ export default function RssFeedsClient({ rssFeeds }: RssFeedsClientProps) {
   const t = useTypeSafeTranslations()
   return (
     <SettingsContent title={t('HeaderRSSFeeds')} moreInfoUrl="https://www.audiobookshelf.org/guides/rss_feeds">
-      {rssFeeds.length > 0 ? (
-        <RssFeedsTable rssFeeds={rssFeeds} />
-      ) : (
-        <p className="text-foreground py-8 text-center text-lg">{t('MessageNoRssFeeds')}</p>
-      )}
+      {rssFeeds.length > 0 ? <RssFeedsTable rssFeeds={rssFeeds} /> : <p className="text-foreground py-8 text-center text-lg">{t('MessageNoRssFeeds')}</p>}
     </SettingsContent>
   )
 }

--- a/src/assets/globals.css
+++ b/src/assets/globals.css
@@ -150,6 +150,14 @@ body {
   outline-color: var(--heatmap-outline-fill);
 }
 
+/* SortableList: vertical-axis modifier can leave the pointer off the handle while dragging; keep grabbing cursor (see DND_POINTER_DRAG_HTML_CLASS). */
+@layer utilities {
+  html.abs-dnd-pointer-dragging,
+  html.abs-dnd-pointer-dragging * {
+    @apply !cursor-grabbing;
+  }
+}
+
 /* Screen reader only utility class */
 .sr-only {
   position: absolute;

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -34,7 +34,11 @@ const Tooltip = ({
   text,
   children,
   position = 'right',
-  usePortal: usePortalProp = false,
+  // Default true: portal to `document.body` or modal root so the tooltip is not clipped by
+  // ancestor `overflow`, trapped under low z-index stacking contexts, or misaligned when a
+  // parent has `transform` (e.g. dnd-kit drag). Opt out with `usePortal={false}` when in-tree
+  // rendering is intentional.
+  usePortal: usePortalProp = true,
   className,
   offsetPx = 8,
   edgePadding = 8,
@@ -92,7 +96,12 @@ const Tooltip = ({
   } = useFloating({
     open,
     placement,
-    strategy: 'absolute',
+    // `fixed` keeps the floating element attached to the viewport so it doesn't widen `<body>`
+    // when its reference sits near the right edge or is being transformed (e.g. dnd-kit cards
+    // during a drag). Functionally identical to `absolute` for our usage — Floating UI applies
+    // the same computed `top/left` either way, and the `shift` middleware keeps the tooltip in
+    // the viewport. Matches the default portaled tooltip path (body or modal root).
+    strategy: 'fixed',
     middleware
   })
 
@@ -252,7 +261,11 @@ const Tooltip = ({
       aria-describedby={tooltipId}
     >
       {children}
+      {/* Skip rendering the floating element when disabled: the tooltip can't open anyway, and an
+          absolutely-positioned element following a transformed reference (e.g. a dnd-kit card during
+          drag) can land past the viewport and widen `<body>`. */}
       {mounted &&
+        !disabled &&
         (usePortal
           ? portalRoot
             ? createPortal(tooltipElement, portalRoot)

--- a/src/components/widgets/SortableList.tsx
+++ b/src/components/widgets/SortableList.tsx
@@ -14,7 +14,8 @@ import {
   type DragEndEvent,
   type DraggableAttributes,
   type DraggableSyntheticListeners,
-  type DragStartEvent
+  type DragStartEvent,
+  type Modifier
 } from '@dnd-kit/core'
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -57,24 +58,26 @@ interface SortableListProps<T extends SortableItem> {
   className?: string
   itemClassName?: string
   disabled?: boolean
+  /** When true for an item, that row is not draggable (e.g. inactive list entries). */
+  isItemDisabled?: (item: T, index: number) => boolean
 }
 
 function SortableListRow<T extends SortableItem>({
   item,
   index,
-  disabled,
+  sortableDisabled,
   itemWrapperClassName,
   renderItem
 }: {
   item: T
   index: number
-  disabled: boolean
+  sortableDisabled: boolean
   itemWrapperClassName: string
   renderItem: (item: T, index: number, dragHandle: SortableListDragHandleProps) => ReactNode
 }) {
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
     id: String(item.id),
-    disabled,
+    disabled: sortableDisabled,
     // Snappier than dnd-kit defaults; avoid CSS `transition-*` on this node (see item wrapper) so
     // `transform` from the sensor isn’t eased separately from layout transitions.
     transition: {
@@ -118,7 +121,8 @@ export default function SortableList<T extends SortableItem>({
   renderItem,
   className = '',
   itemClassName = '',
-  disabled = false
+  disabled = false,
+  isItemDisabled
 }: SortableListProps<T>) {
   const [activeId, setActiveId] = useState<string | null>(null)
 
@@ -187,7 +191,7 @@ export default function SortableList<T extends SortableItem>({
               key={String(item.id)}
               item={item}
               index={index}
-              disabled={disabled}
+              sortableDisabled={disabled || (isItemDisabled?.(item, index) ?? false)}
               itemWrapperClassName={itemWrapperClassName}
               renderItem={renderItem}
             />

--- a/src/components/widgets/SortableList.tsx
+++ b/src/components/widgets/SortableList.tsx
@@ -1,22 +1,25 @@
 'use client'
 
+import { DND_POINTER_DRAG_HTML_CLASS } from '@/lib/dragHandleClasses'
 import { mergeClasses } from '@/lib/merge-classes'
 import {
   closestCenter,
   DndContext,
+  DragOverlay,
   KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
+  type DragCancelEvent,
   type DragEndEvent,
   type DraggableAttributes,
   type DraggableSyntheticListeners,
-  type Modifier
+  type DragStartEvent
 } from '@dnd-kit/core'
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import type { CSSProperties } from 'react'
-import { ReactNode, useCallback, useMemo } from 'react'
+import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 
 interface SortableItem {
   id: string | number
@@ -38,6 +41,13 @@ export type SortableListDragHandleProps = {
   setActivatorNodeRef: (element: HTMLElement | null) => void
   attributes: SortableListDragHandleAttributes
   listeners: DraggableSyntheticListeners | undefined
+}
+
+/** Inert handle for `DragOverlay` clones — avoids duplicate listeners while keeping row layout. */
+const sortableListOverlayDragHandleStub: SortableListDragHandleProps = {
+  setActivatorNodeRef: () => {},
+  attributes: {} as SortableListDragHandleAttributes,
+  listeners: undefined
 }
 
 interface SortableListProps<T extends SortableItem> {
@@ -73,10 +83,10 @@ function SortableListRow<T extends SortableItem>({
     }
   })
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition
-  }
+  // While dragging, the live preview is rendered in `<DragOverlay>` (portaled). Clearing
+  // `transform` here keeps the in-list slot from following the pointer so scroll parents
+  // don’t grow (transformed overflow expands scrollable area in common browsers).
+  const style = isDragging ? { transition, opacity: 0 } : { transform: CSS.Transform.toString(transform), transition }
 
   // `touch-action: none` on the activator (same idea as `touch-none` on SortableBookshelfCard’s
   // handle) so coarse pointers don’t scroll the page instead of starting a drag.
@@ -96,7 +106,7 @@ function SortableListRow<T extends SortableItem>({
   }
 
   return (
-    <div ref={setNodeRef} style={style} className={mergeClasses(itemWrapperClassName, isDragging && 'bg-white/20 opacity-50')}>
+    <div ref={setNodeRef} style={style} className={itemWrapperClassName}>
       {renderItem(item, index, dragHandleProps)}
     </div>
   )
@@ -110,6 +120,8 @@ export default function SortableList<T extends SortableItem>({
   itemClassName = '',
   disabled = false
 }: SortableListProps<T>) {
+  const [activeId, setActiveId] = useState<string | null>(null)
+
   const itemsWithIds = useMemo(
     () =>
       items.map((item, index) => ({
@@ -128,8 +140,23 @@ export default function SortableList<T extends SortableItem>({
 
   const sortableIds = useMemo(() => itemsWithIds.map((item) => String(item.id)), [itemsWithIds])
 
+  const activeItem = useMemo(() => (activeId ? (itemsWithIds.find((item) => String(item.id) === activeId) ?? null) : null), [activeId, itemsWithIds])
+  const activeIndex = useMemo(() => (activeId ? itemsWithIds.findIndex((item) => String(item.id) === activeId) : -1), [activeId, itemsWithIds])
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveId(String(event.active.id))
+    document.documentElement.classList.add(DND_POINTER_DRAG_HTML_CLASS)
+  }, [])
+
+  const handleDragCancel = useCallback((_event: DragCancelEvent) => {
+    setActiveId(null)
+    document.documentElement.classList.remove(DND_POINTER_DRAG_HTML_CLASS)
+  }, [])
+
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
+      setActiveId(null)
+      document.documentElement.classList.remove(DND_POINTER_DRAG_HTML_CLASS)
       const { active, over } = event
       if (!over || active.id === over.id) return
       const oldIndex = itemsWithIds.findIndex((item) => String(item.id) === String(active.id))
@@ -140,8 +167,19 @@ export default function SortableList<T extends SortableItem>({
     [itemsWithIds, onSortEnd]
   )
 
+  useEffect(() => {
+    return () => document.documentElement.classList.remove(DND_POINTER_DRAG_HTML_CLASS)
+  }, [])
+
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictSortableListToVerticalAxis]} onDragEnd={handleDragEnd}>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictSortableListToVerticalAxis]}
+      onDragStart={handleDragStart}
+      onDragCancel={handleDragCancel}
+      onDragEnd={handleDragEnd}
+    >
       <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
         <div className={mergeClasses('max-w-full min-w-0 overflow-x-hidden', className)}>
           {itemsWithIds.map((item, index) => (
@@ -156,6 +194,13 @@ export default function SortableList<T extends SortableItem>({
           ))}
         </div>
       </SortableContext>
+      <DragOverlay dropAnimation={null}>
+        {activeItem ? (
+          <div className={mergeClasses('pointer-events-none max-w-full min-w-0', itemWrapperClassName)}>
+            {renderItem(activeItem, activeIndex >= 0 ? activeIndex : 0, sortableListOverlayDragHandleStub)}
+          </div>
+        ) : null}
+      </DragOverlay>
     </DndContext>
   )
 }

--- a/src/components/widgets/SortableList.tsx
+++ b/src/components/widgets/SortableList.tsx
@@ -1,22 +1,105 @@
 'use client'
 
 import { mergeClasses } from '@/lib/merge-classes'
-import { DragendEvent, DragstartEvent } from '@formkit/drag-and-drop'
-import { useDragAndDrop } from '@formkit/drag-and-drop/react'
-import { ReactNode, useCallback, useEffect, useMemo } from 'react'
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DraggableAttributes,
+  type DraggableSyntheticListeners,
+  type Modifier
+} from '@dnd-kit/core'
+import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { CSSProperties } from 'react'
+import { ReactNode, useCallback, useMemo } from 'react'
 
 interface SortableItem {
   id: string | number
 }
 
+/** Vertical list: ignore horizontal pointer delta so rows don’t shift sideways (avoids mobile horizontal scroll / “rubber band”). */
+const restrictSortableListToVerticalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  x: 0
+})
+
+/** Attributes to spread on the drag handle (dnd-kit’s `DraggableAttributes` plus DOM props we set). */
+export type SortableListDragHandleAttributes = DraggableAttributes & {
+  style?: CSSProperties
+  className?: string
+}
+
+export type SortableListDragHandleProps = {
+  setActivatorNodeRef: (element: HTMLElement | null) => void
+  attributes: SortableListDragHandleAttributes
+  listeners: DraggableSyntheticListeners | undefined
+}
+
 interface SortableListProps<T extends SortableItem> {
   items: T[]
   onSortEnd: (sortedItems: T[]) => void
-  renderItem: (item: T, index: number) => ReactNode
-  dragHandle?: string
+  renderItem: (item: T, index: number, dragHandle: SortableListDragHandleProps) => ReactNode
   className?: string
   itemClassName?: string
   disabled?: boolean
+}
+
+function SortableListRow<T extends SortableItem>({
+  item,
+  index,
+  disabled,
+  itemWrapperClassName,
+  renderItem
+}: {
+  item: T
+  index: number
+  disabled: boolean
+  itemWrapperClassName: string
+  renderItem: (item: T, index: number, dragHandle: SortableListDragHandleProps) => ReactNode
+}) {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({
+    id: String(item.id),
+    disabled,
+    // Snappier than dnd-kit defaults; avoid CSS `transition-*` on this node (see item wrapper) so
+    // `transform` from the sensor isn’t eased separately from layout transitions.
+    transition: {
+      duration: 120,
+      easing: 'ease-out'
+    }
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  }
+
+  // `touch-action: none` on the activator (same idea as `touch-none` on SortableBookshelfCard’s
+  // handle) so coarse pointers don’t scroll the page instead of starting a drag.
+  const fromKit = attributes as SortableListDragHandleAttributes
+  const baseStyle = fromKit.style && typeof fromKit.style === 'object' ? { ...fromKit.style } : {}
+  const activatorAttributes: SortableListDragHandleAttributes = {
+    ...fromKit,
+    style: {
+      ...baseStyle,
+      touchAction: 'none'
+    }
+  }
+  const dragHandleProps: SortableListDragHandleProps = {
+    setActivatorNodeRef,
+    attributes: activatorAttributes,
+    listeners
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className={mergeClasses(itemWrapperClassName, isDragging && 'bg-white/20 opacity-50')}>
+      {renderItem(item, index, dragHandleProps)}
+    </div>
+  )
 }
 
 export default function SortableList<T extends SortableItem>({
@@ -27,65 +110,52 @@ export default function SortableList<T extends SortableItem>({
   itemClassName = '',
   disabled = false
 }: SortableListProps<T>) {
-  // Ensure each item has a unique identifier
   const itemsWithIds = useMemo(
     () =>
       items.map((item, index) => ({
         ...item,
         id: item.id || `item-${index}`
-      })),
+      })) as T[],
     [items]
   )
 
-  const onDragend = useCallback<DragendEvent>((data) => {
-    if (data.draggedNode.el) {
-      data.draggedNode.el.classList.remove('opacity-50', 'bg-white/20')
-    }
-  }, [])
+  const itemWrapperClassName = mergeClasses(itemClassName)
 
-  const onDragstart = useCallback<DragstartEvent>((data) => {
-    if (data.draggedNode.el) {
-      data.draggedNode.el.classList.add('opacity-50', 'bg-white/20')
-    }
-  }, [])
-
-  const [parent, sortedItems, setItems] = useDragAndDrop<HTMLDivElement, T>(itemsWithIds, {
-    dragHandle: '.drag-handle',
-    disabled,
-    onDragend,
-    onDragstart,
-    handleDragend: () => onSortEnd(sortedItems)
-  })
-
-  // Order-independent content hash: detects add/remove/property-change but NOT reorder.
-  // Sorting by ID before serializing ensures a drag reorder produces the same hash,
-  // so we don't call setItems after a drop (which would corrupt formkit's internal state).
-  const itemsContentHash = useMemo(
-    () =>
-      [...items]
-        .sort((a, b) => String(a.id).localeCompare(String(b.id)))
-        .map((item) => JSON.stringify(item))
-        .join('|'),
-    [items]
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   )
 
-  // Sync the drag-and-drop internal list when items change (add/remove/edit)
-  useEffect(() => {
-    setItems(itemsWithIds)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemsContentHash])
+  const sortableIds = useMemo(() => itemsWithIds.map((item) => String(item.id)), [itemsWithIds])
 
-  const itemWrapperClassName = useMemo(() => {
-    return mergeClasses('transition-all duration-200', itemClassName)
-  }, [itemClassName])
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+      const oldIndex = itemsWithIds.findIndex((item) => String(item.id) === String(active.id))
+      const newIndex = itemsWithIds.findIndex((item) => String(item.id) === String(over.id))
+      if (oldIndex === -1 || newIndex === -1) return
+      onSortEnd(arrayMove(itemsWithIds, oldIndex, newIndex))
+    },
+    [itemsWithIds, onSortEnd]
+  )
 
   return (
-    <div ref={parent} className={className}>
-      {sortedItems.map((item: T, index: number) => (
-        <div key={item.id || `item-${index}`} className={itemWrapperClassName}>
-          {renderItem(item, index)}
+    <DndContext sensors={sensors} collisionDetection={closestCenter} modifiers={[restrictSortableListToVerticalAxis]} onDragEnd={handleDragEnd}>
+      <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+        <div className={mergeClasses('max-w-full min-w-0 overflow-x-hidden', className)}>
+          {itemsWithIds.map((item, index) => (
+            <SortableListRow
+              key={String(item.id)}
+              item={item}
+              index={index}
+              disabled={disabled}
+              itemWrapperClassName={itemWrapperClassName}
+              renderItem={renderItem}
+            />
+          ))}
         </div>
-      ))}
-    </div>
+      </SortableContext>
+    </DndContext>
   )
 }

--- a/src/components/widgets/media-card/DraggableMediaOverlayIconBtn.tsx
+++ b/src/components/widgets/media-card/DraggableMediaOverlayIconBtn.tsx
@@ -5,11 +5,9 @@ import {
   MediaOverlayIconBtnSurface,
   type MediaOverlayIconPosition
 } from '@/components/widgets/media-card/MediaOverlayIconBtn'
+import { DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH, DRAG_HANDLE_GRAB_CURSOR, DRAG_HANDLE_TOUCH_NONE } from '@/lib/dragHandleClasses'
 import { mergeClasses } from '@/lib/merge-classes'
 import type { HTMLAttributes, MouseEvent, Ref } from 'react'
-
-/** ~44px minimum hit area on touch / coarse pointers (WCAG); mouse keeps compact layout via overlay `w-auto`. */
-const COARSE_POINTER_MIN_TOUCH = '[@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px] [@media(pointer:coarse)]:shrink-0'
 
 export interface DraggableMediaOverlayIconBtnProps {
   icon: string
@@ -46,7 +44,8 @@ export default function DraggableMediaOverlayIconBtn({
       ref={activatorRef}
       {...(restActivator as HTMLAttributes<HTMLDivElement>)}
       className={mergeClasses(
-        'pointer-events-auto absolute z-40 touch-none',
+        'pointer-events-auto absolute z-40',
+        DRAG_HANDLE_TOUCH_NONE,
         MEDIA_OVERLAY_ICON_POSITION_CLASSES[position],
         typeof activatorClassName === 'string' ? activatorClassName : undefined
       )}
@@ -56,7 +55,7 @@ export default function DraggableMediaOverlayIconBtn({
         ariaLabel={ariaLabel}
         iconBtnSize="medium"
         onClick={stopOverlayClick}
-        className={mergeClasses(COARSE_POINTER_MIN_TOUCH, 'cursor-grab active:cursor-grabbing', className)}
+        className={mergeClasses(DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH, DRAG_HANDLE_GRAB_CURSOR, className)}
       />
     </div>
   )

--- a/src/lib/dragHandleClasses.ts
+++ b/src/lib/dragHandleClasses.ts
@@ -9,5 +9,13 @@ export const DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH =
 /** Cursor for draggable reorder handles. */
 export const DRAG_HANDLE_GRAB_CURSOR = 'cursor-grab active:cursor-grabbing'
 
+/**
+ * Add to `document.documentElement` while `SortableList` runs a pointer drag.
+ * The list’s vertical-only transform keeps the dragged preview aligned to the list while the
+ * pointer can sit elsewhere; `active:cursor-grabbing` on the handle then drops, so we force
+ * `grabbing` on the document for the drag lifetime.
+ */
+export const DND_POINTER_DRAG_HTML_CLASS = 'abs-dnd-pointer-dragging'
+
 /** Prevent the browser from treating handle touches as scroll (use on activator shells; SortableList also sets `touch-action` via dnd-kit attributes). */
 export const DRAG_HANDLE_TOUCH_NONE = 'touch-none'

--- a/src/lib/dragHandleClasses.ts
+++ b/src/lib/dragHandleClasses.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared Tailwind class fragments for drag / reorder handles (dnd-kit activators, overlay grips, etc.).
+ */
+
+/** ~44px minimum hit area on touch / coarse pointers (WCAG); mouse keeps compact layout where `w-auto`. */
+export const DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH =
+  '[@media(pointer:coarse)]:min-h-[44px] [@media(pointer:coarse)]:min-w-[44px] [@media(pointer:coarse)]:shrink-0'
+
+/** Cursor for draggable reorder handles. */
+export const DRAG_HANDLE_GRAB_CURSOR = 'cursor-grab active:cursor-grabbing'
+
+/** Prevent the browser from treating handle touches as scroll (use on activator shells; SortableList also sets `touch-action` via dnd-kit attributes). */
+export const DRAG_HANDLE_TOUCH_NONE = 'touch-none'


### PR DESCRIPTION
This re-implements `SortableList` using dnd-kit, and removes the dependency on formkit.

### Notable changes:
- `LibrariesList` and `LibraryScannerTab` now use the modified `SortableList`
- Drag handle classes are refactored out of `DraggableMediaOverlayIconBtn` to be used by all drag handles
- Drag handles are using the `drag_handle` icon across the code for consistency.