### PR TITLE
Add support for cross-origin dev requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This assumes that you have [audiobookshelf](https://github.com/advplyr/audiobook
 3. Start the audiobookshelf server with the `REACT_CLIENT_PATH` env variable set to this project path. Or in the `dev.js` file add `ReactClientPath` to config.
 4. In the audiobookshelf server repo run with `pnpm run dev` as usual. This will serve the NextJS app using HMR.
 
+If you access the dev app through a reverse proxy (not `localhost`), add `AllowedDevOrigins` to your audiobookshelf `dev.js` (mapped to `ALLOWED_DEV_ORIGINS` in `index.js`). Restart the dev server after changing it.
+
 ```js
 // example dev.js file in audiobookshelf
 const Path = require('path')
@@ -26,7 +28,8 @@ const Path = require('path')
 module.exports.config = {
   ConfigPath: Path.resolve('config'),
   MetadataPath: Path.resolve('metadata'),
-  ReactClientPath: Path.resolve('../audiobookshelf-client-react')
+  ReactClientPath: Path.resolve('../audiobookshelf-client-react'),
+  AllowedDevOrigins: ['your-reverse-proxy-host.example.com']
 }
 ```
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,14 @@ import createNextIntlPlugin from 'next-intl/plugin'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+/** Set via audiobookshelf dev.js `AllowedDevOrigins` → index.js sets ALLOWED_DEV_ORIGINS. */
+function allowedDevOriginsFromEnv(): string[] {
+  return (process.env.ALLOWED_DEV_ORIGINS ?? '')
+    .split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean)
+}
+
 /**
  * next-intl validates the i18n config path against process.cwd(). When Next is
  * embedded in the audiobookshelf server (Server.js), cwd stays at the server root
@@ -30,6 +38,7 @@ function runWithProjectCwd<T>(fn: () => T): T {
 const withNextIntl = createNextIntlPlugin('./src/lib/i18n.ts')
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: allowedDevOriginsFromEnv(),
   experimental: {
     serverActions: {
       bodySizeLimit: '10mb'


### PR DESCRIPTION
This adds support for allowing access to cross-origin dev resources, which is blocked by default in Next.js 16.

To support this, I sent audiobookshelf [PR #5291](https://github.com/advplyr/audiobookshelf/pull/5291) which sets the `ALLOWED_DEV_ORIGINS` env variable from a `dev.js` option. This PR reads this variable and sets the `allowedDevOrigins` in `next.config.ts`

I updated the README file with proper instructions.