### PR TITLE
Fix keyboard navigation for SortableBookshelf

### DIFF
--- a/src/components/widgets/SortableBookshelfReorderGrid.tsx
+++ b/src/components/widgets/SortableBookshelfReorderGrid.tsx
@@ -11,18 +11,27 @@ import {
   closestCenter,
   DndContext,
   DragOverlay,
+  KeyboardCode,
   KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
-  type DragStartEvent
+  type DragStartEvent,
+  type KeyboardCodes
 } from '@dnd-kit/core'
 import { arrayMove, rectSortingStrategy, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 import { useCallback, useMemo, useRef, useState, useTransition } from 'react'
 import SortableBookshelfCard from './media-card/SortableBookshelfCard'
 
 const itemsConfig = ENTITY_CONFIGS.items
+
+/** Arrow keys start keyboard reorder (with Space); Enter/Space/Tab drop; Escape cancels — matches dnd-kit defaults minus Enter on start so Enter only commits. */
+const reorderGridKeyboardCodes: KeyboardCodes = {
+  start: [KeyboardCode.Down, KeyboardCode.Up, KeyboardCode.Left, KeyboardCode.Right],
+  cancel: [KeyboardCode.Esc],
+  end: [KeyboardCode.Enter, KeyboardCode.Tab]
+}
 
 export interface SortableBookshelfReorderGridProps {
   items: LibraryItem[]
@@ -90,7 +99,10 @@ export default function SortableBookshelfReorderGrid({
    */
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+      keyboardCodes: reorderGridKeyboardCodes
+    })
   )
 
   const itemIds = useMemo(() => items.map((b) => b.id), [items])

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -305,13 +305,12 @@ function MediaCard(props: MediaCardProps) {
   const navigateOnCardClick = !processing && !isDragOnlyOverlay(sortableBookshelfOverlayMode)
 
   const dragHandle = useMemo(() => {
-    if (!dragOptions) return undefined
+    if (!dragOptions?.ariaLabel) return undefined
     return (
       <DraggableMediaOverlayIconBtn
         icon="drag_handle"
         ariaLabel={dragOptions.ariaLabel}
-        activatorRef={dragOptions.activatorRef}
-        activatorProps={dragOptions.activatorProps}
+        activatorProps={dragOptions.dragHandlePointerProps}
       />
     )
   }, [dragOptions])
@@ -321,6 +320,8 @@ function MediaCard(props: MediaCardProps) {
       <MediaCardFrame
         width={coverWidth}
         height={coverHeight}
+        rootRef={dragOptions?.cardActivatorRef}
+        sortableFrameProps={dragOptions?.sortableFrameProps}
         className={dragOptions ? 'group' : undefined}
         onClick={navigateOnCardClick ? handleCardClick : undefined}
         onMouseEnter={() => setIsHovering(true)}

--- a/src/components/widgets/media-card/MediaCardFrame.tsx
+++ b/src/components/widgets/media-card/MediaCardFrame.tsx
@@ -1,9 +1,13 @@
 import { mergeClasses } from '@/lib/merge-classes'
-import { type MouseEvent as ReactMouseEvent, type ReactNode } from 'react'
+import { type HTMLAttributes, type MouseEvent as ReactMouseEvent, type ReactNode, type Ref } from 'react'
 
 interface MediaCardFrameProps {
   width: number | string
   height: number | string
+  /** e.g. dnd-kit `setActivatorNodeRef` for keyboard sort when focus is on the card frame */
+  rootRef?: Ref<HTMLDivElement | null>
+  /** Props merged onto the root (e.g. dnd-kit `attributes`). `onKeyDown` / `tabIndex` are merged explicitly. */
+  sortableFrameProps?: HTMLAttributes<HTMLDivElement>
   onClick?: (event: React.MouseEvent) => void
   onMouseEnter?: () => void
   onMouseLeave?: () => void
@@ -22,6 +26,8 @@ interface MediaCardFrameProps {
 export default function MediaCardFrame({
   width,
   height,
+  rootRef,
+  sortableFrameProps,
   onClick,
   onMouseEnter,
   onMouseLeave,
@@ -35,16 +41,23 @@ export default function MediaCardFrame({
   className,
   'cy-id': cyId = 'mediaCard'
 }: MediaCardFrameProps) {
+  const { onKeyDown: sortableOnKeyDown, tabIndex: sortableTabIndex, ...sortableRest } = sortableFrameProps ?? {}
+
   return (
     <div
+      ref={rootRef}
       cy-id={cyId}
       id={cardId}
-      tabIndex={0}
+      {...sortableRest}
+      tabIndex={sortableTabIndex ?? 0}
       onClick={onClick}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onMouseOver={onMouseOver}
-      onKeyDown={onKeyDown}
+      onKeyDown={(event) => {
+        sortableOnKeyDown?.(event)
+        onKeyDown?.(event)
+      }}
       className={mergeClasses(
         'relative z-30 rounded-xs',
         onClick && 'cursor-pointer',

--- a/src/components/widgets/media-card/SortableBookshelfCard.tsx
+++ b/src/components/widgets/media-card/SortableBookshelfCard.tsx
@@ -4,11 +4,14 @@ import { ENTITY_CONFIGS, type CardComponentProps } from '@/app/(main)/library/[l
 import { getSortableBookshelfItemOrderBy, type SortableBookshelfOverlayMode } from '@/contexts/SortableBookshelfContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import type { LibraryItem } from '@/types/api'
+import { useDndMonitor } from '@dnd-kit/core'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useMemo, type Ref } from 'react'
+import { useCallback, useEffect, useMemo, useRef, type HTMLAttributes, type KeyboardEvent, type KeyboardEventHandler, type Ref } from 'react'
 
 const itemsConfig = ENTITY_CONFIGS.items
+
+const ARROW_CODES = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'])
 
 /**
  * Options passed from sortable bookshelf hosts into the shared items card: dnd-kit drag activator
@@ -16,9 +19,15 @@ const itemsConfig = ENTITY_CONFIGS.items
  */
 export interface SortableBookshelfCardOptions {
   ariaLabel: string
-  activatorRef?: Ref<HTMLDivElement>
-  /** @dnd-kit `attributes` + `listeners`; loose record for clean merging onto the drag wrapper `div`. */
-  activatorProps?: Record<string, unknown>
+  /**
+   * dnd-kit activator node: must be the focusable card root so `KeyboardSensor` can start
+   * when the frame is focused (listeners stay on the drag handle for pointer).
+   */
+  cardActivatorRef?: Ref<HTMLDivElement | null>
+  /** Merged onto {@link MediaCardFrame} root: `useSortable` `attributes` + keyboard `onKeyDown`. */
+  sortableFrameProps?: HTMLAttributes<HTMLDivElement>
+  /** Pointer-only subset of `useSortable` `listeners` for the drag handle. */
+  dragHandlePointerProps?: Record<string, unknown>
   /**
    * When set (e.g. `drag` on the dnd-kit `DragOverlay` card), overrides shelf context `overlayMode`
    * for overlay chrome and card navigation on this card only.
@@ -32,9 +41,9 @@ type SortableBookshelfCardProps = Omit<CardComponentProps, 'entity'> & {
 
 /**
  * Sortable wrapper that wires dnd-kit's `useSortable` to the standard items card.
- * The drag handle uses DraggableMediaOverlayIconBtn with setActivatorNodeRef so dnd-kit
- * applies `touch-action: none` and pointer listeners only there, leaving the rest of
- * the card click/scroll friendly.
+ * The drag handle keeps pointer listeners (`touch-action: none`); keyboard listeners and
+ * `setActivatorNodeRef` sit on the card frame so tab focus + Arrow keys work with
+ * `SortableBookshelfReorderGrid`'s `KeyboardSensor`.
  *
  * While this item is the active drag, the in-grid slot is hidden via opacity so the
  * portal-rendered `<DragOverlay>` is the only visible representation — the recommended
@@ -43,6 +52,41 @@ type SortableBookshelfCardProps = Omit<CardComponentProps, 'entity'> & {
 export default function SortableBookshelfCard({ libraryItem, ...cardProps }: SortableBookshelfCardProps) {
   const t = useTypeSafeTranslations()
   const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging } = useSortable({ id: libraryItem.id })
+
+  /** dnd-kit defers attaching the keyboard-move listener to the next task, so the arrow that *starts* drag never moves — replay it once. */
+  const synthArrowMoveAfterStartRef = useRef<string | null>(null)
+  const synthArrowTimeoutRef = useRef<number | null>(null)
+
+  useDndMonitor({
+    onDragStart({ active, activatorEvent }) {
+      if (String(active.id) !== libraryItem.id) return
+      if (activatorEvent instanceof globalThis.KeyboardEvent && ARROW_CODES.has(activatorEvent.code)) {
+        synthArrowMoveAfterStartRef.current = activatorEvent.code
+      }
+    },
+    onDragEnd() {
+      if (synthArrowTimeoutRef.current != null) {
+        window.clearTimeout(synthArrowTimeoutRef.current)
+        synthArrowTimeoutRef.current = null
+      }
+      synthArrowMoveAfterStartRef.current = null
+    },
+    onDragCancel() {
+      if (synthArrowTimeoutRef.current != null) {
+        window.clearTimeout(synthArrowTimeoutRef.current)
+        synthArrowTimeoutRef.current = null
+      }
+      synthArrowMoveAfterStartRef.current = null
+    }
+  })
+
+  useEffect(() => {
+    return () => {
+      if (synthArrowTimeoutRef.current != null) {
+        window.clearTimeout(synthArrowTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const style = useMemo(
     () => ({
@@ -53,17 +97,59 @@ export default function SortableBookshelfCard({ libraryItem, ...cardProps }: Sor
     [transform, transition, isDragging]
   )
 
-  const dragHandleProps = useMemo(() => ({ ...attributes, ...listeners }), [attributes, listeners])
+  const listenerRecord = listeners as Record<string, unknown> | undefined
+  const dragHandlePointerProps = useMemo(() => {
+    if (!listenerRecord) return undefined
+    const pointerOnly = { ...listenerRecord }
+    delete pointerOnly.onKeyDown
+    return pointerOnly
+  }, [listenerRecord])
+
+  const handleFrameKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      const dndKeyDown = listenerRecord?.onKeyDown as KeyboardEventHandler<HTMLDivElement> | undefined
+      if (!dndKeyDown) return
+      dndKeyDown(event)
+      const code = synthArrowMoveAfterStartRef.current
+      if (code && code === event.code) {
+        synthArrowMoveAfterStartRef.current = null
+        const el = event.currentTarget
+        if (synthArrowTimeoutRef.current != null) {
+          window.clearTimeout(synthArrowTimeoutRef.current)
+        }
+        synthArrowTimeoutRef.current = window.setTimeout(() => {
+          synthArrowTimeoutRef.current = null
+          el.dispatchEvent(
+            new window.KeyboardEvent('keydown', {
+              code,
+              key: event.key,
+              bubbles: true,
+              cancelable: true,
+              view: window
+            })
+          )
+        }, 0)
+      }
+    },
+    [listenerRecord]
+  )
+
+  const sortableFrameProps = useMemo((): HTMLAttributes<HTMLDivElement> => {
+    if (!listenerRecord?.onKeyDown) return { ...attributes }
+    return { ...attributes, onKeyDown: handleFrameKeyDown }
+  }, [attributes, listenerRecord, handleFrameKeyDown])
 
   const orderBy = useMemo(() => getSortableBookshelfItemOrderBy(libraryItem), [libraryItem])
 
   const sortableBookshelfCardOptions = useMemo(
     (): SortableBookshelfCardOptions => ({
       ariaLabel: t('TooltipCollectionDragHandle'),
-      activatorRef: setActivatorNodeRef,
-      activatorProps: dragHandleProps
+      cardActivatorRef: setActivatorNodeRef,
+      sortableFrameProps,
+      dragHandlePointerProps,
+      overlayMode: isDragging ? 'drag' : undefined
     }),
-    [t, setActivatorNodeRef, dragHandleProps]
+    [t, setActivatorNodeRef, sortableFrameProps, dragHandlePointerProps, isDragging]
   )
 
   return (


### PR DESCRIPTION
This makes the required changes to make keyboard navigation work correctly in `SortableBookshelf`.

The follwing behavior is implemented:
- Tab moves between cards (only one tab stop per card)
- Arrow keys take the bookshelf into reorder mode and also move the card
- In reorder mode:
  - Enter/Tab accepts new card position and goes out of reorder mode
  - Escape reverts to the original card position and goes out of reorder mode
  - Arrow keys move the card