### PR TITLE
Episode edit and match modals

### DIFF
--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -220,18 +220,18 @@ describe('<DropdownMenu />', () => {
 
     it('applies correct text styling for items with subtext', () => {
       cy.mount(<DropdownMenu {...defaultProps} />)
-      cy.get('[role="listbox"] > li').eq(1).find('span').first().should('have.class', 'font-semibold')
+      cy.get('[role="listbox"] > li').eq(1).find('span.font-semibold').should('contain.text', 'Option 2')
     })
 
     it('applies correct text styling for items without subtext', () => {
       cy.mount(<DropdownMenu {...defaultProps} />)
-      cy.get('[role="listbox"] > li').eq(0).find('span').first().should('not.have.class', 'font-semibold')
+      cy.get('[role="listbox"] > li').eq(0).find('span.font-semibold').should('not.exist')
     })
 
     it('renders subtext with correct styling', () => {
       cy.mount(<DropdownMenu {...defaultProps} />)
-      cy.get('[role="listbox"] > li').eq(1).find('span').last().should('have.class', 'text-foreground-subdued')
-      cy.get('[role="listbox"] > li').eq(1).find('span').last().should('have.class', 'font-normal')
+      cy.get('[role="listbox"] > li').eq(1).find('span.text-foreground-subdued').should('have.class', 'font-normal')
+      cy.get('[role="listbox"] > li').eq(1).find('span.text-foreground-subdued').should('contain.text', 'Description')
     })
 
     it('maintains proper z-index for dropdown positioning', () => {
@@ -264,7 +264,8 @@ describe('<DropdownMenu />', () => {
 
     it('applies proper overflow handling', () => {
       cy.mount(<DropdownMenu {...defaultProps} />)
-      cy.get('[role="listbox"]').should('have.class', 'overflow-auto')
+      cy.get('[role="listbox"]').should('have.class', 'overflow-x-hidden')
+      cy.get('[role="listbox"]').should('have.class', 'overflow-y-auto')
     })
 
     it('applies responsive text sizing', () => {

--- a/src/app/(main)/components_catalog/examples/TextInputExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/TextInputExamples.tsx
@@ -32,9 +32,9 @@ export function TextInputExamples() {
         </p>
         <p className="mb-2">
           <span className="font-bold">Props:</span> <Code>value</Code>, <Code>onChange</Code>, <Code>label</Code>, <Code>placeholder</Code>, <Code>type</Code>,{' '}
-          <Code>readOnly</Code>, <Code>disabled</Code>, <Code>clearable</Code>, <Code>showCopy</Code>, <Code>customInputClass</Code>, <Code>wrapperClassName</Code>,{' '}
-          <Code>size</Code>, <Code>step</Code>, <Code>min</Code>, <Code>onClear</Code>, <Code>onFocus</Code>, <Code>onBlur</Code>, <Code>id</Code>, <Code>name</Code>,{' '}
-          <Code>className</Code>, <Code>ref</Code>
+          <Code>readOnly</Code>, <Code>disabled</Code>, <Code>clearable</Code>, <Code>showCopy</Code>, <Code>customInputClass</Code>,{' '}
+          <Code>wrapperClassName</Code>, <Code>size</Code>, <Code>step</Code>, <Code>min</Code>, <Code>onClear</Code>, <Code>onFocus</Code>, <Code>onBlur</Code>
+          , <Code>id</Code>, <Code>name</Code>, <Code>className</Code>, <Code>ref</Code>
         </p>
       </ComponentInfo>
 

--- a/src/app/(main)/components_catalog/examples/TextInputExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/TextInputExamples.tsx
@@ -32,9 +32,9 @@ export function TextInputExamples() {
         </p>
         <p className="mb-2">
           <span className="font-bold">Props:</span> <Code>value</Code>, <Code>onChange</Code>, <Code>label</Code>, <Code>placeholder</Code>, <Code>type</Code>,{' '}
-          <Code>readOnly</Code>, <Code>disabled</Code>, <Code>clearable</Code>, <Code>showCopy</Code>, <Code>customInputClass</Code>, <Code>step</Code>,{' '}
-          <Code>min</Code>, <Code>onClear</Code>, <Code>onFocus</Code>, <Code>onBlur</Code>, <Code>id</Code>, <Code>name</Code>, <Code>className</Code>,{' '}
-          <Code>ref</Code>
+          <Code>readOnly</Code>, <Code>disabled</Code>, <Code>clearable</Code>, <Code>showCopy</Code>, <Code>customInputClass</Code>, <Code>wrapperClassName</Code>,{' '}
+          <Code>size</Code>, <Code>step</Code>, <Code>min</Code>, <Code>onClear</Code>, <Code>onFocus</Code>, <Code>onBlur</Code>, <Code>id</Code>, <Code>name</Code>,{' '}
+          <Code>className</Code>, <Code>ref</Code>
         </p>
       </ComponentInfo>
 
@@ -43,8 +43,16 @@ export function TextInputExamples() {
           <TextInput label="Name" value={textValue1} onChange={setTextValue1} placeholder="Enter your name" />
         </Example>
 
-        <Example title="Text Input with Label">
-          <TextInput label="Email" value={textValue2} onChange={setTextValue2} placeholder="Enter your email" />
+        <Example title="Small Size">
+          <TextInput label="Small" value={textValue2} onChange={setTextValue2} placeholder="Compact h-9 input" size="small" />
+        </Example>
+
+        <Example title="Large Size">
+          <TextInput label="Large" value={textValue2} onChange={setTextValue2} placeholder="Tall h-11 input" size="large" />
+        </Example>
+
+        <Example title="Text Input without Label">
+          <TextInput value={textValue2} onChange={setTextValue2} placeholder="Search..." type="search" size="small" />
         </Example>
 
         <Example title="Password Input">

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -320,6 +320,8 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
                       showSubtitles={true}
                       mediaProgress={mediaProgress}
                       continueListeningShelf={continueListeningShelf}
+                      shelfEntities={shelf.entities}
+                      entityIndex={entityIndex}
                     />
                   </div>
                 )

--- a/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
+++ b/src/app/(main)/library/[library]/[entityType]/entity-config.tsx
@@ -16,6 +16,7 @@ import type { SortableBookshelfCardOptions } from '@/components/widgets/media-ca
 import { UpdateSettingFn } from '@/contexts/LibraryContext'
 import { useUser } from '@/contexts/UserContext'
 import { downloadLibraryOpml } from '@/lib/download'
+import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import {
   Author,
   BookshelfEntity,
@@ -54,7 +55,7 @@ export interface CardComponentProps {
   orderBy?: string
   seriesSortBy?: string
   mediaItemProgressMap: Map<string, MediaProgress>
-  shelfEntities?: (BookshelfEntity | null)[]
+  shelfEntities?: (ShelfNavigationEntity | null)[]
   entityIndex?: number
   /** Sortable collection bookshelf: options from `SortableBookshelfCard` (drag activator + overlay override). */
   sortableBookshelfCardOptions?: SortableBookshelfCardOptions

--- a/src/app/(main)/library/[library]/playlist/[playlist]/PlaylistBookshelf.tsx
+++ b/src/app/(main)/library/[library]/playlist/[playlist]/PlaylistBookshelf.tsx
@@ -9,7 +9,7 @@ import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { buildMediaItemProgressMap } from '@/lib/mediaProgress'
 import { playlistItemsToPayload, toSortablePlaylistItems } from '@/lib/playlistItems'
-import type { BookshelfEntity, Playlist, PlaylistItem } from '@/types/api'
+import type { Playlist, PlaylistItem } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import type { SortableBookshelfEntry } from '@/types/compilation'
 import { useCallback, useMemo } from 'react'
@@ -40,7 +40,6 @@ export default function PlaylistBookshelf({ playlist, orderedItems, setOrderedIt
   const isPodcastLibrary = library.mediaType === 'podcast'
 
   const shelfEntries = useMemo(() => toSortablePlaylistItems(orderedItems), [orderedItems])
-  const shelfEntitiesDense = useMemo(() => orderedItems.map((i) => i.libraryItem) as unknown as (BookshelfEntity | null)[], [orderedItems])
   const mediaItemProgressMap = useMemo(() => buildMediaItemProgressMap(user.mediaProgress), [user.mediaProgress])
 
   const handlePersistOrder = useCallback(
@@ -71,11 +70,11 @@ export default function PlaylistBookshelf({ playlist, orderedItems, setOrderedIt
         orderBy={getSortableBookshelfItemOrderBy(entry.libraryItem)}
         seriesSortBy={seriesSortBy}
         mediaItemProgressMap={mediaItemProgressMap}
-        shelfEntities={shelfEntitiesDense}
+        shelfEntities={orderedItems}
         entityIndex={entityIndex}
       />
     ),
-    [isPodcastLibrary, library.id, mediaItemProgressMap, seriesSortBy, shelfEntitiesDense, showSubtitles]
+    [isPodcastLibrary, library.id, mediaItemProgressMap, orderedItems, seriesSortBy, showSubtitles]
   )
 
   return (

--- a/src/app/(main)/library/[library]/playlist/[playlist]/PlaylistList.tsx
+++ b/src/app/(main)/library/[library]/playlist/[playlist]/PlaylistList.tsx
@@ -8,8 +8,7 @@ import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getPlaylistItemKey, playlistItemsToPayload } from '@/lib/playlistItems'
-import { getPlaylistEpisodeNavigationContext } from '@/lib/episodeEditNavigation'
-import type { BookshelfEntity, Playlist, PlaylistItem } from '@/types/api'
+import type { Playlist, PlaylistItem } from '@/types/api'
 import { useCallback, useMemo, useTransition } from 'react'
 
 type SortablePlaylistItem = PlaylistItem & { id: string }
@@ -30,17 +29,6 @@ export default function PlaylistList({ playlist, orderedItems, setOrderedItems, 
   const showDragHandle = userCanUpdate && showReorder
 
   const sortableItems = useMemo((): SortablePlaylistItem[] => orderedItems.map((item) => ({ ...item, id: getPlaylistItemKey(item) })), [orderedItems])
-
-  const shelfEntitiesDense = useMemo(() => orderedItems.map((i) => i.libraryItem) as unknown as (BookshelfEntity | null)[], [orderedItems])
-
-  const episodeNavByItemKey = useMemo(() => {
-    const navByKey = new Map<string, ReturnType<typeof getPlaylistEpisodeNavigationContext>>()
-    for (const item of orderedItems) {
-      if (!item.episode) continue
-      navByKey.set(getPlaylistItemKey(item), getPlaylistEpisodeNavigationContext(orderedItems, item.episode.id))
-    }
-    return navByKey
-  }, [orderedItems])
 
   const handleSortEnd = useCallback(
     (sortedItems: SortablePlaylistItem[]) => {
@@ -67,13 +55,12 @@ export default function PlaylistList({ playlist, orderedItems, setOrderedItems, 
         episode={item.episode}
         context={{ kind: 'playlist', playlistId: playlist.id }}
         entityIndex={index}
-        shelfEntities={shelfEntitiesDense}
-        episodeNavCtx={item.episode ? (episodeNavByItemKey.get(item.id) ?? undefined) : undefined}
+        shelfEntities={orderedItems}
         showDragHandle={showDragHandle}
         sortableDragHandleProps={dragHandle}
       />
     ),
-    [episodeNavByItemKey, playlist.id, shelfEntitiesDense, showDragHandle]
+    [orderedItems, playlist.id, showDragHandle]
   )
 
   return (

--- a/src/app/actions/mediaActions.ts
+++ b/src/app/actions/mediaActions.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import * as api from '@/lib/api'
-import { RssPodcastEpisode, UpdateLibraryItemMediaPayload } from '@/types/api'
+import { RssPodcastEpisode, UpdateLibraryItemMediaPayload, UpdatePodcastEpisodePayload } from '@/types/api'
 
 export async function toggleFinishedAction(libraryItemId: string, params: { isFinished: boolean; episodeId?: string }) {
   return api.updateMediaFinished(libraryItemId, params)
@@ -53,4 +53,16 @@ export async function downloadPodcastEpisodesAction(libraryItemId: string, episo
 
 export async function clearPodcastDownloadQueueAction(libraryItemId: string) {
   return api.clearPodcastDownloadQueue(libraryItemId)
+}
+
+export async function getPodcastEpisodeAction(libraryItemId: string, episodeId: string) {
+  return api.getPodcastEpisode(libraryItemId, episodeId)
+}
+
+export async function updatePodcastEpisodeAction(libraryItemId: string, episodeId: string, payload: UpdatePodcastEpisodePayload) {
+  return api.updatePodcastEpisode(libraryItemId, episodeId, payload)
+}
+
+export async function searchPodcastEpisodeAction(libraryItemId: string, title: string) {
+  return api.searchPodcastEpisode(libraryItemId, title)
 }

--- a/src/components/modals/EpisodeEditModal.tsx
+++ b/src/components/modals/EpisodeEditModal.tsx
@@ -2,32 +2,37 @@
 
 import Modal from '@/components/modals/Modal'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
-import type { LibraryItem, PodcastEpisode } from '@/types/api'
+import type { EpisodeNavigationContext } from '@/lib/episodeEditNavigation'
+import type { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
 
-export interface EpisodeEditModalProps {
+export type EpisodeEditModalProps = {
   isOpen: boolean
   onClose: () => void
-  libraryItem: LibraryItem
-  episode: PodcastEpisode
-  navCtx?: EntityNavigationContext
-}
+} & ({ navCtx: EpisodeNavigationContext } | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode })
 
 /**
  * Episode edit modal shell. Full details/match tabs are not yet ported from the Vue client.
  */
-export default function EpisodeEditModal({ isOpen, onClose, libraryItem, episode, navCtx }: EpisodeEditModalProps) {
+export default function EpisodeEditModal(props: EpisodeEditModalProps) {
+  const { isOpen, onClose } = props
+  const navCtx = 'navCtx' in props ? props.navCtx : undefined
+  const libraryItem = 'libraryItem' in props ? props.libraryItem : undefined
+  const episode = 'episode' in props ? props.episode : undefined
+
   const t = useTypeSafeTranslations()
+
+  const title = episode?.title ?? ''
+  const podcastTitle = libraryItem?.media.metadata.title ?? ''
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} className="max-w-3xl">
       <div className="bg-bg border-black-300 w-full rounded-lg border p-6 shadow-lg">
-        <h2 className="text-foreground mb-2 text-2xl font-semibold">{episode.title}</h2>
-        {libraryItem.media.metadata.title && <p className="text-foreground-muted mb-4 text-sm">{libraryItem.media.metadata.title}</p>}
+        {title && <h2 className="text-foreground mb-2 text-2xl font-semibold">{title}</h2>}
+        {podcastTitle && <p className="text-foreground-muted mb-4 text-sm">{podcastTitle}</p>}
         <p className="text-foreground-muted text-sm">{t('HeaderDetails')} — coming soon in the React client.</p>
-        {navCtx && navCtx.entityIds.length > 1 && (
+        {navCtx && navCtx.slots.length > 1 && (
           <p className="text-foreground-subdued mt-2 text-xs">
-            {navCtx.initialIndex + 1} / {navCtx.entityIds.length}
+            {navCtx.initialIndex + 1} / {navCtx.slots.length}
           </p>
         )}
       </div>

--- a/src/components/modals/EpisodeEditModal.tsx
+++ b/src/components/modals/EpisodeEditModal.tsx
@@ -1,41 +1,237 @@
 'use client'
 
-import Modal from '@/components/modals/Modal'
+import { updatePodcastEpisodeAction } from '@/app/actions/mediaActions'
+import EpisodeModal, { useEpisodeModal, type EpisodeModalItemSource } from '@/components/modals/EpisodeModal'
+import Btn from '@/components/ui/Btn'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
+import EpisodeDetailsEdit, { type EpisodeDetailsEditRef, type EpisodeDetailsEditSubmitResult } from '@/components/widgets/EpisodeDetailsEdit'
+import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { EpisodeNavigationContext } from '@/lib/episodeEditNavigation'
 import type { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, useTransition, type TransitionStartFunction } from 'react'
 
 export type EpisodeEditModalProps = {
   isOpen: boolean
   onClose: () => void
-} & ({ navCtx: EpisodeNavigationContext } | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode })
+  onSaved?: (episode: PodcastEpisode, libraryItem: PodcastLibraryItem) => void
+} & EpisodeModalItemSource
 
-/**
- * Episode edit modal shell. Full details/match tabs are not yet ported from the Vue client.
- */
-export default function EpisodeEditModal(props: EpisodeEditModalProps) {
-  const { isOpen, onClose } = props
-  const navCtx = 'navCtx' in props ? props.navCtx : undefined
-  const libraryItem = 'libraryItem' in props ? props.libraryItem : undefined
-  const episode = 'episode' in props ? props.episode : undefined
+type EpisodeEditModalContentProps = {
+  isOpen: boolean
+  startSaveTransition: TransitionStartFunction
+  isSavePending: boolean
+  onClose: () => void
+  onSaved?: (episode: PodcastEpisode, libraryItem: PodcastLibraryItem) => void
+  stableBodyHeight: boolean
+}
 
+function createPlaceholderEpisode(episodeId: string, libraryItemId: string): PodcastEpisode {
+  return {
+    id: episodeId,
+    libraryItemId,
+    podcastId: libraryItemId,
+    title: '',
+    chapters: [],
+    addedAt: 0,
+    updatedAt: 0
+  }
+}
+
+function EpisodeEditModalContent({ isOpen, startSaveTransition, isSavePending, onClose, onSaved, stableBodyHeight }: EpisodeEditModalContentProps) {
+  const { resolvedEpisode, resolvedLibraryItem, fetchPending, pendingEpisodeId, syncResolvedEpisode } = useEpisodeModal()
   const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+  const [hasChanges, setHasChanges] = useState(false)
+  const saveAndCloseRef = useRef(false)
+  const detailsRef = useRef<EpisodeDetailsEditRef>(null)
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [footerShadow, setFooterShadow] = useState(false)
 
-  const title = episode?.title ?? ''
-  const podcastTitle = libraryItem?.media.metadata.title ?? ''
+  const resolvedEpisodeId = resolvedEpisode?.id
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHasChanges(false)
+      saveAndCloseRef.current = false
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!resolvedEpisodeId) return
+    setHasChanges(false)
+    saveAndCloseRef.current = false
+  }, [resolvedEpisodeId])
+
+  useEffect(() => {
+    setHasChanges(false)
+    saveAndCloseRef.current = false
+  }, [pendingEpisodeId])
+
+  const updateFooterShadow = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container) return
+    const isScrollable = container.scrollHeight > container.clientHeight
+    const isAtBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 1
+    setFooterShadow(isScrollable && !isAtBottom)
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const container = scrollContainerRef.current
+    if (!container) return
+    updateFooterShadow()
+    container.addEventListener('scroll', updateFooterShadow)
+    const resizeObserver = new ResizeObserver(updateFooterShadow)
+    resizeObserver.observe(container)
+    return () => {
+      container.removeEventListener('scroll', updateFooterShadow)
+      resizeObserver.disconnect()
+    }
+  }, [isOpen, updateFooterShadow])
+
+  useLayoutEffect(() => {
+    if (!isOpen) return
+    updateFooterShadow()
+  }, [isOpen, resolvedEpisodeId, pendingEpisodeId, fetchPending, updateFooterShadow])
+
+  const handleChange = useCallback((_details: { episodeId: string; hasChanges: boolean }) => {
+    setHasChanges(_details.hasChanges)
+  }, [])
+
+  const handleSubmit = useCallback(
+    (result: EpisodeDetailsEditSubmitResult) => {
+      if (result.invalidPubDate) {
+        showToast(t('ToastDateTimeInvalidOrIncomplete'), { type: 'error' })
+        return
+      }
+
+      const libraryItemId = resolvedLibraryItem?.id
+      const episodeId = resolvedEpisode?.id
+      if (!libraryItemId || !episodeId) return
+
+      if (!result.hasChanges) {
+        if (saveAndCloseRef.current) {
+          onClose()
+        } else {
+          showToast(t('ToastNoUpdatesNecessary'), { type: 'info' })
+        }
+        return
+      }
+
+      startSaveTransition(async () => {
+        try {
+          const updatedLibraryItem = await updatePodcastEpisodeAction(libraryItemId, episodeId, result.updatePayload)
+          const updatedEpisode = updatedLibraryItem.media.episodes?.find((ep) => ep.id === episodeId)
+          if (!updatedEpisode) {
+            throw new Error('Updated episode not found in response')
+          }
+          showToast(t('ToastItemUpdateSuccess'), { type: 'success' })
+          syncResolvedEpisode(updatedEpisode, updatedLibraryItem)
+          onSaved?.(updatedEpisode, updatedLibraryItem)
+          if (saveAndCloseRef.current) {
+            onClose()
+          }
+        } catch (error) {
+          console.error('Failed to update episode', error)
+          showToast(t('ToastFailedToUpdate'), { type: 'error' })
+        }
+      })
+    },
+    [onClose, onSaved, resolvedEpisode?.id, resolvedLibraryItem?.id, showToast, startSaveTransition, syncResolvedEpisode, t]
+  )
+
+  const handleSave = (close: boolean = false) => {
+    saveAndCloseRef.current = close
+    detailsRef.current?.submit()
+  }
+
+  const saveDisabled = !hasChanges || isSavePending || !resolvedEpisode || fetchPending
+
+  const showPlaceholderShell = fetchPending && !resolvedEpisode && pendingEpisodeId !== null
+  const placeholderEpisode =
+    showPlaceholderShell && pendingEpisodeId && resolvedLibraryItem
+      ? createPlaceholderEpisode(pendingEpisodeId, resolvedLibraryItem.id)
+      : showPlaceholderShell && pendingEpisodeId
+        ? createPlaceholderEpisode(pendingEpisodeId, '')
+        : null
+
+  const fetchLoadingOverlay = (
+    <div className="bg-bg/50 absolute inset-0 z-10 flex items-center justify-center">
+      <LoadingIndicator variant="inline" />
+    </div>
+  )
+
+  const formInner = resolvedEpisode ? (
+    <EpisodeDetailsEdit key={resolvedEpisode.id} ref={detailsRef} episode={resolvedEpisode} onChange={handleChange} onSubmit={handleSubmit} />
+  ) : showPlaceholderShell && placeholderEpisode ? (
+    <div className="relative">
+      <EpisodeDetailsEdit
+        key={`placeholder-episode-${pendingEpisodeId}`}
+        ref={detailsRef}
+        episode={placeholderEpisode}
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+      />
+      {fetchLoadingOverlay}
+    </div>
+  ) : fetchPending ? (
+    <div className="flex min-h-[24rem] items-center justify-center">
+      <LoadingIndicator variant="inline" />
+    </div>
+  ) : null
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} className="max-w-3xl">
-      <div className="bg-bg border-black-300 w-full rounded-lg border p-6 shadow-lg">
-        {title && <h2 className="text-foreground mb-2 text-2xl font-semibold">{title}</h2>}
-        {podcastTitle && <p className="text-foreground-muted mb-4 text-sm">{podcastTitle}</p>}
-        <p className="text-foreground-muted text-sm">{t('HeaderDetails')} — coming soon in the React client.</p>
-        {navCtx && navCtx.slots.length > 1 && (
-          <p className="text-foreground-subdued mt-2 text-xs">
-            {navCtx.initialIndex + 1} / {navCtx.slots.length}
-          </p>
-        )}
+    <div
+      className={
+        stableBodyHeight
+          ? 'bg-bg border-border flex max-h-[80vh] w-full flex-col overflow-hidden rounded-lg border'
+          : 'bg-bg border-border flex max-h-[85vh] w-full flex-col rounded-lg border'
+      }
+    >
+      <div ref={scrollContainerRef} className="min-h-0 overflow-x-hidden overflow-y-auto">
+        {formInner}
       </div>
-    </Modal>
+
+      <div
+        className={`bg-bg border-border flex shrink-0 justify-end gap-3 border-t px-4 py-3 transition-shadow duration-200 ${footerShadow ? 'box-shadow-md-up' : ''}`}
+      >
+        <Btn onClick={() => handleSave(false)} disabled={saveDisabled} className="hidden md:inline-flex">
+          {t('ButtonSave')}
+        </Btn>
+        <Btn onClick={() => handleSave(true)} disabled={saveDisabled}>
+          <span className="hidden md:inline">{t('ButtonSaveAndClose')}</span>
+          <span className="md:hidden">{t('ButtonSave')}</span>
+        </Btn>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Modal for editing podcast episode metadata.
+ * Pass `navCtx` to load episodes and enable prev/next, or `libraryItem` + `episode` for direct mode.
+ */
+export default function EpisodeEditModal(props: EpisodeEditModalProps) {
+  const { isOpen, onClose, onSaved } = props
+  const navCtxMode = 'navCtx' in props
+  const [isSavePending, startSaveTransition] = useTransition()
+
+  return (
+    <EpisodeModal
+      isOpen={isOpen}
+      onClose={onClose}
+      {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem, episode: props.episode })}
+      additionalProcessing={isSavePending}
+      className="sm:max-w-screen md:max-w-[800px]"
+    >
+      <EpisodeEditModalContent
+        isOpen={isOpen}
+        startSaveTransition={startSaveTransition}
+        isSavePending={isSavePending}
+        onClose={onClose}
+        onSaved={onSaved}
+        stableBodyHeight={navCtxMode}
+      />
+    </EpisodeModal>
   )
 }

--- a/src/components/modals/EpisodeEditModal.tsx
+++ b/src/components/modals/EpisodeEditModal.tsx
@@ -64,7 +64,6 @@ function EpisodeEditModalContent({ isOpen, startSaveTransition, isSavePending, o
 
   useEffect(() => {
     setHasChanges(false)
-    saveAndCloseRef.current = false
   }, [pendingEpisodeId])
 
   const updateFooterShadow = useCallback(() => {
@@ -111,12 +110,15 @@ function EpisodeEditModalContent({ isOpen, startSaveTransition, isSavePending, o
 
       if (!result.hasChanges) {
         if (saveAndCloseRef.current) {
+          saveAndCloseRef.current = false
           onClose()
         } else {
           showToast(t('ToastNoUpdatesNecessary'), { type: 'info' })
         }
         return
       }
+
+      const shouldCloseAfterSave = saveAndCloseRef.current
 
       startSaveTransition(async () => {
         try {
@@ -128,7 +130,8 @@ function EpisodeEditModalContent({ isOpen, startSaveTransition, isSavePending, o
           showToast(t('ToastItemUpdateSuccess'), { type: 'success' })
           syncResolvedEpisode(updatedEpisode, updatedLibraryItem)
           onSaved?.(updatedEpisode, updatedLibraryItem)
-          if (saveAndCloseRef.current) {
+          if (shouldCloseAfterSave) {
+            saveAndCloseRef.current = false
             onClose()
           }
         } catch (error) {

--- a/src/components/modals/EpisodeMatchModal.tsx
+++ b/src/components/modals/EpisodeMatchModal.tsx
@@ -1,23 +1,52 @@
 'use client'
 
-import Modal from '@/components/modals/Modal'
-import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { EpisodeNavigationContext } from '@/lib/episodeEditNavigation'
-import type { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
+import EpisodeModal, { useEpisodeModal, type EpisodeModalItemSource } from '@/components/modals/EpisodeModal'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
+import EpisodeMatch from '@/components/widgets/EpisodeMatch'
 
 export type EpisodeMatchModalProps = {
   isOpen: boolean
   onClose: () => void
-} & ({ navCtx: EpisodeNavigationContext } | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode })
+} & EpisodeModalItemSource
 
-export default function EpisodeMatchModal({ isOpen, onClose }: EpisodeMatchModalProps) {
-  const t = useTypeSafeTranslations()
+function EpisodeMatchModalBody() {
+  const { resolvedEpisode, resolvedLibraryItem, fetchPending, syncResolvedEpisode } = useEpisodeModal()
+
+  if (fetchPending && !resolvedEpisode) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <LoadingIndicator variant="inline" />
+      </div>
+    )
+  }
+
+  if (!resolvedEpisode || !resolvedLibraryItem) return null
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} className="max-w-3xl">
-      <div className="bg-bg border-border w-full rounded-lg border p-6 shadow-lg">
-        <p className="text-foreground-muted text-sm">{t('HeaderMatch')} — coming soon in the React client.</p>
+    <EpisodeMatch
+      libraryItem={resolvedLibraryItem}
+      episode={resolvedEpisode}
+      onEpisodeUpdated={(episode, libraryItem) => syncResolvedEpisode(episode, libraryItem)}
+    />
+  )
+}
+
+export default function EpisodeMatchModal(props: EpisodeMatchModalProps) {
+  const { isOpen, onClose } = props
+  const navCtxMode = 'navCtx' in props
+
+  return (
+    <EpisodeModal
+      isOpen={isOpen}
+      onClose={onClose}
+      {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem, episode: props.episode })}
+      className="md:max-w-[min(90vw,56rem)] lg:max-w-[min(90vw,56rem)]"
+    >
+      <div className="bg-bg border-border flex max-h-[80vh] flex-col overflow-hidden rounded-lg border">
+        <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+          <EpisodeMatchModalBody />
+        </div>
       </div>
-    </Modal>
+    </EpisodeModal>
   )
 }

--- a/src/components/modals/EpisodeMatchModal.tsx
+++ b/src/components/modals/EpisodeMatchModal.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import Modal from '@/components/modals/Modal'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { EpisodeNavigationContext } from '@/lib/episodeEditNavigation'
+import type { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
+
+export type EpisodeMatchModalProps = {
+  isOpen: boolean
+  onClose: () => void
+} & ({ navCtx: EpisodeNavigationContext } | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode })
+
+export default function EpisodeMatchModal({ isOpen, onClose }: EpisodeMatchModalProps) {
+  const t = useTypeSafeTranslations()
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} className="max-w-3xl">
+      <div className="bg-bg border-border w-full rounded-lg border p-6 shadow-lg">
+        <p className="text-foreground-muted text-sm">{t('HeaderMatch')} — coming soon in the React client.</p>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/modals/EpisodeModal.tsx
+++ b/src/components/modals/EpisodeModal.tsx
@@ -1,0 +1,201 @@
+'use client'
+
+import { getExpandedLibraryItemAction, getPodcastEpisodeAction } from '@/app/actions/mediaActions'
+import type { ModalProps } from '@/components/modals/Modal'
+import Modal from '@/components/modals/Modal'
+import ModalSideNavigation from '@/components/modals/ModalSideNavigation'
+import { useSocketEvent } from '@/contexts/SocketContext'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useEpisodeNavigationContext } from '@/hooks/useEpisodeNavigationContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { EpisodeNavigationContext } from '@/lib/episodeEditNavigation'
+import type { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
+import { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState, useTransition, type ReactNode } from 'react'
+
+export type EpisodeModalContextValue = {
+  resolvedEpisode: PodcastEpisode | null
+  resolvedLibraryItem: PodcastLibraryItem | null
+  fetchPending: boolean
+  pendingEpisodeId: string | null
+  syncResolvedEpisode: (episode: PodcastEpisode, libraryItem?: PodcastLibraryItem) => void
+}
+
+const EpisodeModalContext = createContext<EpisodeModalContextValue | null>(null)
+
+export function useEpisodeModal(): EpisodeModalContextValue {
+  const ctx = useContext(EpisodeModalContext)
+  if (!ctx) {
+    throw new Error('useEpisodeModal must be used within EpisodeModal')
+  }
+  return ctx
+}
+
+export type EpisodeModalItemSource =
+  | { navCtx: EpisodeNavigationContext }
+  | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode }
+
+export type EpisodeModalProps = Omit<ModalProps, 'outerContent' | 'sideNavigation' | 'processing' | 'children'> &
+  EpisodeModalItemSource & {
+    additionalProcessing?: boolean
+    children: ReactNode
+  }
+
+export default function EpisodeModal(props: EpisodeModalProps) {
+  const { additionalProcessing = false, children, isOpen, onClose, persistent, zIndexClass, bgOpacityClass, className, style } = props
+
+  const navCtxMode = 'navCtx' in props
+  const navCtx = navCtxMode ? props.navCtx : undefined
+  const directLibraryItem = 'libraryItem' in props ? props.libraryItem : undefined
+  const directEpisode = 'episode' in props ? props.episode : undefined
+
+  const slots = navCtx?.slots ?? []
+
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+  const [fetchedEpisode, setFetchedEpisode] = useState<PodcastEpisode | null>(null)
+  const [fetchedLibraryItem, setFetchedLibraryItem] = useState<PodcastLibraryItem | null>(null)
+  const [isNavPending, startNavTransition] = useTransition()
+  const [navFetchPending, setNavFetchPending] = useState(false)
+  const fetchGenRef = useRef(0)
+
+  const { currentSlot, canGoPrev, canGoNext, goPrev, goNext } = useEpisodeNavigationContext(navCtx, isOpen)
+
+  useLayoutEffect(() => {
+    if (!isOpen || !navCtxMode) return
+    if (!currentSlot) {
+      setFetchedEpisode(null)
+      setFetchedLibraryItem(null)
+      return
+    }
+
+    const { libraryItemId, episodeId } = currentSlot
+    const gen = ++fetchGenRef.current
+    setNavFetchPending(true)
+    setFetchedEpisode(null)
+
+    startNavTransition(async () => {
+      try {
+        const [episode, libraryItem] = await Promise.all([
+          getPodcastEpisodeAction(libraryItemId, episodeId),
+          getExpandedLibraryItemAction(libraryItemId)
+        ])
+        if (fetchGenRef.current !== gen) return
+        setFetchedEpisode(episode)
+        setFetchedLibraryItem(libraryItem as PodcastLibraryItem)
+      } catch (error) {
+        console.error('Failed to load podcast episode', error)
+        if (fetchGenRef.current === gen) {
+          showToast(t('ToastFailedToLoadData'), { type: 'error' })
+          onClose?.()
+        }
+      } finally {
+        if (fetchGenRef.current === gen) {
+          setNavFetchPending(false)
+        }
+      }
+    })
+  }, [isOpen, navCtxMode, navCtx, currentSlot, onClose, showToast, startNavTransition, t])
+
+  const resolvedEpisode = navCtxMode ? fetchedEpisode : (directEpisode ?? null)
+  const resolvedLibraryItem = navCtxMode ? fetchedLibraryItem : (directLibraryItem ?? null)
+
+  const syncResolvedEpisode = useCallback(
+    (episode: PodcastEpisode, libraryItem?: PodcastLibraryItem) => {
+      if (!navCtxMode) return
+      setFetchedEpisode(episode)
+      if (libraryItem) {
+        setFetchedLibraryItem(libraryItem)
+      } else if (fetchedLibraryItem) {
+        const episodes = fetchedLibraryItem.media.episodes ?? []
+        const updatedEpisodes = episodes.map((ep) => (ep.id === episode.id ? { ...ep, ...episode } : ep))
+        setFetchedLibraryItem({
+          ...fetchedLibraryItem,
+          media: {
+            ...fetchedLibraryItem.media,
+            episodes: updatedEpisodes
+          }
+        })
+      }
+    },
+    [navCtxMode, fetchedLibraryItem]
+  )
+
+  const handleItemUpdated = useCallback(
+    (libraryItem: PodcastLibraryItem) => {
+      if (!navCtxMode || !resolvedEpisode) return
+      if (libraryItem.id !== resolvedLibraryItem?.id) return
+      const episode = libraryItem.media.episodes?.find((ep) => ep.id === resolvedEpisode.id)
+      if (episode) {
+        setFetchedEpisode(episode)
+        setFetchedLibraryItem(libraryItem)
+      }
+    },
+    [navCtxMode, resolvedEpisode, resolvedLibraryItem?.id]
+  )
+
+  useSocketEvent<PodcastLibraryItem>('item_updated', handleItemUpdated, [handleItemUpdated])
+
+  const blurActiveElement = useCallback(() => {
+    const el = document.activeElement
+    if (el instanceof HTMLElement) el.blur()
+  }, [])
+
+  const handleGoPrev = useCallback(() => {
+    blurActiveElement()
+    goPrev()
+  }, [blurActiveElement, goPrev])
+
+  const handleGoNext = useCallback(() => {
+    blurActiveElement()
+    goNext()
+  }, [blurActiveElement, goNext])
+
+  const mediaTitle = resolvedLibraryItem?.media.metadata.title ?? ''
+  const outerContent = useMemo(() => {
+    if (!mediaTitle) return undefined
+    return (
+      <div className="absolute start-0 top-0 p-4">
+        <h2 className="max-w-[calc(100vw-4rem)] truncate text-xl text-white" title={mediaTitle}>
+          {mediaTitle}
+        </h2>
+      </div>
+    )
+  }, [mediaTitle])
+
+  const showRails = navCtxMode && slots.length > 1
+  const fetchPending = navCtxMode && (navFetchPending || isNavPending)
+  const pendingEpisodeId = navCtxMode && fetchPending && !resolvedEpisode ? (currentSlot?.episodeId ?? null) : null
+
+  const sideNavigation = useMemo(() => {
+    if (!showRails || !isOpen) return undefined
+    return <ModalSideNavigation canGoPrev={canGoPrev} canGoNext={canGoNext} onPrevAction={handleGoPrev} onNextAction={handleGoNext} />
+  }, [showRails, isOpen, canGoPrev, canGoNext, handleGoPrev, handleGoNext])
+
+  const modalCtx = useMemo(
+    () => ({
+      resolvedEpisode,
+      resolvedLibraryItem,
+      fetchPending,
+      pendingEpisodeId,
+      syncResolvedEpisode
+    }),
+    [resolvedEpisode, resolvedLibraryItem, fetchPending, pendingEpisodeId, syncResolvedEpisode]
+  )
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      persistent={persistent}
+      zIndexClass={zIndexClass}
+      bgOpacityClass={bgOpacityClass}
+      className={className}
+      style={style}
+      outerContent={outerContent}
+      sideNavigation={sideNavigation}
+      processing={additionalProcessing}
+    >
+      <EpisodeModalContext.Provider value={modalCtx}>{children}</EpisodeModalContext.Provider>
+    </Modal>
+  )
+}

--- a/src/components/modals/EpisodeModal.tsx
+++ b/src/components/modals/EpisodeModal.tsx
@@ -30,9 +30,7 @@ export function useEpisodeModal(): EpisodeModalContextValue {
   return ctx
 }
 
-export type EpisodeModalItemSource =
-  | { navCtx: EpisodeNavigationContext }
-  | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode }
+export type EpisodeModalItemSource = { navCtx: EpisodeNavigationContext } | { libraryItem: PodcastLibraryItem; episode: PodcastEpisode }
 
 export type EpisodeModalProps = Omit<ModalProps, 'outerContent' | 'sideNavigation' | 'processing' | 'children'> &
   EpisodeModalItemSource & {
@@ -60,25 +58,26 @@ export default function EpisodeModal(props: EpisodeModalProps) {
 
   const { currentSlot, canGoPrev, canGoNext, goPrev, goNext } = useEpisodeNavigationContext(navCtx, isOpen)
 
+  const currentLibraryItemId = currentSlot?.libraryItemId ?? null
+  const currentEpisodeId = currentSlot?.episodeId ?? null
+
   useLayoutEffect(() => {
     if (!isOpen || !navCtxMode) return
-    if (!currentSlot) {
+    if (!currentLibraryItemId || !currentEpisodeId) {
       setFetchedEpisode(null)
       setFetchedLibraryItem(null)
       return
     }
 
-    const { libraryItemId, episodeId } = currentSlot
+    const libraryItemId = currentLibraryItemId
+    const episodeId = currentEpisodeId
     const gen = ++fetchGenRef.current
     setNavFetchPending(true)
     setFetchedEpisode(null)
 
     startNavTransition(async () => {
       try {
-        const [episode, libraryItem] = await Promise.all([
-          getPodcastEpisodeAction(libraryItemId, episodeId),
-          getExpandedLibraryItemAction(libraryItemId)
-        ])
+        const [episode, libraryItem] = await Promise.all([getPodcastEpisodeAction(libraryItemId, episodeId), getExpandedLibraryItemAction(libraryItemId)])
         if (fetchGenRef.current !== gen) return
         setFetchedEpisode(episode)
         setFetchedLibraryItem(libraryItem as PodcastLibraryItem)
@@ -94,7 +93,7 @@ export default function EpisodeModal(props: EpisodeModalProps) {
         }
       }
     })
-  }, [isOpen, navCtxMode, navCtx, currentSlot, onClose, showToast, startNavTransition, t])
+  }, [isOpen, navCtxMode, currentLibraryItemId, currentEpisodeId, onClose, showToast, startNavTransition, t])
 
   const resolvedEpisode = navCtxMode ? fetchedEpisode : (directEpisode ?? null)
   const resolvedLibraryItem = navCtxMode ? fetchedLibraryItem : (directLibraryItem ?? null)

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -105,52 +105,49 @@ export default function Modal({
     return () => document.removeEventListener('keydown', handleDocumentKeyDown)
   }, [isOpen, processing, persistent, onClose])
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      // Focus trap
-      if (e.key === 'Tab') {
-        if (!contentRef.current) return
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Focus trap
+    if (e.key === 'Tab') {
+      if (!contentRef.current) return
 
-        const focusableElements = contentRef.current.querySelectorAll<HTMLElement>(
-          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
-        )
+      const focusableElements = contentRef.current.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )
 
-        // If no focusable elements, keep focus on content container
-        if (focusableElements.length === 0) {
-          e.preventDefault()
-          contentRef.current.focus()
-          return
-        }
+      // If no focusable elements, keep focus on content container
+      if (focusableElements.length === 0) {
+        e.preventDefault()
+        contentRef.current.focus()
+        return
+      }
 
-        const firstElement = focusableElements[0]
-        const lastElement = focusableElements[focusableElements.length - 1]
+      const firstElement = focusableElements[0]
+      const lastElement = focusableElements[focusableElements.length - 1]
 
-        // Check if focus is within the modal
-        const isFocusInModal = contentRef.current.contains(document.activeElement)
+      // Check if focus is within the modal
+      const isFocusInModal = contentRef.current.contains(document.activeElement)
 
-        if (!isFocusInModal) {
-          // If focus somehow got outside, bring it back
-          e.preventDefault()
-          if (e.shiftKey) lastElement.focus()
-          else firstElement.focus()
+      if (!isFocusInModal) {
+        // If focus somehow got outside, bring it back
+        e.preventDefault()
+        if (e.shiftKey) lastElement.focus()
+        else firstElement.focus()
+      } else {
+        // Normal trap logic
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement || document.activeElement === contentRef.current) {
+            e.preventDefault()
+            lastElement.focus()
+          }
         } else {
-          // Normal trap logic
-          if (e.shiftKey) {
-            if (document.activeElement === firstElement || document.activeElement === contentRef.current) {
-              e.preventDefault()
-              lastElement.focus()
-            }
-          } else {
-            if (document.activeElement === lastElement) {
-              e.preventDefault()
-              firstElement.focus()
-            }
+          if (document.activeElement === lastElement) {
+            e.preventDefault()
+            firstElement.focus()
           }
         }
       }
-    },
-    []
-  )
+    }
+  }, [])
 
   if (!isOpen) {
     return null

--- a/src/components/modals/Modal.tsx
+++ b/src/components/modals/Modal.tsx
@@ -8,6 +8,8 @@ import { mergeClasses } from '@/lib/merge-classes'
 import React, { ReactNode, useCallback, useEffect, useRef } from 'react'
 import { createPortal } from 'react-dom'
 
+const MODAL_ROOT_SELECTOR = '[data-abs-modal]'
+
 export interface ModalProps {
   isOpen: boolean
   processing?: boolean
@@ -82,16 +84,29 @@ export default function Modal({
     }
   }, [isOpen])
 
+  // Close on Escape even when focus is outside the modal (e.g. after blurring a field
+  // or using episode prev/next navigation). Only the topmost nested modal should respond.
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleDocumentKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || processing || persistent) return
+
+      const modalWrappers = document.querySelectorAll(MODAL_ROOT_SELECTOR)
+      const topmostWrapper = modalWrappers[modalWrappers.length - 1]
+      if (topmostWrapper !== wrapperRef.current) return
+
+      e.preventDefault()
+      e.stopPropagation()
+      onClose?.()
+    }
+
+    document.addEventListener('keydown', handleDocumentKeyDown)
+    return () => document.removeEventListener('keydown', handleDocumentKeyDown)
+  }, [isOpen, processing, persistent, onClose])
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      // Escape key to close
-      if (e.key === 'Escape' && !processing && !persistent) {
-        e.preventDefault()
-        e.stopPropagation()
-        onClose?.()
-        return
-      }
-
       // Focus trap
       if (e.key === 'Tab') {
         if (!contentRef.current) return
@@ -134,7 +149,7 @@ export default function Modal({
         }
       }
     },
-    [processing, persistent, onClose]
+    []
   )
 
   if (!isOpen) {
@@ -146,6 +161,7 @@ export default function Modal({
       ref={wrapperRef}
       role="dialog"
       aria-modal="true"
+      data-abs-modal
       className={mergeClasses(
         'modal modal-bg fixed start-0 top-0 flex h-full w-full items-center justify-center overflow-x-hidden',
         zIndexClass,

--- a/src/components/modals/ViewEpisodeModal.tsx
+++ b/src/components/modals/ViewEpisodeModal.tsx
@@ -1,24 +1,32 @@
+'use client'
+
 import PreviewCover from '@/components/covers/PreviewCover'
-import Modal from '@/components/modals/Modal'
+import EpisodeModal, { useEpisodeModal, type EpisodeModalItemSource } from '@/components/modals/EpisodeModal'
+import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { formatDuration } from '@/lib/formatDuration'
 import { bytesPretty } from '@/lib/string'
-import { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
 import Link from 'next/link'
 import React, { useCallback, useMemo } from 'react'
 
-export interface ViewEpisodeModalProps {
+export type ViewEpisodeModalProps = {
   isOpen: boolean
   onClose: () => void
-  episode: PodcastEpisode | null
-  libraryItem: PodcastLibraryItem | null
+} & EpisodeModalItemSource
+
+type ViewEpisodeModalBodyProps = {
+  onClose: () => void
 }
 
-export default function ViewEpisodeModal({ isOpen, onClose, episode, libraryItem }: ViewEpisodeModalProps) {
+function ViewEpisodeModalBody({ onClose }: ViewEpisodeModalBodyProps) {
   const t = useTypeSafeTranslations()
   const { playItem } = useMediaContext()
+  const { resolvedEpisode, resolvedLibraryItem, fetchPending } = useEpisodeModal()
+
+  const episode = resolvedEpisode
+  const libraryItem = resolvedLibraryItem
 
   const coverUrl = libraryItem ? getLibraryItemCoverUrl(libraryItem.id, libraryItem.updatedAt) : ''
 
@@ -82,26 +90,25 @@ export default function ViewEpisodeModal({ isOpen, onClose, episode, libraryItem
     [episode, libraryItem, playItem, onClose]
   )
 
+  if (fetchPending && !episode) {
+    return (
+      <div className="flex min-h-[200px] items-center justify-center">
+        <LoadingIndicator variant="inline" />
+      </div>
+    )
+  }
+
   if (!episode || !libraryItem) return null
 
   const podcastHref = `/library/${libraryItem.libraryId}/item/${libraryItem.id}`
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      outerContent={
-        <div className="pointer-events-none absolute top-0 left-0 w-2/3 overflow-hidden p-5">
-          <p className="truncate text-3xl text-white">{t('LabelEpisode')}</p>
-        </div>
-      }
-      className="bg-bg relative max-h-[80vh] w-full overflow-y-auto rounded-lg p-4 text-sm shadow-lg"
-    >
+    <>
       <div className="mb-4 flex">
         <div className="relative h-12 w-12 flex-shrink-0">
           <PreviewCover src={coverUrl} fill bookCoverAspectRatio={1} showResolution={false} />
         </div>
-        <div className="grow min-w-0 px-2">
+        <div className="min-w-0 grow px-2">
           <Link
             href={podcastHref}
             className="focus-visible:outline-foreground-muted mb-1 inline-block max-w-full rounded-sm text-base underline focus-visible:outline-1 focus-visible:outline-offset-2 md:no-underline md:hover:underline"
@@ -146,6 +153,26 @@ export default function ViewEpisodeModal({ isOpen, onClose, episode, libraryItem
           <p className="mb-2 text-xs">{audioFileDuration}</p>
         </div>
       </div>
-    </Modal>
+    </>
+  )
+}
+
+/**
+ * Modal for viewing podcast episode details.
+ * Pass `navCtx` to load episodes and enable prev/next, or `libraryItem` + `episode` for direct mode.
+ */
+export default function ViewEpisodeModal(props: ViewEpisodeModalProps) {
+  const { isOpen, onClose } = props
+  const navCtxMode = 'navCtx' in props
+
+  return (
+    <EpisodeModal
+      isOpen={isOpen}
+      onClose={onClose}
+      {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem, episode: props.episode })}
+      className="bg-bg relative max-h-[80vh] w-full overflow-y-auto rounded-lg p-4 text-sm shadow-lg"
+    >
+      <ViewEpisodeModalBody onClose={onClose} />
+    </EpisodeModal>
   )
 }

--- a/src/components/modals/ViewEpisodeModal.tsx
+++ b/src/components/modals/ViewEpisodeModal.tsx
@@ -170,7 +170,7 @@ export default function ViewEpisodeModal(props: ViewEpisodeModalProps) {
       isOpen={isOpen}
       onClose={onClose}
       {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem, episode: props.episode })}
-      className="bg-bg relative max-h-[80vh] w-full overflow-y-auto rounded-lg p-4 text-sm shadow-lg"
+      className="bg-bg relative max-h-[80vh] w-[calc(100vw-1rem)] overflow-y-auto rounded-lg p-4 text-sm shadow-lg sm:w-[600px] md:w-[700px] lg:w-[800px]"
     >
       <ViewEpisodeModalBody onClose={onClose} />
     </EpisodeModal>

--- a/src/components/modals/ViewEpisodeModal.tsx
+++ b/src/components/modals/ViewEpisodeModal.tsx
@@ -6,6 +6,7 @@ import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { formatDuration } from '@/lib/formatDuration'
 import { bytesPretty } from '@/lib/string'
 import { PodcastEpisode, PodcastLibraryItem } from '@/types/api'
+import Link from 'next/link'
 import React, { useCallback, useMemo } from 'react'
 
 export interface ViewEpisodeModalProps {
@@ -83,6 +84,8 @@ export default function ViewEpisodeModal({ isOpen, onClose, episode, libraryItem
 
   if (!episode || !libraryItem) return null
 
+  const podcastHref = `/library/${libraryItem.libraryId}/item/${libraryItem.id}`
+
   return (
     <Modal
       isOpen={isOpen}
@@ -98,8 +101,14 @@ export default function ViewEpisodeModal({ isOpen, onClose, episode, libraryItem
         <div className="relative h-12 w-12 flex-shrink-0">
           <PreviewCover src={coverUrl} fill bookCoverAspectRatio={1} showResolution={false} />
         </div>
-        <div className="grow overflow-hidden px-2">
-          <p className="mb-1 truncate text-base">{podcastTitle}</p>
+        <div className="grow min-w-0 px-2">
+          <Link
+            href={podcastHref}
+            className="focus-visible:outline-foreground-muted mb-1 inline-block max-w-full rounded-sm text-base underline focus-visible:outline-1 focus-visible:outline-offset-2 md:no-underline md:hover:underline"
+            onClick={onClose}
+          >
+            <span className="block truncate">{podcastTitle}</span>
+          </Link>
           <p className="text-foreground-muted truncate text-xs">{podcastAuthor}</p>
         </div>
       </div>

--- a/src/components/ui/ContextMenuDropdown.tsx
+++ b/src/components/ui/ContextMenuDropdown.tsx
@@ -25,6 +25,7 @@ interface ContextMenuDropdownProps<T = string> {
   iconClass?: string
   menuWidth?: number
   processing?: boolean
+  isOpen?: boolean
   onAction?: (params: { action: string; data?: Record<string, T> }) => void
   onOpenChange?: (isOpen: boolean) => void
   menuAlign?: 'right' | 'left'
@@ -46,6 +47,7 @@ export default function ContextMenuDropdown<T = string>({
   iconClass = '',
   menuWidth = 96,
   processing = false,
+  isOpen: isOpenProp,
   onAction,
   onOpenChange,
   menuAlign = 'right',
@@ -57,7 +59,9 @@ export default function ContextMenuDropdown<T = string>({
   usePortal = false
 }: ContextMenuDropdownProps<T>) {
   const t = useTypeSafeTranslations()
-  const [showMenu, setShowMenu] = useState(false)
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false)
+  const isControlled = isOpenProp !== undefined
+  const showMenu = isControlled ? isOpenProp : uncontrolledOpen
   const menuWrapperRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<HTMLButtonElement>(null)
   const [openSubmenuIndex, setOpenSubmenuIndex] = useState<number | null>(null)
@@ -67,10 +71,19 @@ export default function ContextMenuDropdown<T = string>({
   // Generate unique ID for this dropdown instance
   const dropdownId = useId()
 
+  const setMenuOpen = useCallback(
+    (isOpen: boolean) => {
+      if (!isControlled) {
+        setUncontrolledOpen(isOpen)
+      }
+      onOpenChange?.(isOpen)
+    },
+    [isControlled, onOpenChange]
+  )
+
   // Helper functions to manage menu state
   const openMenu = (index: number = 0) => {
-    setShowMenu(true)
-    onOpenChange?.(true)
+    setMenuOpen(true)
     setFocusedIndex(index)
     setFocusedSubIndex(-1)
     setOpenSubmenuIndex(null)
@@ -78,12 +91,11 @@ export default function ContextMenuDropdown<T = string>({
 
   // Keep useCallback for closeMenu since it's used in useClickOutside hook dependency
   const closeMenu = useCallback(() => {
-    setShowMenu(false)
-    onOpenChange?.(false)
+    setMenuOpen(false)
     setFocusedIndex(-1)
     setFocusedSubIndex(-1)
     setOpenSubmenuIndex(null)
-  }, [onOpenChange])
+  }, [setMenuOpen])
 
   // Handle click outside to close menu
   useClickOutside(menuWrapperRef, buttonRef, closeMenu)

--- a/src/components/ui/InputWrapper.tsx
+++ b/src/components/ui/InputWrapper.tsx
@@ -56,7 +56,7 @@ const InputWrapper = ({
       <div className={wrapperClass} cy-id="control-wrapper" onClick={handleClick}>
         {children}
       </div>
-      {error && <div className="text-error mt-1 text-sm">{typeof error === 'string' ? error : 'Invalid value'}</div>}
+      {typeof error === 'string' && error && <div className="text-error mt-1 text-sm">{error}</div>}
     </>
   )
 }

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -23,6 +23,7 @@ export interface TextInputProps {
   min?: string | number
   customInputClass?: string
   wrapperClassName?: string
+  size?: 'small' | 'medium' | 'large' | 'auto'
   clearButtonClassName?: string
   enterKeyHint?: 'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'
   onChange?: (value: string) => void
@@ -51,6 +52,7 @@ export default function TextInput({
   min,
   customInputClass,
   wrapperClassName,
+  size = 'medium',
   clearButtonClassName,
   enterKeyHint,
   onChange,
@@ -166,6 +168,7 @@ export default function TextInput({
         readOnly={readOnly}
         error={error || isInvalidDate}
         inputRef={readInputRef}
+        size={size}
         className={mergeClasses('group', wrapperClassName)}
       >
         <input

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -78,19 +78,22 @@ export default function TextInput({
   const ariaLabel = label || placeholder || undefined
   const ariaInvalid = isInvalidDate
 
+  const isDatetimeLocal = type === 'datetime-local'
+
   const inputClass = mergeClasses(
-    'w-full bg-transparent px-1 outline-none border-none h-full',
+    'w-full bg-transparent outline-none border-none h-full',
     'disabled:cursor-not-allowed disabled:text-disabled read-only:text-read-only',
     // type="search" adds a native clear control in Blink/WebKit; hide it because we show our own
     actualType === 'search' &&
       '[&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden [&::-webkit-search-results-button]:hidden [&::-webkit-search-results-decoration]:hidden',
-    '[&::-webkit-calendar-picker-indicator]:invert',
-    showCopy ? 'ps-1 pe-8' : 'px-1',
+    isDatetimeLocal
+      ? 'ps-1 pe-8 [&::-webkit-calendar-picker-indicator]:hidden [&::-moz-calendar-picker-indicator]:hidden'
+      : mergeClasses('[&::-webkit-calendar-picker-indicator]:invert', showCopy ? 'ps-1 pe-8' : 'px-1'),
     customInputClass
   )
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (type === 'datetime-local') {
+    if (isDatetimeLocal) {
       setIsInvalidDate(Boolean(e.target.validity?.badInput))
     }
     onChange?.(e.target.value)
@@ -110,7 +113,7 @@ export default function TextInput({
   }
 
   const handleKeyUp = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (type === 'datetime-local') {
+    if (isDatetimeLocal) {
       if (e.currentTarget.validity?.badInput) {
         setIsInvalidDate(true)
       } else {
@@ -139,8 +142,16 @@ export default function TextInput({
     setShowPassword((prev) => !prev)
   }
 
+  const openDatePicker = () => {
+    const input = readInputRef.current
+    if (!input || disabled || readOnly) return
+    input.focus()
+    input.showPicker?.()
+  }
+
   // Show password toggle when it is a password field
   const shouldShowPasswordToggle = type === 'password'
+  const shouldShowDatePickerButton = isDatetimeLocal && !readOnly && !disabled
 
   return (
     <div className={mergeClasses('w-full', className)} cy-id="text-input">
@@ -221,6 +232,22 @@ export default function TextInput({
                   visibility_off
                 </span>
               )}
+            </button>
+          </div>
+        )}
+
+        {shouldShowDatePickerButton && (
+          <div className="absolute end-0 top-0 flex h-full items-center justify-center px-2">
+            <button
+              type="button"
+              className="text-foreground-muted hover:text-foreground focus:ring-foreground-muted flex cursor-pointer rounded text-lg focus:ring-2 focus:ring-offset-1 focus:outline-none"
+              onClick={openDatePicker}
+              aria-label={label || t('LabelDatetime')}
+              cy-id="text-input-date-picker"
+            >
+              <span className="material-symbols text-xl" aria-hidden="true">
+                calendar_today
+              </span>
             </button>
           </div>
         )}

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -32,7 +32,7 @@ export interface TextInputProps {
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void
   className?: string
   ref?: React.Ref<HTMLInputElement>
-  error?: string
+  error?: boolean | string
   autocomplete?: 'off' | 'username' | 'current-password' | 'new-password' | 'email' | 'tel' | string
 }
 
@@ -90,6 +90,9 @@ export default function TextInput({
   )
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (type === 'datetime-local') {
+      setIsInvalidDate(Boolean(e.target.validity?.badInput))
+    }
     onChange?.(e.target.value)
   }
 

--- a/src/components/widgets/EpisodeDetailsEdit.tsx
+++ b/src/components/widgets/EpisodeDetailsEdit.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import Dropdown, { DropdownItem } from '@/components/ui/Dropdown'
+import SlateEditor from '@/components/ui/SlateEditor'
+import TextareaInput from '@/components/ui/TextareaInput'
+import TextInput from '@/components/ui/TextInput'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { formatJsDate } from '@/lib/datefns'
+import type { PodcastEpisode, UpdatePodcastEpisodePayload } from '@/types/api'
+import { useCallback, useEffect, useImperativeHandle, useMemo, useReducer, useRef, useState } from 'react'
+
+type EpisodeDetails = {
+  season: string
+  episode: string
+  episodeType: string
+  title: string
+  subtitle: string
+  description: string
+  pubDate: string | null
+  publishedAt: number | null
+}
+
+function episodeToDetails(episode: PodcastEpisode): EpisodeDetails {
+  return {
+    season: episode.season || '',
+    episode: episode.episode || '',
+    episodeType: episode.episodeType || '',
+    title: episode.title || '',
+    subtitle: episode.subtitle || '',
+    description: episode.description || '',
+    pubDate: episode.pubDate || null,
+    publishedAt: episode.publishedAt ?? null
+  }
+}
+
+function pubDateToDatetimeLocal(pubDate: string | null | undefined): string {
+  if (!pubDate) return ''
+  const date = new Date(pubDate)
+  if (isNaN(date.getTime())) return ''
+  return formatJsDate(date, "yyyy-MM-dd'T'HH:mm")
+}
+
+function datetimeLocalToPubDate(value: string): { pubDate: string | null; publishedAt: number | null } {
+  if (!value) {
+    return { pubDate: null, publishedAt: null }
+  }
+  const date = new Date(value)
+  if (isNaN(date.getTime())) {
+    return { pubDate: null, publishedAt: null }
+  }
+  return {
+    pubDate: formatJsDate(date, 'E, d MMM yyyy HH:mm:ssxx'),
+    publishedAt: date.valueOf()
+  }
+}
+
+export type EpisodeDetailsEditRef = {
+  submit: () => boolean
+}
+
+export type EpisodeDetailsEditSubmitResult = {
+  updatePayload: UpdatePodcastEpisodePayload
+  hasChanges: boolean
+  invalidPubDate: boolean
+}
+
+interface EpisodeDetailsEditProps {
+  episode: PodcastEpisode
+  onChange?: (details: { episodeId: string; hasChanges: boolean }) => void
+  onSubmit?: (result: EpisodeDetailsEditSubmitResult) => void
+  ref?: React.Ref<EpisodeDetailsEditRef>
+}
+
+export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }: EpisodeDetailsEditProps) {
+  const t = useTypeSafeTranslations()
+  const pubDateInputRef = useRef<HTMLInputElement>(null)
+  const [pubDateInvalid, setPubDateInvalid] = useState(false)
+
+  const initial = useMemo(() => episodeToDetails(episode), [episode])
+
+  const [details, setDetails] = useReducer(
+    (state: EpisodeDetails, action: Partial<EpisodeDetails> | 'reset') => {
+      if (action === 'reset') return initial
+      return { ...state, ...action }
+    },
+    initial
+  )
+
+  const [pubDateInput, setPubDateInput] = useState(() => pubDateToDatetimeLocal(episode.pubDate))
+
+  useEffect(() => {
+    setDetails('reset')
+    setPubDateInput(pubDateToDatetimeLocal(episode.pubDate))
+    setPubDateInvalid(false)
+  }, [episode.id, initial, episode.pubDate])
+
+  const updateField = useCallback(<K extends keyof EpisodeDetails>(field: K, value: EpisodeDetails[K]) => {
+    setDetails({ [field]: value })
+  }, [])
+
+  const handlePubDateChange = useCallback((value: string) => {
+    setPubDateInput(value)
+    setPubDateInvalid(false)
+    const { pubDate, publishedAt } = datetimeLocalToPubDate(value)
+    setDetails({ pubDate, publishedAt })
+  }, [])
+
+  const getUpdatePayload = useCallback((): UpdatePodcastEpisodePayload => {
+    const payload: UpdatePodcastEpisodePayload = {}
+    const keys: (keyof EpisodeDetails)[] = ['season', 'episode', 'episodeType', 'title', 'subtitle', 'description', 'pubDate', 'publishedAt']
+    for (const key of keys) {
+      if (details[key] != initial[key]) {
+        const value = details[key]
+        if (value !== null && value !== undefined) {
+          ;(payload as Record<string, unknown>)[key] = value
+        }
+      }
+    }
+    return payload
+  }, [details, initial])
+
+  const hasChanges = useMemo(() => Object.keys(getUpdatePayload()).length > 0, [getUpdatePayload])
+
+  useEffect(() => {
+    onChange?.({ episodeId: episode.id, hasChanges })
+  }, [episode.id, hasChanges, onChange])
+
+  const submitForm = useCallback(() => {
+    const input = pubDateInputRef.current
+    const invalidPubDate = Boolean(pubDateInput && input?.validity?.badInput)
+    if (invalidPubDate) {
+      setPubDateInvalid(true)
+      onSubmit?.({ updatePayload: {}, hasChanges: false, invalidPubDate: true })
+      return false
+    }
+
+    const updatePayload = getUpdatePayload()
+    const result: EpisodeDetailsEditSubmitResult = {
+      updatePayload,
+      hasChanges: Object.keys(updatePayload).length > 0,
+      invalidPubDate: false
+    }
+    onSubmit?.(result)
+    return true
+  }, [getUpdatePayload, onSubmit, pubDateInput])
+
+  useImperativeHandle(ref, () => ({ submit: submitForm }), [submitForm])
+
+  const episodeTypeItems = useMemo<DropdownItem[]>(
+    () => [
+      { text: t('LabelFull'), value: 'full' },
+      { text: t('LabelTrailer'), value: 'trailer' },
+      { text: t('LabelBonus'), value: 'bonus' }
+    ],
+    [t]
+  )
+
+  const enclosureUrl = episode.enclosure?.url
+
+  return (
+    <form
+      className="w-full px-2 pt-4 pb-2 md:px-4"
+      onSubmit={(e) => {
+        e.preventDefault()
+        submitForm()
+      }}
+    >
+      <div className="-mx-1 flex flex-wrap">
+        <div className="w-1/5 p-1">
+          <TextInput value={details.season} onChange={(v) => updateField('season', v)} label={t('LabelSeason')} />
+        </div>
+        <div className="w-1/5 p-1">
+          <TextInput value={details.episode} onChange={(v) => updateField('episode', v)} label={t('LabelEpisode')} />
+        </div>
+        <div className="w-1/5 p-1">
+          <Dropdown
+            label={t('LabelEpisodeType')}
+            value={details.episodeType || 'full'}
+            items={episodeTypeItems}
+            onChange={(value) => updateField('episodeType', String(value))}
+          />
+        </div>
+        <div className="w-2/5 p-1">
+          <TextInput
+            ref={pubDateInputRef}
+            type="datetime-local"
+            value={pubDateInput}
+            onChange={handlePubDateChange}
+            label={t('LabelPubDate')}
+            error={pubDateInvalid ? t('ToastDateTimeInvalidOrIncomplete') : undefined}
+          />
+        </div>
+        <div className="mt-2 w-full p-1">
+          <TextInput value={details.title} onChange={(v) => updateField('title', v)} label={t('LabelTitle')} />
+        </div>
+        <div className="mt-2 w-full p-1">
+          <TextareaInput value={details.subtitle} onChange={(v) => updateField('subtitle', v)} label={t('LabelSubtitle')} rows={3} />
+        </div>
+        <div className="mt-2 w-full p-1">
+          <SlateEditor srcContent={initial.description || ''} onUpdate={(v) => updateField('description', v)} label={t('LabelDescription')} />
+        </div>
+      </div>
+
+      {enclosureUrl ? (
+        <div className="p-1 pt-4">
+          <TextInput value={enclosureUrl} readOnly label={t('LabelEpisodeUrlFromRssFeed')} className="text-xs" />
+        </div>
+      ) : (
+        <p className="text-foreground-muted p-1 pt-4 text-xs font-semibold">{t('LabelEpisodeNotLinkedToRssFeed')}</p>
+      )}
+    </form>
+  )
+}

--- a/src/components/widgets/EpisodeDetailsEdit.tsx
+++ b/src/components/widgets/EpisodeDetailsEdit.tsx
@@ -187,7 +187,7 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
             value={pubDateInput}
             onChange={handlePubDateChange}
             label={t('LabelPubDate')}
-            error={pubDateInvalid ? t('ToastDateTimeInvalidOrIncomplete') : undefined}
+            error={pubDateInvalid || undefined}
           />
         </div>
         <div className="mt-2 w-full p-1">

--- a/src/components/widgets/EpisodeDetailsEdit.tsx
+++ b/src/components/widgets/EpisodeDetailsEdit.tsx
@@ -78,13 +78,10 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
 
   const initial = useMemo(() => episodeToDetails(episode), [episode])
 
-  const [details, setDetails] = useReducer(
-    (state: EpisodeDetails, action: Partial<EpisodeDetails> | 'reset') => {
-      if (action === 'reset') return initial
-      return { ...state, ...action }
-    },
-    initial
-  )
+  const [details, setDetails] = useReducer((state: EpisodeDetails, action: Partial<EpisodeDetails> | 'reset') => {
+    if (action === 'reset') return initial
+    return { ...state, ...action }
+  }, initial)
 
   const [pubDateInput, setPubDateInput] = useState(() => pubDateToDatetimeLocal(episode.pubDate))
 

--- a/src/components/widgets/EpisodeDetailsEdit.tsx
+++ b/src/components/widgets/EpisodeDetailsEdit.tsx
@@ -166,13 +166,13 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
       }}
     >
       <div className="-mx-1 flex flex-wrap">
-        <div className="w-1/5 p-1">
+        <div className="w-1/2 p-1 md:w-1/5">
           <TextInput value={details.season} onChange={(v) => updateField('season', v)} label={t('LabelSeason')} />
         </div>
-        <div className="w-1/5 p-1">
+        <div className="w-1/2 p-1 md:w-1/5">
           <TextInput value={details.episode} onChange={(v) => updateField('episode', v)} label={t('LabelEpisode')} />
         </div>
-        <div className="w-1/5 p-1">
+        <div className="mt-2 w-28 p-1 md:mt-0 md:w-1/5">
           <Dropdown
             label={t('LabelEpisodeType')}
             value={details.episodeType || 'full'}
@@ -180,7 +180,7 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
             onChange={(value) => updateField('episodeType', String(value))}
           />
         </div>
-        <div className="w-2/5 p-1">
+        <div className="mt-2 min-w-0 flex-1 p-1 md:mt-0 md:w-2/5 md:flex-none">
           <TextInput
             ref={pubDateInputRef}
             type="datetime-local"

--- a/src/components/widgets/EpisodeMatch.tsx
+++ b/src/components/widgets/EpisodeMatch.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { searchPodcastEpisodeAction, updatePodcastEpisodeAction } from '@/app/actions/mediaActions'
+import Btn from '@/components/ui/Btn'
+import TextInput from '@/components/ui/TextInput'
+import Alert from '@/components/widgets/Alert'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { PodcastEpisode, PodcastLibraryItem, SearchPodcastEpisodeResult, UpdatePodcastEpisodePayload } from '@/types/api'
+import { formatDistanceToNow } from 'date-fns'
+import { useCallback, useEffect, useState, useTransition } from 'react'
+
+function getMatchUpdatePayload(episode: PodcastEpisode, matchData: SearchPodcastEpisodeResult): UpdatePodcastEpisodePayload {
+  const candidate = {
+    title: matchData.title || '',
+    subtitle: matchData.subtitle || '',
+    description: matchData.description || '',
+    episode: matchData.episode || '',
+    episodeType: matchData.episodeType || '',
+    season: matchData.season || '',
+    pubDate: matchData.pubDate || '',
+    publishedAt: matchData.publishedAt ?? undefined
+  }
+
+  const payload: UpdatePodcastEpisodePayload = {}
+  for (const key of Object.keys(candidate) as (keyof typeof candidate)[]) {
+    const value = candidate[key]
+    const current = episode[key as keyof PodcastEpisode]
+    if (value != current) {
+      ;(payload as Record<string, unknown>)[key] = value
+    }
+  }
+
+  const matchEnclosure = matchData.enclosure ?? null
+  const currentEnclosure = episode.enclosure ?? null
+  if (JSON.stringify(matchEnclosure) !== JSON.stringify(currentEnclosure)) {
+    payload.enclosure = matchEnclosure
+  }
+
+  return payload
+}
+
+interface EpisodeMatchProps {
+  libraryItem: PodcastLibraryItem
+  episode: PodcastEpisode
+  onEpisodeUpdated?: (episode: PodcastEpisode, libraryItem: PodcastLibraryItem) => void
+}
+
+export default function EpisodeMatch({ libraryItem, episode, onEpisodeUpdated }: EpisodeMatchProps) {
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+  const [episodeTitle, setEpisodeTitle] = useState(episode.title || '')
+  const [searchedTitle, setSearchedTitle] = useState<string | null>(null)
+  const [episodesFound, setEpisodesFound] = useState<SearchPodcastEpisodeResult[]>([])
+  const [isSearchPending, startSearchTransition] = useTransition()
+  const [isApplyPending, startApplyTransition] = useTransition()
+
+  const podcastFeedUrl = libraryItem.media.metadata.feedUrl
+  const isProcessing = isSearchPending || isApplyPending
+
+  useEffect(() => {
+    setEpisodeTitle(episode.title || '')
+    setSearchedTitle(null)
+    setEpisodesFound([])
+  }, [episode.id, episode.title])
+
+  const handleSearch = useCallback(
+    (e?: React.FormEvent) => {
+      e?.preventDefault()
+      if (!episodeTitle.trim()) {
+        showToast(t('ToastTitleRequired'), { type: 'error' })
+        return
+      }
+
+      setSearchedTitle(episodeTitle)
+      startSearchTransition(async () => {
+        try {
+          const results = await searchPodcastEpisodeAction(libraryItem.id, episodeTitle)
+          setEpisodesFound(results.episodes)
+        } catch (error) {
+          console.error('Failed to search for episode', error)
+          showToast(t('ToastFailedToUpdate'), { type: 'error' })
+        }
+      })
+    },
+    [episodeTitle, libraryItem.id, showToast, t]
+  )
+
+  const handleSelectEpisode = useCallback(
+    (matchData: SearchPodcastEpisodeResult) => {
+      const updatePayload = getMatchUpdatePayload(episode, matchData)
+      if (!Object.keys(updatePayload).length) {
+        showToast(t('ToastNoUpdatesNecessary'), { type: 'info' })
+        return
+      }
+
+      startApplyTransition(async () => {
+        try {
+          const updatedLibraryItem = await updatePodcastEpisodeAction(libraryItem.id, episode.id, updatePayload)
+          const updatedEpisode = updatedLibraryItem.media.episodes?.find((ep) => ep.id === episode.id)
+          showToast(t('ToastPodcastEpisodeUpdated'), { type: 'success' })
+          if (updatedEpisode) {
+            onEpisodeUpdated?.(updatedEpisode, updatedLibraryItem)
+          }
+        } catch (error) {
+          console.error('Failed to update episode', error)
+          showToast(t('ToastFailedToUpdate'), { type: 'error' })
+        }
+      })
+    },
+    [episode, libraryItem.id, onEpisodeUpdated, showToast, t]
+  )
+
+  if (!podcastFeedUrl) {
+    return (
+      <div className="py-8">
+        <Alert type="error">{t('MessagePodcastHasNoRSSFeedForMatching')}</Alert>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-[200px] px-2 py-4 md:px-4">
+      <form onSubmit={handleSearch} className="mb-2 flex items-end gap-1">
+        <TextInput value={episodeTitle} onChange={setEpisodeTitle} disabled={isProcessing} label={t('LabelEpisodeTitle')} className="grow" />
+        <Btn type="submit" className="shrink-0" loading={isSearchPending} disabled={isProcessing}>
+          {t('ButtonSearch')}
+        </Btn>
+      </form>
+
+      {!isProcessing && searchedTitle && episodesFound.length === 0 && <p className="py-8 text-center text-lg">{t('MessageNoEpisodeMatchesFound')}</p>}
+
+      {episodesFound.length > 0 && (
+        <div className="mt-4 flex flex-col gap-2">
+          {episodesFound.map((result, index) => (
+            <button
+              key={`${result.guid ?? result.title}-${index}`}
+              type="button"
+              disabled={isProcessing}
+              className="border-border hover:bg-bg-hover/50 focus:border-foreground w-full cursor-pointer rounded border p-3 text-start outline-none disabled:cursor-not-allowed disabled:opacity-60"
+              onClick={() => handleSelectEpisode(result)}
+            >
+              {result.episode && <p className="text-foreground font-semibold">#{result.episode}</p>}
+              <p className="mb-1 break-words">{result.title}</p>
+              {result.subtitle && <p className="text-foreground-muted mb-1 line-clamp-2 text-sm">{result.subtitle}</p>}
+              <p className="text-foreground-subdued text-xs">
+                Published {result.publishedAt ? formatDistanceToNow(new Date(result.publishedAt), { addSuffix: true }) : 'Unknown'}
+              </p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/widgets/EpisodeRow.tsx
+++ b/src/components/widgets/EpisodeRow.tsx
@@ -178,7 +178,7 @@ export default function EpisodeRow({
               }}
               onClick={(e) => e.stopPropagation()}
             >
-              <Checkbox value={isSelected} onChange={(checked) => onSelect(episode, checked)} />
+              <Checkbox value={isSelected} checkboxBgClass="bg-primary" onChange={(checked) => onSelect(episode, checked)} />
             </div>
           </div>
 

--- a/src/components/widgets/EpisodeRow.tsx
+++ b/src/components/widgets/EpisodeRow.tsx
@@ -28,6 +28,7 @@ export interface EpisodeRowProps {
   onToggleFinished: (episode: PodcastEpisode) => void
   onSelect: (episode: PodcastEpisode, isSelected: boolean) => void
   onEdit?: (episode: PodcastEpisode) => void
+  onMatch?: (episode: PodcastEpisode) => void
   onRemove?: (episode: PodcastEpisode, hardDelete: boolean) => void
   onDownloadFile?: (episode: PodcastEpisode) => void
   onShowMoreInfo?: (episode: PodcastEpisode) => void
@@ -49,11 +50,11 @@ export default function EpisodeRow({
   onToggleFinished,
   onSelect,
   onEdit,
+  onMatch,
   onRemove,
   onDownloadFile,
   onShowMoreInfo,
   onAddToPlaylist,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   rowIndex
 }: EpisodeRowProps) {
   const t = useTypeSafeTranslations()
@@ -63,10 +64,11 @@ export default function EpisodeRow({
 
   const contextMenuItems = useMemo(() => {
     const items: ContextMenuDropdownItem[] = []
+    if (userCanUpdate && onMatch) items.push({ text: t('HeaderMatch'), action: 'match' })
     if (userCanDownload) items.push({ text: t('LabelDownload'), action: 'download' })
     if (userIsAdminOrUp && episode.audioFile) items.push({ text: t('LabelMoreInfo'), action: 'more' })
     return items
-  }, [userCanDownload, userIsAdminOrUp, episode.audioFile, t])
+  }, [userCanDownload, userCanUpdate, userIsAdminOrUp, episode.audioFile, onMatch, t])
 
   const closeConfirm = () => setConfirmState(null)
 
@@ -235,14 +237,15 @@ export default function EpisodeRow({
                 </IconBtn>
               )}
 
-              {episode.audioFile && contextMenuItems.length > 0 && (
+              {contextMenuItems.length > 0 && (
                 <div onClick={(e) => e.stopPropagation()} className="flex-shrink-0">
                   <ContextMenuDropdown
                     items={contextMenuItems}
                     autoWidth
                     borderless
                     onAction={({ action }) => {
-                      if (action === 'download') onDownloadFile?.(episode)
+                      if (action === 'match') onMatch?.(episode)
+                      else if (action === 'download') onDownloadFile?.(episode)
                       else if (action === 'more') onShowMoreInfo?.(episode)
                     }}
                     usePortal

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -156,8 +156,8 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   }, [])
 
   const editedEpisodeNavCtx = useMemo(
-    () => (editedEpisode ? getPodcastEpisodeNavigationContext(filteredEpisodes, editedEpisode.id) : null),
-    [editedEpisode, filteredEpisodes]
+    () => (editedEpisode ? getPodcastEpisodeNavigationContext(libraryItem.id, filteredEpisodes, editedEpisode.id) : null),
+    [editedEpisode, filteredEpisodes, libraryItem.id]
   )
 
   const handleFindEpisodes = useCallback(() => {
@@ -388,8 +388,8 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
       </div>
 
       <ViewEpisodeModal isOpen={isViewEpisodeModalOpen} onClose={handleCloseViewModal} episode={viewedEpisode} libraryItem={libraryItem} />
-      {editedEpisode && (
-        <EpisodeEditModal isOpen libraryItem={libraryItem} episode={editedEpisode} navCtx={editedEpisodeNavCtx ?? undefined} onClose={handleCloseEditModal} />
+      {editedEpisode && editedEpisodeNavCtx && (
+        <EpisodeEditModal isOpen navCtx={editedEpisodeNavCtx} onClose={handleCloseEditModal} />
       )}
       <AudioFileDataModal isOpen={!!audioFileToShow} audioFile={audioFileToShow} libraryItemId={libraryItem.id} onClose={closeMoreInfo} />
       <EpisodeFeedModal

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -3,8 +3,8 @@
 import { batchUpdateMediaFinishedAction, deleteLibraryItemMediaEpisodeAction, fetchPodcastFeedAction, toggleFinishedAction } from '@/app/actions/mediaActions'
 import AudioFileDataModal from '@/components/modals/AudioFileDataModal'
 import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
-import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import EpisodeFeedModal from '@/components/modals/EpisodeFeedModal'
+import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
 import EpisodeRow, { EPISODE_ROW_HEIGHT_PX } from '@/components/widgets/EpisodeRow'
 import EpisodeTableHeaderActions from '@/components/widgets/EpisodeTableHeaderActions'
@@ -17,8 +17,8 @@ import { useEpisodeFilterAndSort } from '@/hooks/useEpisodeFilterAndSort'
 import { useEpisodeTableVirtualizer } from '@/hooks/useEpisodeTableVirtualizer'
 import { useLibraryFileActions } from '@/hooks/useLibraryFileActions'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { buildPodcastEpisodeProgressMap } from '@/lib/mediaProgress'
 import { getPodcastEpisodeNavigationContext } from '@/lib/episodeEditNavigation'
+import { buildPodcastEpisodeProgressMap } from '@/lib/mediaProgress'
 import { PodcastEpisode, PodcastEpisodeDownload, PodcastLibraryItem, RssPodcastEpisode } from '@/types/api'
 import { useCallback, useMemo, useState, useTransition } from 'react'
 
@@ -76,8 +76,6 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
     }
     setViewedEpisode(null)
   }, [viewedEpisode])
-
-  const isViewEpisodeModalOpen = viewedEpisode !== null
 
   // Virtualizer — lazy render only visible rows
   const { visibleStart, visibleEnd, totalHeight, listContainerRef } = useEpisodeTableVirtualizer(filteredEpisodes.length, EPISODE_ROW_HEIGHT_PX)
@@ -173,6 +171,11 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   const matchedEpisodeNavCtx = useMemo(
     () => (matchedEpisode ? getPodcastEpisodeNavigationContext(libraryItem.id, filteredEpisodes, matchedEpisode.id) : null),
     [matchedEpisode, filteredEpisodes, libraryItem.id]
+  )
+
+  const viewedEpisodeNavCtx = useMemo(
+    () => (viewedEpisode ? getPodcastEpisodeNavigationContext(libraryItem.id, filteredEpisodes, viewedEpisode.id) : null),
+    [viewedEpisode, filteredEpisodes, libraryItem.id]
   )
 
   const handleFindEpisodes = useCallback(() => {
@@ -403,13 +406,9 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
         </div>
       </div>
 
-      <ViewEpisodeModal isOpen={isViewEpisodeModalOpen} onClose={handleCloseViewModal} episode={viewedEpisode} libraryItem={libraryItem} />
-      {editedEpisode && editedEpisodeNavCtx && (
-        <EpisodeEditModal isOpen navCtx={editedEpisodeNavCtx} onClose={handleCloseEditModal} />
-      )}
-      {matchedEpisode && matchedEpisodeNavCtx && (
-        <EpisodeMatchModal isOpen navCtx={matchedEpisodeNavCtx} onClose={handleCloseMatchModal} />
-      )}
+      {viewedEpisode && viewedEpisodeNavCtx && <ViewEpisodeModal isOpen navCtx={viewedEpisodeNavCtx} onClose={handleCloseViewModal} />}
+      {editedEpisode && editedEpisodeNavCtx && <EpisodeEditModal isOpen navCtx={editedEpisodeNavCtx} onClose={handleCloseEditModal} />}
+      {matchedEpisode && matchedEpisodeNavCtx && <EpisodeMatchModal isOpen navCtx={matchedEpisodeNavCtx} onClose={handleCloseMatchModal} />}
       <AudioFileDataModal isOpen={!!audioFileToShow} audioFile={audioFileToShow} libraryItemId={libraryItem.id} onClose={closeMoreInfo} />
       <EpisodeFeedModal
         isOpen={isEpisodeFeedModalOpen}

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -19,6 +19,7 @@ import { useLibraryFileActions } from '@/hooks/useLibraryFileActions'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getPodcastEpisodeNavigationContext } from '@/lib/episodeEditNavigation'
 import { buildPodcastEpisodeProgressMap } from '@/lib/mediaProgress'
+import { mergeClasses } from '@/lib/merge-classes'
 import { PodcastEpisode, PodcastEpisodeDownload, PodcastLibraryItem, RssPodcastEpisode } from '@/types/api'
 import { useCallback, useMemo, useState, useTransition } from 'react'
 
@@ -300,25 +301,31 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   )
 
   const isFiltered = hasMounted && filteredEpisodes.length !== episodes.length
-  const count = !isFiltered && hasMounted ? episodes.length : undefined
-  const badge = isFiltered ? `${filteredEpisodes.length} / ${episodes.length}` : undefined
+  const episodeCountLabel = hasMounted
+    ? isFiltered
+      ? `${filteredEpisodes.length} / ${episodes.length}`
+      : episodes.length > 0
+        ? String(episodes.length)
+        : ''
+    : ''
+  const useCompactEpisodeCount = episodeCountLabel.length >= 8
 
   const headerNode = (
     <div className="mb-4 flex w-full items-center px-1 pt-1">
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <p className="text-xl font-medium">{t('HeaderEpisodes')}</p>
-        {count !== undefined && count > 0 && (
-          <div className="bg-foreground/10 flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full">
-            <span className="font-mono text-sm">{count}</span>
-          </div>
-        )}
-        {badge && (
-          <div className="bg-foreground/10 flex h-6 items-center justify-center rounded-full px-3 text-sm">
-            <span className="font-mono">{badge}</span>
+        {episodeCountLabel && (
+          <div
+            className={mergeClasses(
+              'bg-foreground/10 flex shrink-0 items-center justify-center rounded-full font-mono whitespace-nowrap',
+              useCompactEpisodeCount ? 'h-5 px-2 text-xs' : isFiltered ? 'h-6 px-3 text-sm' : 'h-7 w-7 text-sm'
+            )}
+          >
+            {episodeCountLabel}
           </div>
         )}
       </div>
-      {headerActions && <div className="m-0 flex items-center gap-2">{headerActions}</div>}
+      {headerActions && <div className="flex shrink-0 items-center gap-2">{headerActions}</div>}
     </div>
   )
 

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -3,6 +3,7 @@
 import { batchUpdateMediaFinishedAction, deleteLibraryItemMediaEpisodeAction, fetchPodcastFeedAction, toggleFinishedAction } from '@/app/actions/mediaActions'
 import AudioFileDataModal from '@/components/modals/AudioFileDataModal'
 import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
+import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import EpisodeFeedModal from '@/components/modals/EpisodeFeedModal'
 import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
 import EpisodeRow, { EPISODE_ROW_HEIGHT_PX } from '@/components/widgets/EpisodeRow'
@@ -56,6 +57,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   const [selectedEpisodes, setSelectedEpisodes] = useState<Set<string>>(new Set())
   const [viewedEpisode, setViewedEpisode] = useState<PodcastEpisode | null>(null)
   const [editedEpisode, setEditedEpisode] = useState<PodcastEpisode | null>(null)
+  const [matchedEpisode, setMatchedEpisode] = useState<PodcastEpisode | null>(null)
 
   const { downloadFile, showMoreInfo, audioFileToShow, closeMoreInfo } = useLibraryFileActions(libraryItem.id)
 
@@ -155,9 +157,22 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
     setEditedEpisode(null)
   }, [])
 
+  const handleMatchEpisode = useCallback((episode: PodcastEpisode) => {
+    setMatchedEpisode(episode)
+  }, [])
+
+  const handleCloseMatchModal = useCallback(() => {
+    setMatchedEpisode(null)
+  }, [])
+
   const editedEpisodeNavCtx = useMemo(
     () => (editedEpisode ? getPodcastEpisodeNavigationContext(libraryItem.id, filteredEpisodes, editedEpisode.id) : null),
     [editedEpisode, filteredEpisodes, libraryItem.id]
+  )
+
+  const matchedEpisodeNavCtx = useMemo(
+    () => (matchedEpisode ? getPodcastEpisodeNavigationContext(libraryItem.id, filteredEpisodes, matchedEpisode.id) : null),
+    [matchedEpisode, filteredEpisodes, libraryItem.id]
   )
 
   const handleFindEpisodes = useCallback(() => {
@@ -373,6 +388,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
                     onToggleFinished={handleToggleFinished}
                     onSelect={handleSelectEpisode}
                     onEdit={handleEditEpisode}
+                    onMatch={handleMatchEpisode}
                     onRemove={handleRemoveEpisode}
                     onDownloadFile={handleDownloadFile}
                     onShowMoreInfo={handleShowMoreInfo}
@@ -390,6 +406,9 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
       <ViewEpisodeModal isOpen={isViewEpisodeModalOpen} onClose={handleCloseViewModal} episode={viewedEpisode} libraryItem={libraryItem} />
       {editedEpisode && editedEpisodeNavCtx && (
         <EpisodeEditModal isOpen navCtx={editedEpisodeNavCtx} onClose={handleCloseEditModal} />
+      )}
+      {matchedEpisode && matchedEpisodeNavCtx && (
+        <EpisodeMatchModal isOpen navCtx={matchedEpisodeNavCtx} onClose={handleCloseMatchModal} />
       )}
       <AudioFileDataModal isOpen={!!audioFileToShow} audioFile={audioFileToShow} libraryItemId={libraryItem.id} onClose={closeMoreInfo} />
       <EpisodeFeedModal

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -6,6 +6,7 @@ import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
 import EpisodeFeedModal from '@/components/modals/EpisodeFeedModal'
 import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
+import ConfirmDialog, { type ConfirmState } from '@/components/widgets/ConfirmDialog'
 import EpisodeRow, { EPISODE_ROW_HEIGHT_PX } from '@/components/widgets/EpisodeRow'
 import EpisodeTableHeaderActions from '@/components/widgets/EpisodeTableHeaderActions'
 import EpisodeTableToolbar from '@/components/widgets/EpisodeTableToolbar'
@@ -42,6 +43,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   const [, startTransition] = useTransition()
 
   const [isEpisodeFeedModalOpen, setIsEpisodeFeedModalOpen] = useState(false)
+  const [batchMarkConfirmState, setBatchMarkConfirmState] = useState<ConfirmState | null>(null)
   const [podcastFeedEpisodes, setPodcastFeedEpisodes] = useState<RssPodcastEpisode[]>([])
   const [fetchingRSSFeed, startFetchingRSSTransition] = useTransition()
 
@@ -258,23 +260,31 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
       } else if (action === 'batch-mark-as-finished') {
         const markState = !allEpisodesFinished
 
-        startTransition(async () => {
-          try {
-            await batchUpdateMediaFinishedAction(
-              filteredEpisodes.map((episode) => ({
-                libraryItemId: libraryItem.id,
-                episodeId: episode.id,
-                isFinished: markState
-              }))
-            )
-          } catch (error) {
-            console.error('Failed to batch mark episodes finished state', error)
-            showToast(t('ToastFailedToUpdate'), { type: 'error' })
+        setBatchMarkConfirmState({
+          isOpen: true,
+          message: markState ? t('MessageConfirmMarkAllEpisodesFinished') : t('MessageConfirmMarkAllEpisodesNotFinished'),
+          onConfirm: () => {
+            setBatchMarkConfirmState(null)
+            startTransition(async () => {
+              try {
+                await batchUpdateMediaFinishedAction(
+                  episodes.map((episode) => ({
+                    libraryItemId: libraryItem.id,
+                    episodeId: episode.id,
+                    isFinished: markState
+                  }))
+                )
+                showToast(t('ToastBatchUpdateSuccess'), { type: 'success' })
+              } catch (error) {
+                console.error('Failed to batch mark episodes finished state', error)
+                showToast(t('ToastBatchUpdateFailed'), { type: 'error' })
+              }
+            })
           }
         })
       }
     },
-    [allEpisodesFinished, filteredEpisodes, libraryItem.id, showToast, t]
+    [allEpisodesFinished, episodes, libraryItem.id, showToast, t]
   )
 
   const allSelectedEpisodesFinished = useMemo(() => {
@@ -425,6 +435,14 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
         downloadQueue={episodeDownloadsQueued}
         episodesDownloading={episodesDownloading}
       />
+      {batchMarkConfirmState && (
+        <ConfirmDialog
+          isOpen={batchMarkConfirmState.isOpen}
+          message={batchMarkConfirmState.message}
+          onClose={() => setBatchMarkConfirmState(null)}
+          onConfirm={() => batchMarkConfirmState.onConfirm()}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/widgets/EpisodeTableToolbar.tsx
+++ b/src/components/widgets/EpisodeTableToolbar.tsx
@@ -35,16 +35,20 @@ export default function EpisodeTableToolbar({
   return (
     <div
       className={mergeClasses(
-        'border-border bg-bg-elevated flex flex-wrap items-center gap-2 border-b px-1 py-2 transition-opacity',
+        'border-border bg-bg-elevated flex flex-col gap-2 border-b px-1 py-2 transition-opacity md:flex-row md:flex-wrap md:items-center',
         isSelectionMode ? 'pointer-events-none opacity-50' : ''
       )}
     >
       <TextInput value={search} onChange={onSearchChange} type="search" placeholder={t('PlaceholderSearchEpisode')} className="w-full md:w-auto md:grow" />
 
-      <EpisodesFilterSelect value={filterKey} onChange={onFilterChange} className="w-32" />
-      <EpisodesSortSelect sortBy={sortKey} sortDesc={sortDesc} onChange={onSortChange} className="w-38" />
+      <div className="flex w-full min-w-0 flex-nowrap items-center gap-2 md:contents">
+        <EpisodesFilterSelect value={filterKey} onChange={onFilterChange} className="w-32 min-w-0 md:w-32" />
+        <EpisodesSortSelect sortBy={sortKey} sortDesc={sortDesc} onChange={onSortChange} className="w-30 min-w-0 md:w-38" />
 
-      <ContextMenuDropdown size="small" items={contextMenuItems} onAction={({ action }) => onContextMenuAction(action)} autoWidth className="ms-auto md:ms-0" />
+        <div className="ms-auto shrink-0 md:contents">
+          <ContextMenuDropdown size="small" items={contextMenuItems} onAction={({ action }) => onContextMenuAction(action)} autoWidth />
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/components/widgets/EpisodeTableToolbar.tsx
+++ b/src/components/widgets/EpisodeTableToolbar.tsx
@@ -39,7 +39,14 @@ export default function EpisodeTableToolbar({
         isSelectionMode ? 'pointer-events-none opacity-50' : ''
       )}
     >
-      <TextInput value={search} onChange={onSearchChange} type="search" placeholder={t('PlaceholderSearchEpisode')} className="w-full md:w-auto md:grow" />
+      <TextInput
+        value={search}
+        onChange={onSearchChange}
+        type="search"
+        size="small"
+        placeholder={t('PlaceholderSearchEpisode')}
+        className="w-full md:w-auto md:grow"
+      />
 
       <div className="flex w-full min-w-0 flex-nowrap items-center gap-2 md:contents">
         <EpisodesFilterSelect value={filterKey} onChange={onFilterChange} className="w-32 min-w-0 md:w-32" />

--- a/src/components/widgets/EpisodeTableToolbar.tsx
+++ b/src/components/widgets/EpisodeTableToolbar.tsx
@@ -44,6 +44,7 @@ export default function EpisodeTableToolbar({
         onChange={onSearchChange}
         type="search"
         size="small"
+        clearable
         placeholder={t('PlaceholderSearchEpisode')}
         className="w-full md:w-auto md:grow"
       />

--- a/src/components/widgets/EpisodesFilterSelect.tsx
+++ b/src/components/widgets/EpisodesFilterSelect.tsx
@@ -35,10 +35,11 @@ export default function EpisodesFilterSelect({ value, onChange, disabled, classN
         value={value}
         items={filterItems}
         onChange={(val) => onChange(String(val))}
-        size="auto"
-        className="h-9 text-xs"
+        size="small"
+        className="text-xs [&_button]:text-xs"
         displayText={currentLabel}
         disabled={disabled}
+        rightIcon={<span className="material-symbols text-xl">expand_more</span>}
       />
     </div>
   )

--- a/src/components/widgets/EpisodesSortSelect.tsx
+++ b/src/components/widgets/EpisodesSortSelect.tsx
@@ -56,7 +56,7 @@ export default function EpisodesSortSelect({ sortBy, sortDesc, onChange, disable
   }
 
   const rightIcon = (
-    <span className="material-symbols text-lg text-yellow-400" aria-label={sortDesc ? t('LabelSortDescending') : t('LabelSortAscending')}>
+    <span className="material-symbols text-xl text-yellow-400" aria-label={sortDesc ? t('LabelSortDescending') : t('LabelSortAscending')}>
       {sortDesc ? 'expand_more' : 'expand_less'}
     </span>
   )
@@ -67,9 +67,9 @@ export default function EpisodesSortSelect({ sortBy, sortDesc, onChange, disable
         value={sortBy}
         items={displayItems}
         onChange={handleSortChange}
-        size="auto"
+        size="small"
         rightIcon={rightIcon}
-        className="h-9 text-xs"
+        className="text-xs [&_button]:text-xs"
         highlightSelected={true}
         menuMaxHeight="none"
         disabled={disabled}

--- a/src/components/widgets/SortableBookshelf.tsx
+++ b/src/components/widgets/SortableBookshelf.tsx
@@ -6,7 +6,7 @@ import SortableBookshelfCard from '@/components/widgets/media-card/SortableBooks
 import { getSortableBookshelfItemOrderBy } from '@/contexts/SortableBookshelfOverlayContext'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { BookshelfEntity, BookshelfView, MediaProgress } from '@/types/api'
+import type { BookshelfView, MediaProgress, PlaylistItem } from '@/types/api'
 import type { SortableBookshelfEntry } from '@/types/compilation'
 import {
   closestCenter,
@@ -22,7 +22,7 @@ import {
   type KeyboardCodes
 } from '@dnd-kit/core'
 import { arrayMove, rectSortingStrategy, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
-import { useCallback, useMemo, useRef, useState, useTransition } from 'react'
+import { useCallback, useId, useMemo, useRef, useState, useTransition } from 'react'
 
 const itemsConfig = ENTITY_CONFIGS.items
 
@@ -71,6 +71,7 @@ export default function SortableBookshelf({
   mediaItemProgressMap,
   isPodcastLibrary = false
 }: SortableBookshelfProps) {
+  const dndContextId = useId()
   const t = useTypeSafeTranslations()
   const dragOverlayCardOptions = useMemo(
     (): SortableBookshelfCardOptions => ({
@@ -95,7 +96,16 @@ export default function SortableBookshelf({
 
   const itemIds = useMemo(() => entries.map((e) => e.sortableId), [entries])
 
-  const shelfEntitiesDense = useMemo(() => entries.map((e) => e.libraryItem) as unknown as (BookshelfEntity | null)[], [entries])
+  const shelfEntitiesDense = useMemo(
+    (): PlaylistItem[] =>
+      entries.map((entry) => ({
+        libraryItemId: entry.libraryItem.id,
+        libraryItem: entry.libraryItem,
+        episodeId: entry.episode?.id,
+        episode: entry.episode
+      })),
+    [entries]
+  )
 
   const handleDragStart = useCallback((event: DragStartEvent) => {
     setActiveId(String(event.active.id))
@@ -146,7 +156,7 @@ export default function SortableBookshelf({
   )
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
+    <DndContext id={dndContextId} sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
       <SortableContext items={itemIds} strategy={rectSortingStrategy}>
         <div className="grid w-full max-w-full min-w-0 pt-4" style={gridStyle}>
           {entries.map((entry, entityIndex) => (

--- a/src/components/widgets/SortableBookshelf.tsx
+++ b/src/components/widgets/SortableBookshelf.tsx
@@ -156,7 +156,14 @@ export default function SortableBookshelf({
   )
 
   return (
-    <DndContext id={dndContextId} sensors={sensors} collisionDetection={closestCenter} onDragStart={handleDragStart} onDragEnd={handleDragEnd} onDragCancel={handleDragCancel}>
+    <DndContext
+      id={dndContextId}
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
       <SortableContext items={itemIds} strategy={rectSortingStrategy}>
         <div className="grid w-full max-w-full min-w-0 pt-4" style={gridStyle}>
           {entries.map((entry, entityIndex) => (

--- a/src/components/widgets/SortableList.tsx
+++ b/src/components/widgets/SortableList.tsx
@@ -23,7 +23,7 @@ import {
 import { arrayMove, SortableContext, sortableKeyboardCoordinates, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import type { CSSProperties, KeyboardEvent, KeyboardEventHandler } from 'react'
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 
 const VERTICAL_ARROW_CODES = new Set(['ArrowUp', 'ArrowDown'])
 
@@ -207,6 +207,7 @@ export default function SortableList<T extends SortableItem>({
   disabled = false,
   isItemDisabled
 }: SortableListProps<T>) {
+  const dndContextId = useId()
   const [activeId, setActiveId] = useState<string | null>(null)
 
   const itemsWithIds = useMemo(
@@ -263,6 +264,7 @@ export default function SortableList<T extends SortableItem>({
 
   return (
     <DndContext
+      id={dndContextId}
       sensors={sensors}
       collisionDetection={closestCenter}
       modifiers={[restrictSortableListToVerticalAxis]}

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -17,14 +17,16 @@ import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useCompilationListRowLayout } from '@/hooks/useCompilationListRowLayout'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { getMediaCardModalNavigationContext, type EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
+import { getMediaCardModalNavigationContext } from '@/lib/bookshelfNavigationContext'
+import { getMediaCardEpisodeEditNavigationContext } from '@/lib/episodeEditNavigation'
 import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
+import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import { DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH, DRAG_HANDLE_GRAB_CURSOR } from '@/lib/dragHandleClasses'
 import { formatDuration } from '@/lib/formatDuration'
 import { buildMediaItemProgressMap, buildPodcastEpisodeProgressMap, getLibraryItemProgressFromMap } from '@/lib/mediaProgress'
 import { mergeClasses } from '@/lib/merge-classes'
 import { getEpisodeDuration, getPlaylistItemDuration } from '@/lib/playlistItems'
-import type { BookshelfEntity, LibraryItem, PodcastEpisode } from '@/types/api'
+import type { LibraryItem, PodcastEpisode } from '@/types/api'
 import { isBookMedia, isBookMetadata, isPodcastMedia } from '@/types/api'
 import Link from 'next/link'
 import { useCallback, useMemo, useState, useTransition } from 'react'
@@ -40,8 +42,7 @@ interface CompilationItemListRowProps {
   episode?: PodcastEpisode | null
   context: CompilationItemListRowContext
   entityIndex: number
-  shelfEntities: (BookshelfEntity | null)[]
-  episodeNavCtx?: EntityNavigationContext
+  shelfEntities: (ShelfNavigationEntity | null)[]
   showDragHandle: boolean
   sortableDragHandleProps: SortableListDragHandleProps
   isDragging?: boolean
@@ -53,7 +54,6 @@ export default function CompilationItemListRow({
   context,
   entityIndex,
   shelfEntities,
-  episodeNavCtx,
   showDragHandle,
   sortableDragHandleProps,
   isDragging = false
@@ -107,21 +107,13 @@ export default function CompilationItemListRow({
 
   const handleEdit = useCallback(() => {
     if (episode) {
-      setBoundModal(
-        <EpisodeEditModal
-          key={`episode-edit-modal-${episode.id}`}
-          isOpen
-          libraryItem={libraryItem}
-          episode={episode}
-          navCtx={episodeNavCtx}
-          onClose={clearBoundModal}
-        />
-      )
+      const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+      setBoundModal(<EpisodeEditModal key={`episode-edit-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
       return
     }
     const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
     setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, entityIndex, episode, episodeNavCtx, libraryItem, setBoundModal, shelfEntities])
+  }, [clearBoundModal, entityIndex, episode, libraryItem, setBoundModal, shelfEntities])
 
   const handlePlayClick = useCallback(
     (e: React.MouseEvent) => {

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -7,6 +7,7 @@ import PreviewCover from '@/components/covers/PreviewCover'
 import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
 import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
 import IconBtn from '@/components/ui/IconBtn'
 import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
 import ReadIconBtn from '@/components/ui/ReadIconBtn'
@@ -29,7 +30,7 @@ import { buildMediaItemProgressMap, buildPodcastEpisodeProgressMap, getLibraryIt
 import { mergeClasses } from '@/lib/merge-classes'
 import { getEpisodeDuration, getPlaylistItemDuration } from '@/lib/playlistItems'
 import type { LibraryItem, PodcastEpisode } from '@/types/api'
-import { isBookMedia, isBookMetadata, isPodcastMedia } from '@/types/api'
+import { isBookMedia, isBookMetadata, isPodcastLibraryItem, isPodcastMedia } from '@/types/api'
 import Link from 'next/link'
 import { useCallback, useMemo, useState, useTransition } from 'react'
 
@@ -122,6 +123,19 @@ export default function CompilationItemListRow({
     const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
     setBoundModal(<EpisodeMatchModal key={`episode-match-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
   }, [clearBoundModal, entityIndex, episode, libraryItem.id, setBoundModal, shelfEntities])
+
+  const handleViewEpisode = useCallback(() => {
+    if (!episode || !isPodcastLibraryItem(libraryItem)) return
+    setBoundModal(
+      <ViewEpisodeModal
+        key={`view-episode-modal-${episode.id}`}
+        isOpen
+        onClose={clearBoundModal}
+        episode={episode}
+        libraryItem={libraryItem}
+      />
+    )
+  }, [clearBoundModal, episode, libraryItem, setBoundModal])
 
   const canShowRemove = context.kind === 'collection' ? userCanDelete : userCanUpdate
 
@@ -257,16 +271,27 @@ export default function CompilationItemListRow({
         )}
 
         <div className="relative flex min-w-0 flex-1 items-center">
-          {!isMdUp && (
-            <Link
-              href={itemHref}
-              className={mergeClasses(
-                'focus-visible:outline-foreground-muted absolute inset-0 z-[1] rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
-                isDragging && 'pointer-events-none'
-              )}
-              aria-label={itemTitle}
-            />
-          )}
+          {!isMdUp &&
+            (episode ? (
+              <button
+                type="button"
+                onClick={handleViewEpisode}
+                className={mergeClasses(
+                  'focus-visible:outline-foreground-muted absolute inset-0 z-[1] cursor-pointer rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
+                  isDragging && 'pointer-events-none'
+                )}
+                aria-label={itemTitle}
+              />
+            ) : (
+              <Link
+                href={itemHref}
+                className={mergeClasses(
+                  'focus-visible:outline-foreground-muted absolute inset-0 z-[1] rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
+                  isDragging && 'pointer-events-none'
+                )}
+                aria-label={itemTitle}
+              />
+            ))}
 
           <div className="flex shrink-0 items-center" style={{ width: coverWidth, minWidth: coverWidth, maxWidth: coverWidth }}>
             <div className="relative">
@@ -289,16 +314,30 @@ export default function CompilationItemListRow({
           <div className="px-2e md:px-3e flex min-w-0 flex-1 items-center">
             <div className="flex w-full min-w-0 flex-col justify-center">
               {isMdUp ? (
-                <Link
-                  href={itemHref}
-                  className={mergeClasses(
-                    'text-foreground inline-block w-fit max-w-full text-[0.875em] hover:underline md:text-[1em]',
-                    COMPILATION_ROW_LINK_FOCUS
-                  )}
-                  title={itemTitle}
-                >
-                  <span className="block truncate">{itemTitle}</span>
-                </Link>
+                episode ? (
+                  <button
+                    type="button"
+                    onClick={handleViewEpisode}
+                    className={mergeClasses(
+                      'text-foreground inline-block w-fit max-w-full cursor-pointer text-start text-[0.875em] hover:underline md:text-[1em]',
+                      COMPILATION_ROW_LINK_FOCUS
+                    )}
+                    title={itemTitle}
+                  >
+                    <span className="block truncate">{itemTitle}</span>
+                  </button>
+                ) : (
+                  <Link
+                    href={itemHref}
+                    className={mergeClasses(
+                      'text-foreground inline-block w-fit max-w-full text-[0.875em] hover:underline md:text-[1em]',
+                      COMPILATION_ROW_LINK_FOCUS
+                    )}
+                    title={itemTitle}
+                  >
+                    <span className="block truncate">{itemTitle}</span>
+                  </Link>
+                )
               ) : (
                 <span className="text-foreground block truncate text-[0.875em]" title={itemTitle}>
                   {itemTitle}

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -8,8 +8,8 @@ import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
 import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
-import IconBtn from '@/components/ui/IconBtn'
 import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
+import IconBtn from '@/components/ui/IconBtn'
 import ReadIconBtn from '@/components/ui/ReadIconBtn'
 import Tooltip from '@/components/ui/Tooltip'
 import type { SortableListDragHandleProps } from '@/components/widgets/SortableList'
@@ -21,14 +21,14 @@ import { useUser } from '@/contexts/UserContext'
 import { useCompilationListRowLayout } from '@/hooks/useCompilationListRowLayout'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getMediaCardModalNavigationContext } from '@/lib/bookshelfNavigationContext'
-import { getMediaCardEpisodeEditNavigationContext } from '@/lib/episodeEditNavigation'
 import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
-import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import { DRAG_HANDLE_COARSE_POINTER_MIN_TOUCH, DRAG_HANDLE_GRAB_CURSOR } from '@/lib/dragHandleClasses'
+import { getMediaCardEpisodeEditNavigationContext } from '@/lib/episodeEditNavigation'
 import { formatDuration } from '@/lib/formatDuration'
 import { buildMediaItemProgressMap, buildPodcastEpisodeProgressMap, getLibraryItemProgressFromMap } from '@/lib/mediaProgress'
 import { mergeClasses } from '@/lib/merge-classes'
 import { getEpisodeDuration, getPlaylistItemDuration } from '@/lib/playlistItems'
+import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import type { LibraryItem, PodcastEpisode } from '@/types/api'
 import { isBookMedia, isBookMetadata, isPodcastLibraryItem, isPodcastMedia } from '@/types/api'
 import Link from 'next/link'
@@ -126,16 +126,9 @@ export default function CompilationItemListRow({
 
   const handleViewEpisode = useCallback(() => {
     if (!episode || !isPodcastLibraryItem(libraryItem)) return
-    setBoundModal(
-      <ViewEpisodeModal
-        key={`view-episode-modal-${episode.id}`}
-        isOpen
-        onClose={clearBoundModal}
-        episode={episode}
-        libraryItem={libraryItem}
-      />
-    )
-  }, [clearBoundModal, episode, libraryItem, setBoundModal])
+    const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+    setBoundModal(<ViewEpisodeModal key={`view-episode-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+  }, [clearBoundModal, entityIndex, episode, libraryItem, setBoundModal, shelfEntities])
 
   const canShowRemove = context.kind === 'collection' ? userCanDelete : userCanUpdate
 

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -5,8 +5,10 @@ import { toggleFinishedAction } from '@/app/actions/mediaActions'
 import { batchRemoveFromPlaylistAction } from '@/app/actions/playlistActions'
 import PreviewCover from '@/components/covers/PreviewCover'
 import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
+import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import IconBtn from '@/components/ui/IconBtn'
+import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
 import ReadIconBtn from '@/components/ui/ReadIconBtn'
 import Tooltip from '@/components/ui/Tooltip'
 import type { SortableListDragHandleProps } from '@/components/widgets/SortableList'
@@ -115,6 +117,14 @@ export default function CompilationItemListRow({
     setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
   }, [clearBoundModal, entityIndex, episode, libraryItem, setBoundModal, shelfEntities])
 
+  const handleMatch = useCallback(() => {
+    if (!episode) return
+    const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+    setBoundModal(<EpisodeMatchModal key={`episode-match-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+  }, [clearBoundModal, entityIndex, episode, libraryItem.id, setBoundModal, shelfEntities])
+
+  const canShowRemove = context.kind === 'collection' ? userCanDelete : userCanUpdate
+
   const handlePlayClick = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation()
@@ -190,6 +200,28 @@ export default function CompilationItemListRow({
     })
   }, [context, episodeId, libraryItem.id, showToast, sortableCompilation, t])
 
+  const contextMenuItems = useMemo(() => {
+    const items: { text: string; action: string }[] = []
+    if (canShowRemove) {
+      items.push({
+        text: context.kind === 'playlist' ? t('LabelRemoveFromPlaylist') : t('LabelRemoveFromCollection'),
+        action: 'remove'
+      })
+    }
+    if (episode && userCanUpdate) {
+      items.push({ text: t('HeaderMatch'), action: 'match' })
+    }
+    return items
+  }, [canShowRemove, context.kind, episode, t, userCanUpdate])
+
+  const handleContextMenuAction = useCallback(
+    ({ action }: { action: string }) => {
+      if (action === 'match') handleMatch()
+      else if (action === 'remove') handleRemoveClick()
+    },
+    [handleMatch, handleRemoveClick]
+  )
+
   const handleMouseEnter = () => {
     if (isDragging) return
     setIsHovering(true)
@@ -203,7 +235,6 @@ export default function CompilationItemListRow({
   const showMobilePlayBtn = !isMdUp && !showDragHandle && showPlayBtn
   const itemHref = `/library/${libraryItem.libraryId}/item/${libraryItem.id}`
   const canShowEdit = userCanUpdate
-  const canShowRemove = context.kind === 'collection' ? userCanDelete : userCanUpdate
 
   return (
     <div
@@ -358,17 +389,19 @@ export default function CompilationItemListRow({
                 edit
               </IconBtn>
             )}
-            {canShowRemove && (
-              <IconBtn
-                borderless
-                size="custom"
-                className={COMPILATION_ROW_ACTION_BTN_CLASS}
-                ariaLabel={t('ButtonRemove')}
-                disabled={processingRemove}
-                onClick={handleRemoveClick}
-              >
-                close
-              </IconBtn>
+            {contextMenuItems.length > 0 && (
+              <div onClick={(e) => e.stopPropagation()}>
+                <ContextMenuDropdown
+                  items={contextMenuItems}
+                  borderless
+                  size="small"
+                  className={COMPILATION_ROW_ACTION_BTN_CLASS}
+                  autoWidth
+                  processing={processingRemove}
+                  onAction={handleContextMenuAction}
+                  usePortal
+                />
+              </div>
             )}
           </div>
         )}

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -2,6 +2,8 @@
 
 import AddToCollectionModal from '@/components/modals/AddToCollectionModal'
 import AddToPlaylistModal from '@/components/modals/AddToPlaylistModal'
+import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
+import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import MatchModal from '@/components/modals/MatchModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
@@ -19,10 +21,12 @@ import { useMediaContext } from '@/contexts/MediaContext'
 import { isDragOnlyOverlay, useSortableBookshelfOverlay } from '@/contexts/SortableBookshelfOverlayContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getMediaCardModalNavigationContext } from '@/lib/bookshelfNavigationContext'
+import { getMediaCardEpisodeEditNavigationContext } from '@/lib/episodeEditNavigation'
 import { getPlaceholderCoverUrl } from '@/lib/coverUtils'
 import { getEbookFormat } from '@/lib/ereader/ereaderEbook'
+import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import { computeProgress } from '@/lib/mediaProgress'
-import type { BookMedia, BookshelfEntity, EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode, PodcastMedia, UserPermissions } from '@/types/api'
+import type { BookMedia, EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode, PodcastMedia, UserPermissions } from '@/types/api'
 import { BookshelfView, isBookMedia, isBookMetadata, isPodcastLibraryItem } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { memo, useCallback, useEffect, useId, useMemo, useState, type ReactNode } from 'react'
@@ -76,7 +80,7 @@ export interface MediaCardProps {
   /**
    * When both are set, modal prev/next scope is built lazily on open from this shelf snapshot (sparse bookshelf grid or dense home row).
    */
-  shelfEntities?: (BookshelfEntity | null)[]
+  shelfEntities?: (ShelfNavigationEntity | null)[]
   entityIndex?: number
   /** Wired by sortable bookshelf hosts (`SortableBookshelfCard`, `DragOverlay`, etc.). */
   dragOptions?: SortableBookshelfCardOptions
@@ -128,14 +132,24 @@ function MediaCard(props: MediaCardProps) {
   const clearBoundModal = useCallback(() => setBoundModal(null), [setBoundModal])
 
   const handleOpenMatch = useCallback(() => {
+    if (episode) {
+      const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+      setBoundModal(<EpisodeMatchModal key={`episode-match-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+      return
+    }
     const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
     setBoundModal(<MatchModal key="match-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, libraryItem.id, shelfEntities, entityIndex, setBoundModal])
+  }, [clearBoundModal, episode, entityIndex, libraryItem.id, shelfEntities, setBoundModal])
 
   const handleOpenEdit = useCallback(() => {
+    if (episode) {
+      const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+      setBoundModal(<EpisodeEditModal key={`episode-edit-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+      return
+    }
     const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
     setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, libraryItem.id, shelfEntities, entityIndex, setBoundModal])
+  }, [clearBoundModal, episode, libraryItem, shelfEntities, entityIndex, setBoundModal])
 
   const handleMoreMenuOpenChange = (isOpen: boolean) => {
     setIsMoreMenuOpen(isOpen)

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -22,11 +22,11 @@ import { useMediaContext } from '@/contexts/MediaContext'
 import { isDragOnlyOverlay, useSortableBookshelfOverlay } from '@/contexts/SortableBookshelfOverlayContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getMediaCardModalNavigationContext } from '@/lib/bookshelfNavigationContext'
-import { getMediaCardEpisodeEditNavigationContext } from '@/lib/episodeEditNavigation'
 import { getPlaceholderCoverUrl } from '@/lib/coverUtils'
+import { getMediaCardEpisodeEditNavigationContext } from '@/lib/episodeEditNavigation'
 import { getEbookFormat } from '@/lib/ereader/ereaderEbook'
-import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import { computeProgress } from '@/lib/mediaProgress'
+import type { ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 import type { BookMedia, EReaderDevice, LibraryItem, MediaProgress, PodcastEpisode, PodcastMedia, UserPermissions } from '@/types/api'
 import { BookshelfView, isBookMedia, isBookMetadata, isPodcastLibraryItem } from '@/types/api'
 import { useRouter } from 'next/navigation'
@@ -326,19 +326,12 @@ function MediaCard(props: MediaCardProps) {
   const handleCardClick = useCallback(() => {
     closeMoreMenu()
     if (episode && isPodcastLibraryItem(libraryItem)) {
-      setBoundModal(
-        <ViewEpisodeModal
-          key={`view-episode-modal-${episode.id}`}
-          isOpen
-          onClose={clearBoundModal}
-          episode={episode}
-          libraryItem={libraryItem}
-        />
-      )
+      const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+      setBoundModal(<ViewEpisodeModal key={`view-episode-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
       return
     }
     router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}`)
-  }, [clearBoundModal, closeMoreMenu, episode, libraryItem, router, setBoundModal])
+  }, [clearBoundModal, closeMoreMenu, entityIndex, episode, libraryItem, router, setBoundModal, shelfEntities])
 
   const navigateOnCardClick = !processing && !isDragOnlyOverlay(overlayMode)
 

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -8,6 +8,7 @@ import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import MatchModal from '@/components/modals/MatchModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
 import ShareModal from '@/components/modals/ShareModal'
+import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import DraggableMediaOverlayIconBtn from '@/components/widgets/media-card/DraggableMediaOverlayIconBtn'
 import MediaCardCover from '@/components/widgets/media-card/MediaCardCover'
@@ -315,9 +316,21 @@ function MediaCard(props: MediaCardProps) {
     playerControls: playerHandler.controls
   })
 
-  const handleCardClick = () => {
+  const handleCardClick = useCallback(() => {
+    if (episode && isPodcastLibraryItem(libraryItem)) {
+      setBoundModal(
+        <ViewEpisodeModal
+          key={`view-episode-modal-${episode.id}`}
+          isOpen
+          onClose={clearBoundModal}
+          episode={episode}
+          libraryItem={libraryItem}
+        />
+      )
+      return
+    }
     router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}`)
-  }
+  }, [clearBoundModal, episode, libraryItem, router, setBoundModal])
 
   const navigateOnCardClick = !processing && !isDragOnlyOverlay(overlayMode)
 

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -132,7 +132,13 @@ function MediaCard(props: MediaCardProps) {
 
   const clearBoundModal = useCallback(() => setBoundModal(null), [setBoundModal])
 
+  const closeMoreMenu = useCallback(() => {
+    setIsMoreMenuOpen(false)
+    setIsHovering(false)
+  }, [])
+
   const handleOpenMatch = useCallback(() => {
+    closeMoreMenu()
     if (episode) {
       const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
       setBoundModal(<EpisodeMatchModal key={`episode-match-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
@@ -140,9 +146,10 @@ function MediaCard(props: MediaCardProps) {
     }
     const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
     setBoundModal(<MatchModal key="match-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, episode, entityIndex, libraryItem.id, shelfEntities, setBoundModal])
+  }, [clearBoundModal, closeMoreMenu, episode, entityIndex, libraryItem.id, shelfEntities, setBoundModal])
 
   const handleOpenEdit = useCallback(() => {
+    closeMoreMenu()
     if (episode) {
       const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
       setBoundModal(<EpisodeEditModal key={`episode-edit-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
@@ -150,7 +157,7 @@ function MediaCard(props: MediaCardProps) {
     }
     const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
     setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, episode, libraryItem, shelfEntities, entityIndex, setBoundModal])
+  }, [clearBoundModal, closeMoreMenu, episode, libraryItem, shelfEntities, entityIndex, setBoundModal])
 
   const handleMoreMenuOpenChange = (isOpen: boolean) => {
     setIsMoreMenuOpen(isOpen)
@@ -317,6 +324,7 @@ function MediaCard(props: MediaCardProps) {
   })
 
   const handleCardClick = useCallback(() => {
+    closeMoreMenu()
     if (episode && isPodcastLibraryItem(libraryItem)) {
       setBoundModal(
         <ViewEpisodeModal
@@ -330,7 +338,7 @@ function MediaCard(props: MediaCardProps) {
       return
     }
     router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}`)
-  }, [clearBoundModal, episode, libraryItem, router, setBoundModal])
+  }, [clearBoundModal, closeMoreMenu, episode, libraryItem, router, setBoundModal])
 
   const navigateOnCardClick = !processing && !isDragOnlyOverlay(overlayMode)
 

--- a/src/components/widgets/media-card/MediaCardMoreMenu.tsx
+++ b/src/components/widgets/media-card/MediaCardMoreMenu.tsx
@@ -31,12 +31,13 @@ export function mapMediaCardMoreMenuItemsToDropdownItems(items: MediaCardMoreMen
 interface MediaCardMoreMenuProps {
   items: MediaCardMoreMenuItem[]
   processing?: boolean
+  isOpen?: boolean
   onAction: (func: string, data?: Record<string, string>) => void
   onOpenChange?: (isOpen: boolean) => void
   className?: string
 }
 
-export default function MediaCardMoreMenu({ items, processing = false, onAction, onOpenChange, className }: MediaCardMoreMenuProps) {
+export default function MediaCardMoreMenu({ items, processing = false, isOpen, onAction, onOpenChange, className }: MediaCardMoreMenuProps) {
   const contextMenuItems = useMemo(() => mapMediaCardMoreMenuItemsToDropdownItems(items), [items])
 
   const handleContextMenuAction = useCallback(
@@ -66,6 +67,7 @@ export default function MediaCardMoreMenu({ items, processing = false, onAction,
       menuAlign="right"
       autoWidth
       processing={processing}
+      isOpen={isOpen}
       onAction={handleContextMenuAction}
       onOpenChange={handleOpenChange}
       className={mergeClasses('h-auto w-auto text-[1em] text-white', className)}

--- a/src/components/widgets/media-card/MediaCardOverlay.tsx
+++ b/src/components/widgets/media-card/MediaCardOverlay.tsx
@@ -235,7 +235,13 @@ export default function MediaCardOverlay({
                 'hover:scale-125 hover:[&_.material-symbols]:!text-yellow-300'
               )}
             >
-              <MediaCardMoreMenu items={moreMenuItems} processing={isProcessingOrPending} onAction={onMoreAction} onOpenChange={onMoreMenuOpenChange} />
+              <MediaCardMoreMenu
+                items={moreMenuItems}
+                processing={isProcessingOrPending}
+                isOpen={isMoreMenuOpen}
+                onAction={onMoreAction}
+                onOpenChange={onMoreMenuOpenChange}
+              />
             </div>
           )}
 

--- a/src/components/widgets/media-card/PodcastEpisodeCard.tsx
+++ b/src/components/widgets/media-card/PodcastEpisodeCard.tsx
@@ -5,7 +5,7 @@ import type { PodcastEpisode } from '@/types/api'
 import { useMemo } from 'react'
 import MediaCard, { type MediaCardProps } from './MediaCard'
 
-export type PodcastEpisodeCardProps = Omit<MediaCardProps, 'shelfEntities' | 'entityIndex'>
+export type PodcastEpisodeCardProps = MediaCardProps
 
 /**
  * Podcast episode card.

--- a/src/components/widgets/media-card/PodcastMediaCard.tsx
+++ b/src/components/widgets/media-card/PodcastMediaCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import type { PodcastMedia } from '@/types/api'
 import { useMemo } from 'react'
 import MediaCard, { type MediaCardProps } from './MediaCard'
@@ -10,39 +11,45 @@ export type PodcastMediaCardProps = MediaCardProps
  * Podcast-specific media card with podcast-specific badges.
  */
 export default function PodcastMediaCard(props: PodcastMediaCardProps) {
-  const { libraryItem } = props
+  const { libraryItem, episode } = props
+  const t = useTypeSafeTranslations()
   const media = libraryItem.media as PodcastMedia
 
   const recentEpisode = useMemo(() => libraryItem.recentEpisode, [libraryItem])
+  const badgeEpisode = episode ?? recentEpisode
 
-  const recentEpisodeNumber = useMemo(() => {
-    if (!recentEpisode) return null
-    if (recentEpisode.episode) {
-      return recentEpisode.episode.replace(/^#/, '')
+  const episodeNumber = useMemo(() => {
+    if (!badgeEpisode) return null
+    if (badgeEpisode.episode) {
+      return badgeEpisode.episode.replace(/^#/, '')
     }
     return ''
-  }, [recentEpisode])
+  }, [badgeEpisode])
 
   const numEpisodes = useMemo(() => media.numEpisodes || 0, [media])
   const numEpisodesIncomplete = useMemo(() => libraryItem.numEpisodesIncomplete || 0, [libraryItem])
 
   const renderBadges = useMemo(() => {
     const PodcastBadges = ({ isHovering, isSelectionMode, processing }: { isHovering: boolean; isSelectionMode: boolean; processing: boolean }) => {
-      // Podcast episode number badge (when showing recent episode)
-      if (recentEpisodeNumber !== null && !isHovering && !isSelectionMode && !processing) {
+      const isEpisodeCard = !!episode || !!recentEpisode
+
+      // Episode number badge (specific episode entry or recent episode on home shelf)
+      if (isEpisodeCard && episodeNumber !== null && !isHovering && !isSelectionMode && (!processing || !!episode)) {
         return (
           <div
-            cy-id="podcastEpisodeNumber"
+            cy-id={episode ? 'episodeNumber' : 'podcastEpisodeNumber'}
             className="shadow-modal-content absolute end-[0.375em] top-[0.375em] z-10 rounded-lg bg-black/90 text-white"
             style={{ padding: '0.1em 0.25em' }}
           >
             <p style={{ fontSize: '0.8em' }}>
-              Episode
-              {recentEpisodeNumber && <span>#{recentEpisodeNumber}</span>}
+              {t('LabelEpisode')}
+              {episodeNumber && <span> #{episodeNumber}</span>}
             </p>
           </div>
         )
       }
+
+      if (episode) return null
 
       // Num episodes incomplete badge (yellow, highest priority)
       if (numEpisodesIncomplete && !isHovering && !isSelectionMode) {
@@ -78,7 +85,7 @@ export default function PodcastMediaCard(props: PodcastMediaCardProps) {
     }
     PodcastBadges.displayName = 'PodcastBadges'
     return PodcastBadges
-  }, [numEpisodes, numEpisodesIncomplete, recentEpisodeNumber])
+  }, [episode, episodeNumber, numEpisodes, numEpisodesIncomplete, recentEpisode, t])
 
   return <MediaCard {...props} renderBadges={renderBadges} />
 }

--- a/src/components/widgets/media-card/useMediaCardActions.ts
+++ b/src/components/widgets/media-card/useMediaCardActions.ts
@@ -454,7 +454,7 @@ export function useMediaCardActions({
       }
     }
 
-    if (userCanUpdate && onOpenMatch && !episodeForQueue) {
+    if (userCanUpdate && onOpenMatch) {
       items.push({
         text: t('HeaderMatch'),
         func: 'showMatchModal'

--- a/src/hooks/useEpisodeNavigationContext.ts
+++ b/src/hooks/useEpisodeNavigationContext.ts
@@ -1,0 +1,33 @@
+import type { EpisodeNavigationContext } from '@/lib/episodeEditNavigation'
+import { useCallback, useLayoutEffect, useState } from 'react'
+
+/**
+ * Tracks index into `navigation.slots` for episode modal prev/next; resets when the modal opens.
+ */
+export function useEpisodeNavigationContext(navigationContext: EpisodeNavigationContext | undefined, isOpen: boolean) {
+  const slots = navigationContext?.slots ?? []
+  const initialIndex = navigationContext?.initialIndex ?? 0
+
+  const [navIndex, setNavIndex] = useState(initialIndex)
+
+  useLayoutEffect(() => {
+    if (isOpen) {
+      setNavIndex(initialIndex)
+    }
+  }, [isOpen, initialIndex])
+
+  const safeIndex = Math.min(Math.max(0, navIndex), Math.max(0, slots.length - 1))
+  const currentSlot = slots.length > 0 ? slots[safeIndex]! : null
+  const canGoPrev = slots.length > 0 && safeIndex > 0
+  const canGoNext = slots.length > 0 && safeIndex < slots.length - 1
+
+  const goPrev = useCallback(() => {
+    setNavIndex((i) => (i > 0 ? i - 1 : i))
+  }, [])
+
+  const goNext = useCallback(() => {
+    setNavIndex((i) => (i < slots.length - 1 ? i + 1 : i))
+  }, [slots.length])
+
+  return { currentSlot, canGoPrev, canGoNext, goPrev, goNext }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1005,11 +1005,7 @@ export async function getPodcastEpisode(libraryItemId: string, episodeId: string
 /**
  * Update podcast episode metadata.
  */
-export async function updatePodcastEpisode(
-  libraryItemId: string,
-  episodeId: string,
-  payload: UpdatePodcastEpisodePayload
-): Promise<PodcastLibraryItem> {
+export async function updatePodcastEpisode(libraryItemId: string, episodeId: string, payload: UpdatePodcastEpisodePayload): Promise<PodcastLibraryItem> {
   return apiRequest<PodcastLibraryItem>(`/api/podcasts/${libraryItemId}/episode/${episodeId}`, {
     method: 'PATCH',
     body: JSON.stringify(payload)

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -61,10 +61,14 @@ import {
   PersonalizedShelf,
   Playlist,
   PlaylistItemPayload,
+  PodcastEpisode,
+  PodcastLibraryItem,
   PodcastSearchResult,
   RssPodcastEpisode,
   SaveLibraryOrderApiResponse,
   SearchLibraryResponse,
+  SearchPodcastEpisodeResponse,
+  SearchPodcastEpisodeResult,
   Series,
   ServerStatus,
   TasksResponse,
@@ -74,6 +78,7 @@ import {
   UpdateEReaderDevicesResponse,
   UpdateLibraryItemMediaPayload,
   UpdateLibraryItemMediaResponse,
+  UpdatePodcastEpisodePayload,
   UploadCoverResponse,
   User,
   UserLoginResponse
@@ -988,6 +993,38 @@ export async function deleteLibraryItemMediaEpisode(libraryItemId: string, episo
   return apiRequest<void>(`/api/podcasts/${libraryItemId}/episode/${episodeId}${hard}`, {
     method: 'DELETE'
   })
+}
+
+/**
+ * Fetch a single podcast episode with full details.
+ */
+export async function getPodcastEpisode(libraryItemId: string, episodeId: string): Promise<PodcastEpisode> {
+  return apiRequest<PodcastEpisode>(`/api/podcasts/${libraryItemId}/episode/${episodeId}`)
+}
+
+/**
+ * Update podcast episode metadata.
+ */
+export async function updatePodcastEpisode(
+  libraryItemId: string,
+  episodeId: string,
+  payload: UpdatePodcastEpisodePayload
+): Promise<PodcastLibraryItem> {
+  return apiRequest<PodcastLibraryItem>(`/api/podcasts/${libraryItemId}/episode/${episodeId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload)
+  })
+}
+
+/**
+ * Search RSS feed for episodes matching a title.
+ */
+export async function searchPodcastEpisode(libraryItemId: string, title: string): Promise<{ episodes: SearchPodcastEpisodeResult[] }> {
+  const params = new URLSearchParams({ title })
+  const response = await apiRequest<SearchPodcastEpisodeResponse>(`/api/podcasts/${libraryItemId}/search-episode?${params.toString()}`)
+  return {
+    episodes: (response.episodes || []).map((item) => item.episode)
+  }
 }
 
 /**

--- a/src/lib/bookshelfNavigationContext.ts
+++ b/src/lib/bookshelfNavigationContext.ts
@@ -1,4 +1,4 @@
-import type { BookshelfEntity } from '@/types/api'
+import { getShelfEntityNavigationId, type ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 
 /**
  * Generic prev/next scope for modals.
@@ -13,7 +13,7 @@ export type EntityNavigationContext = {
  * Prev/next entity scope for one bookshelf entity slot: contiguous non-null run around `entityIndex`, in array order.
  * Call when opening a modal (lazy). Returns a fresh `entityIds` array; safe to pass through to the modal.
  */
-function getEntityNavigationContext(entities: (BookshelfEntity | null)[], entityIndex: number): EntityNavigationContext | null {
+function getEntityNavigationContext(entities: (ShelfNavigationEntity | null)[], entityIndex: number): EntityNavigationContext | null {
   if (entityIndex < 0 || entityIndex >= entities.length) return null
 
   const at = entities[entityIndex]
@@ -38,7 +38,7 @@ function getEntityNavigationContext(entities: (BookshelfEntity | null)[], entity
     if (j === entityIndex) {
       initialIndex = entityIds.length
     }
-    entityIds.push(e.id)
+    entityIds.push(getShelfEntityNavigationId(e))
   }
 
   if (initialIndex < 0) return null
@@ -57,7 +57,7 @@ const defaultSingleEntityNavCtx = (libraryItemId: string): EntityNavigationConte
  */
 export function getMediaCardModalNavigationContext(
   libraryItemId: string,
-  shelfEntities: (BookshelfEntity | null)[] | undefined,
+  shelfEntities: (ShelfNavigationEntity | null)[] | undefined,
   entityIndex: number | undefined
 ): EntityNavigationContext {
   if (shelfEntities !== undefined && entityIndex !== undefined) {

--- a/src/lib/episodeEditNavigation.ts
+++ b/src/lib/episodeEditNavigation.ts
@@ -1,16 +1,88 @@
-import type { EntityNavigationContext } from '@/lib/bookshelfNavigationContext'
-import type { PlaylistItem } from '@/types/api'
+import { getShelfEntityEpisode, getShelfEntityNavigationId, type ShelfNavigationEntity } from '@/lib/shelfNavigationEntity'
 
-export function getPlaylistEpisodeNavigationContext(orderedItems: PlaylistItem[], episodeId: string): EntityNavigationContext | null {
-  const episodeIds = orderedItems.flatMap((item) => (item.episode ? [item.episode.id] : []))
-  const initialIndex = episodeIds.indexOf(episodeId)
-  if (initialIndex < 0) return null
-  return { entityIds: episodeIds, initialIndex }
+export type EpisodeNavigationSlot = {
+  episodeId: string
+  libraryItemId: string
 }
 
-export function getPodcastEpisodeNavigationContext(episodes: { id: string }[], episodeId: string): EntityNavigationContext | null {
-  const episodeIds = episodes.map((episode) => episode.id)
-  const initialIndex = episodeIds.indexOf(episodeId)
+export type EpisodeNavigationContext = {
+  slots: EpisodeNavigationSlot[]
+  initialIndex: number
+}
+
+/**
+ * Prev/next episode scope for one shelf slot: contiguous non-null run around `entityIndex`,
+ * filtered to episode-only entities within that run.
+ */
+function getShelfEpisodeNavigationContext(
+  entities: (ShelfNavigationEntity | null)[],
+  entityIndex: number
+): EpisodeNavigationContext | null {
+  if (entityIndex < 0 || entityIndex >= entities.length) return null
+
+  const at = entities[entityIndex]
+  if (at === null) return null
+
+  const atEpisode = getShelfEntityEpisode(at)
+  if (!atEpisode?.id) return null
+
+  let start = entityIndex
+  while (start > 0 && entities[start - 1] !== null) {
+    start--
+  }
+
+  let end = entityIndex
+  while (end < entities.length - 1 && entities[end + 1] !== null) {
+    end++
+  }
+
+  const slots: EpisodeNavigationSlot[] = []
+  let initialIndex = -1
+
+  for (let j = start; j <= end; j++) {
+    const entity = entities[j]
+    if (entity === null) continue
+    const episode = getShelfEntityEpisode(entity)
+    if (!episode?.id) continue
+    if (j === entityIndex) {
+      initialIndex = slots.length
+    }
+    slots.push({
+      episodeId: episode.id,
+      libraryItemId: getShelfEntityNavigationId(entity)
+    })
+  }
+
+  if (initialIndex < 0 || slots.length === 0) return null
+
+  return { slots, initialIndex }
+}
+
+const defaultSingleEpisodeNavCtx = (episodeId: string, libraryItemId: string): EpisodeNavigationContext => ({
+  slots: [{ episodeId, libraryItemId }],
+  initialIndex: 0
+})
+
+export function getMediaCardEpisodeEditNavigationContext(
+  episodeId: string,
+  libraryItemId: string,
+  shelfEntities?: (ShelfNavigationEntity | null)[],
+  entityIndex?: number
+): EpisodeNavigationContext {
+  if (shelfEntities !== undefined && entityIndex !== undefined) {
+    const computed = getShelfEpisodeNavigationContext(shelfEntities, entityIndex)
+    if (computed) return computed
+  }
+  return defaultSingleEpisodeNavCtx(episodeId, libraryItemId)
+}
+
+export function getPodcastEpisodeNavigationContext(
+  libraryItemId: string,
+  episodes: { id: string }[],
+  episodeId: string
+): EpisodeNavigationContext | null {
+  const slots = episodes.map((episode) => ({ episodeId: episode.id, libraryItemId }))
+  const initialIndex = slots.findIndex((slot) => slot.episodeId === episodeId)
   if (initialIndex < 0) return null
-  return { entityIds: episodeIds, initialIndex }
+  return { slots, initialIndex }
 }

--- a/src/lib/episodeEditNavigation.ts
+++ b/src/lib/episodeEditNavigation.ts
@@ -14,10 +14,7 @@ export type EpisodeNavigationContext = {
  * Prev/next episode scope for one shelf slot: contiguous non-null run around `entityIndex`,
  * filtered to episode-only entities within that run.
  */
-function getShelfEpisodeNavigationContext(
-  entities: (ShelfNavigationEntity | null)[],
-  entityIndex: number
-): EpisodeNavigationContext | null {
+function getShelfEpisodeNavigationContext(entities: (ShelfNavigationEntity | null)[], entityIndex: number): EpisodeNavigationContext | null {
   if (entityIndex < 0 || entityIndex >= entities.length) return null
 
   const at = entities[entityIndex]
@@ -76,11 +73,7 @@ export function getMediaCardEpisodeEditNavigationContext(
   return defaultSingleEpisodeNavCtx(episodeId, libraryItemId)
 }
 
-export function getPodcastEpisodeNavigationContext(
-  libraryItemId: string,
-  episodes: { id: string }[],
-  episodeId: string
-): EpisodeNavigationContext | null {
+export function getPodcastEpisodeNavigationContext(libraryItemId: string, episodes: { id: string }[], episodeId: string): EpisodeNavigationContext | null {
   const slots = episodes.map((episode) => ({ episodeId: episode.id, libraryItemId }))
   const initialIndex = slots.findIndex((slot) => slot.episodeId === episodeId)
   if (initialIndex < 0) return null

--- a/src/lib/shelfNavigationEntity.ts
+++ b/src/lib/shelfNavigationEntity.ts
@@ -1,0 +1,23 @@
+import type { BookshelfEntity, LibraryItem, PlaylistItem, PodcastEpisode } from '@/types/api'
+
+/** Shelf snapshot for modal prev/next: main-library entities or playlist compilation rows. */
+export type ShelfNavigationEntity = BookshelfEntity | PlaylistItem
+
+export function isPlaylistItem(entity: ShelfNavigationEntity): entity is PlaylistItem {
+  return typeof (entity as PlaylistItem).libraryItemId === 'string' && 'libraryItem' in entity && !('id' in entity)
+}
+
+function isLibraryItemEntity(entity: ShelfNavigationEntity): entity is LibraryItem {
+  return 'id' in entity && 'libraryId' in entity && 'media' in entity
+}
+
+export function getShelfEntityNavigationId(entity: ShelfNavigationEntity): string {
+  if (isPlaylistItem(entity)) return entity.libraryItemId
+  return entity.id
+}
+
+export function getShelfEntityEpisode(entity: ShelfNavigationEntity): PodcastEpisode | null | undefined {
+  if (isPlaylistItem(entity)) return entity.episode ?? null
+  if (isLibraryItemEntity(entity)) return entity.recentEpisode ?? null
+  return null
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -638,6 +638,44 @@ export interface PodcastEpisode {
   }
 }
 
+export interface UpdatePodcastEpisodePayload {
+  season?: string
+  episode?: string
+  episodeType?: string
+  title?: string
+  subtitle?: string
+  description?: string
+  pubDate?: string
+  publishedAt?: number
+  chapters?: Chapter[]
+  enclosure?: {
+    url: string
+    type?: string
+    length?: string
+  } | null
+}
+
+export interface SearchPodcastEpisodeResult {
+  title?: string
+  subtitle?: string
+  description?: string
+  episode?: string
+  episodeType?: string
+  season?: string
+  pubDate?: string
+  publishedAt?: number
+  enclosure?: {
+    url: string
+    type?: string
+    length?: string
+  }
+  guid?: string
+}
+
+export interface SearchPodcastEpisodeResponse {
+  episodes: Array<{ episode: SearchPodcastEpisodeResult }>
+}
+
 export interface PodcastEpisodeDownload {
   id: string
   episodeDisplayTitle?: string


### PR DESCRIPTION
This implements the episode edit and match modals.

### Notable changes:
- Supports context navigation in all episode card/list-row contexts:
  - Playlist
  - Homepage episode shelves
  - Episode table in podcast page

### Other changes and fixes:
- ViewEpisodeModal is opened:
  - when an episode card is clicked 
  - when episode title is clicked in playlist list view
  - when episode is clicked in playlist list view on mobile
- Podcast title in ViewEdpisodeModal now links to the podcast page
  - on mobile, the link is always underlined
  - on desktop it's underlined on hover
- Fixed bug where Escape didn't close a modal if one of its descendants was not focused.
- Added episode badge to episode cards in playlist bookshelf view
- Fixed bug where episode card context menu stayed open when the card was clicked
- Added context navigation to ViewEpisodeModal (in all contexts)