### PR TITLE
Implement search results page

### DIFF
--- a/src/app/(main)/library/[library]/Toolbar.tsx
+++ b/src/app/(main)/library/[library]/Toolbar.tsx
@@ -48,8 +48,7 @@ export default function Toolbar() {
     onContextMenuAction?.(action)
   }
 
-  const showBookshelfSummary =
-    !isSearchPage && (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage) && itemCount !== null && !isSeriesDetailPage
+  const showBookshelfSummary = !isSearchPage && (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage) && itemCount !== null && !isSeriesDetailPage
   const showSeriesDetailSummary = !isSearchPage && isSeriesDetailPage && itemCount !== null
   const showSearchSummary = isSearchPage && searchQuery
   const showToolbarExtras = isBookshelfPage && !isBookshelfEmpty && !isSeriesDetailPage && !isSearchPage

--- a/src/app/(main)/library/[library]/Toolbar.tsx
+++ b/src/app/(main)/library/[library]/Toolbar.tsx
@@ -3,15 +3,19 @@
 import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
 import { useLibrary } from '@/contexts/LibraryContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { usePathname } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 
 // Pages that should show item count and toolbar extras
 const BOOKSHELF_PAGE_PATTERNS = ['/items', '/series', '/collections', '/playlists', '/authors']
 
 export default function Toolbar() {
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const { library, itemCount, itemCountSupplement, detailToolbarTitle, contextMenuItems, onContextMenuAction, toolbarExtras, filterBy } = useLibrary()
   const t = useTypeSafeTranslations()
+
+  const isSearchPage = pathname.endsWith('/search')
+  const searchQuery = searchParams.get('q')?.trim() ?? ''
 
   // Check if we're on any bookshelf-like page (or a single collection, which syncs the same summary fields)
   const isBookshelfPage = BOOKSHELF_PAGE_PATTERNS.some((pattern) => pathname.endsWith(pattern))
@@ -44,14 +48,26 @@ export default function Toolbar() {
     onContextMenuAction?.(action)
   }
 
-  const showBookshelfSummary = (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage) && itemCount !== null && !isSeriesDetailPage
-  const showSeriesDetailSummary = isSeriesDetailPage && itemCount !== null
-  const showToolbarExtras = isBookshelfPage && !isBookshelfEmpty && !isSeriesDetailPage
-  const showContextMenu = contextMenuItems.length > 0 && (!isBookshelfEmpty || isSeriesDetailPage)
+  const showBookshelfSummary =
+    !isSearchPage && (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage) && itemCount !== null && !isSeriesDetailPage
+  const showSeriesDetailSummary = !isSearchPage && isSeriesDetailPage && itemCount !== null
+  const showSearchSummary = isSearchPage && searchQuery
+  const showToolbarExtras = isBookshelfPage && !isBookshelfEmpty && !isSeriesDetailPage && !isSearchPage
+  const showContextMenu = contextMenuItems.length > 0 && (!isBookshelfEmpty || isSeriesDetailPage) && !isSearchPage
 
   return (
     <div className="bg-bg box-shadow-toolbar relative z-40 h-10 w-full" cy-id="library-toolbar">
       <div className="flex h-full w-full items-center justify-between px-4">
+        {showSearchSummary && (
+          <>
+            <div className="flex-grow" />
+            <p className="text-foreground text-base">
+              {t('MessageSearchResultsFor')} &quot;{searchQuery}&quot;
+            </p>
+            <div className="flex-grow" />
+          </>
+        )}
+
         {showBookshelfSummary && (
           <p className="text-foreground hidden text-base md:block">
             <span>
@@ -70,7 +86,7 @@ export default function Toolbar() {
           </div>
         )}
 
-        <div className="flex-grow" />
+        {!showSearchSummary && <div className="flex-grow" />}
 
         {showToolbarExtras && <div className="mr-2 flex items-center gap-4">{toolbarExtras}</div>}
 

--- a/src/app/(main)/library/[library]/search/SearchClient.tsx
+++ b/src/app/(main)/library/[library]/search/SearchClient.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import { searchLibraryAction } from '@/app/actions/searchActions'
+import BookShelfRow from '@/components/widgets/BookShelfRow'
+import ItemSlider from '@/components/widgets/ItemSlider'
+import { AuthorCard } from '@/components/widgets/media-card/AuthorCard'
+import BookMediaCard from '@/components/widgets/media-card/BookMediaCard'
+import MetadataFilterCard from '@/components/widgets/media-card/MetadataFilterCard'
+import PodcastEpisodeCard from '@/components/widgets/media-card/PodcastEpisodeCard'
+import PodcastMediaCard from '@/components/widgets/media-card/PodcastMediaCard'
+import { SeriesCard } from '@/components/widgets/media-card/SeriesCard'
+import { useCardSize } from '@/contexts/CardSizeContext'
+import { useLibrary } from '@/contexts/LibraryContext'
+import { useUser } from '@/contexts/UserContext'
+import { useLibraryItemUpdated } from '@/hooks/useLibraryItemUpdated'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { applyLibraryItemUpdateToShelves } from '@/lib/libraryItemUpdatedUtils'
+import { searchResultsToShelves } from '@/lib/searchResultsToShelves'
+import { Author, BookshelfView, LibraryItem, MediaProgress, PersonalizedShelf, SearchLibraryResponse, Series } from '@/types/api'
+import type { GenreShelfEntity, NarratorShelfEntity, SearchShelf, TagShelfEntity } from '@/types/search'
+import { useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+
+interface SearchClientProps {
+  initialQuery: string
+  initialResults: SearchLibraryResponse | null
+}
+
+export default function SearchClient({ initialQuery, initialResults }: SearchClientProps) {
+  const t = useTypeSafeTranslations()
+  const searchParams = useSearchParams()
+  const urlQuery = searchParams.get('q')?.trim() ?? ''
+  const { sizeMultiplier } = useCardSize()
+  const { user, serverSettings, ereaderDevices, getMediaItemProgress } = useUser()
+  const { library, homeBookshelfView } = useLibrary()
+
+  const [query, setQuery] = useState(initialQuery)
+  const [shelves, setShelves] = useState<SearchShelf[]>(() => searchResultsToShelves(initialResults, t))
+
+  useEffect(() => {
+    setQuery(initialQuery)
+    setShelves(searchResultsToShelves(initialResults, t))
+  }, [initialQuery, initialResults, t])
+
+  useEffect(() => {
+    if (!urlQuery || urlQuery === initialQuery) return
+
+    let cancelled = false
+
+    searchLibraryAction(library.id, urlQuery)
+      .then((results) => {
+        if (!cancelled) {
+          setQuery(urlQuery)
+          setShelves(searchResultsToShelves(results, t))
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to search library', error)
+        if (!cancelled) {
+          setQuery(urlQuery)
+          setShelves([])
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [urlQuery, initialQuery, library.id, t])
+
+  const handleItemUpdated = useCallback((updatedItem: LibraryItem) => {
+    setShelves((prev) => applyLibraryItemUpdateToShelves(prev as PersonalizedShelf[], updatedItem) as SearchShelf[])
+  }, [])
+
+  useLibraryItemUpdated(library.id, handleItemUpdated)
+
+  const hasResults = shelves.length > 0
+
+  return (
+    <div className="pb-20" style={{ fontSize: sizeMultiplier + 'rem' }}>
+      {hasResults ? (
+        shelves.map((shelf) => {
+          const Wrapper = homeBookshelfView === BookshelfView.STANDARD ? BookShelfRow : ItemSlider
+
+          return (
+            <Wrapper key={shelf.id} title={shelf.label}>
+              {shelf.entities.map((entity, entityIndex) => {
+                if (shelf.type === 'book' || shelf.type === 'podcast') {
+                  const EntityMediaCard = shelf.type === 'book' ? BookMediaCard : PodcastMediaCard
+                  const libraryItem = entity as LibraryItem
+                  const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
+                  const shelfLibraryItems = shelf.entities as LibraryItem[]
+
+                  return (
+                    <div key={libraryItem.id + '-' + shelf.id} className="mx-2e shrink-0">
+                      <EntityMediaCard
+                        libraryItem={libraryItem}
+                        bookshelfView={homeBookshelfView}
+                        dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                        timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+                        userPermissions={user.permissions}
+                        ereaderDevices={ereaderDevices}
+                        showSubtitles={true}
+                        mediaProgress={mediaProgress}
+                        shelfEntities={shelfLibraryItems}
+                        entityIndex={entityIndex}
+                      />
+                    </div>
+                  )
+                }
+
+                if (shelf.type === 'series') {
+                  const series = entity as Series
+                  const libraryItems = series.books || []
+                  const mediaItemProgressMap = new Map<string, MediaProgress>()
+                  libraryItems.forEach((libraryItem) => {
+                    const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
+                    if (mediaProgress) {
+                      const key = mediaProgress.mediaItemId ?? libraryItem.media?.id
+                      if (key) mediaItemProgressMap.set(key, mediaProgress)
+                    }
+                  })
+
+                  return (
+                    <div key={series.id + '-' + shelf.id} className="mx-2e shrink-0">
+                      <SeriesCard
+                        series={series}
+                        libraryId={library.id}
+                        bookshelfView={homeBookshelfView}
+                        dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                        mediaItemProgressMap={mediaItemProgressMap}
+                      />
+                    </div>
+                  )
+                }
+
+                if (shelf.type === 'episode') {
+                  const libraryItem = entity as LibraryItem
+                  const episode = libraryItem.recentEpisode
+                  if (!episode) return null
+
+                  const mediaProgress = getMediaItemProgress(episode.id)
+                  const shelfLibraryItems = shelf.entities as LibraryItem[]
+                  return (
+                    <div key={episode.id + '-' + shelf.id} className="mx-2e shrink-0">
+                      <PodcastEpisodeCard
+                        libraryItem={libraryItem}
+                        bookshelfView={homeBookshelfView}
+                        dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                        timeFormat={serverSettings?.timeFormat ?? 'HH:mm'}
+                        userPermissions={user.permissions}
+                        ereaderDevices={ereaderDevices}
+                        showSubtitles={true}
+                        mediaProgress={mediaProgress}
+                        shelfEntities={shelfLibraryItems}
+                        entityIndex={entityIndex}
+                      />
+                    </div>
+                  )
+                }
+
+                if (shelf.type === 'authors') {
+                  const author = entity as Author
+                  return (
+                    <div key={author.id + '-' + shelf.id} className="mx-2e shrink-0">
+                      <AuthorCard author={author} />
+                    </div>
+                  )
+                }
+
+                if (shelf.type === 'tags') {
+                  const tag = entity as TagShelfEntity
+                  return (
+                    <div key={tag.name + '-' + shelf.id} className="mx-2e shrink-0">
+                      <MetadataFilterCard name={tag.name} count={tag.numItems} filterKey="tags" icon="label" />
+                    </div>
+                  )
+                }
+
+                if (shelf.type === 'genres') {
+                  const genre = entity as GenreShelfEntity
+                  return (
+                    <div key={genre.name + '-' + shelf.id} className="mx-2e shrink-0">
+                      <MetadataFilterCard name={genre.name} count={genre.numItems} filterKey="genres" icon="category" />
+                    </div>
+                  )
+                }
+
+                if (shelf.type === 'narrators') {
+                  const narrator = entity as NarratorShelfEntity
+                  return (
+                    <div key={narrator.name + '-' + shelf.id} className="mx-2e shrink-0">
+                      <MetadataFilterCard name={narrator.name} count={narrator.numBooks} filterKey="narrators" icon="record_voice_over" />
+                    </div>
+                  )
+                }
+
+                return null
+              })}
+            </Wrapper>
+          )
+        })
+      ) : (
+        <div className="w-full py-16">
+          <p className="text-center text-xl">{t('MessageNoSearchResultsFor', { 0: query })}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(main)/library/[library]/search/page.tsx
+++ b/src/app/(main)/library/[library]/search/page.tsx
@@ -2,13 +2,7 @@ import { getData, searchLibrary } from '@/lib/api'
 import { redirect } from 'next/navigation'
 import SearchClient from './SearchClient'
 
-export default async function SearchPage({
-  params,
-  searchParams
-}: {
-  params: Promise<{ library: string }>
-  searchParams: Promise<{ q?: string }>
-}) {
+export default async function SearchPage({ params, searchParams }: { params: Promise<{ library: string }>; searchParams: Promise<{ q?: string }> }) {
   const { library: libraryId } = await params
   const { q } = await searchParams
   const query = q?.trim()

--- a/src/app/(main)/library/[library]/search/page.tsx
+++ b/src/app/(main)/library/[library]/search/page.tsx
@@ -1,3 +1,27 @@
-export default function SearchPage() {
-  return <div className="w-full p-8">Search</div>
+import { getData, searchLibrary } from '@/lib/api'
+import { redirect } from 'next/navigation'
+import SearchClient from './SearchClient'
+
+export default async function SearchPage({
+  params,
+  searchParams
+}: {
+  params: Promise<{ library: string }>
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { library: libraryId } = await params
+  const { q } = await searchParams
+  const query = q?.trim()
+
+  if (!query) {
+    redirect(`/library/${libraryId}`)
+  }
+
+  const [results] = await getData(searchLibrary(libraryId, query))
+
+  return (
+    <div className="w-full">
+      <SearchClient initialQuery={query} initialResults={results} />
+    </div>
+  )
 }

--- a/src/components/covers/AuthorImage.tsx
+++ b/src/components/covers/AuthorImage.tsx
@@ -44,7 +44,7 @@ export default function AuthorImage({ author, className }: AuthorImageProps) {
         <svg
           width="140%"
           height="140%"
-          style={{ marginLeft: '-20%', marginTop: '-20%', opacity: 0.6 }}
+          style={{ marginLeft: '-20%', marginTop: '-20%', opacity: 0.4 }}
           viewBox="0 0 177 266"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/components/ui/TruncatingTooltipText.tsx
+++ b/src/components/ui/TruncatingTooltipText.tsx
@@ -7,15 +7,16 @@ import { mergeClasses } from '@/lib/merge-classes'
 interface TruncatingTooltipTextProps {
   text: string
   className: string
+  position?: 'top' | 'bottom' | 'left' | 'right'
 }
 
 /**
  * If the text is truncated, a tooltip will be shown.
  */
-export default function TruncatingTooltipText({ text, className }: TruncatingTooltipTextProps) {
+export default function TruncatingTooltipText({ text, className, position = 'top' }: TruncatingTooltipTextProps) {
   const { ref, isTruncated } = useTruncation(text, false)
   return (
-    <Tooltip text={text} position="top" disabled={!isTruncated} className="block w-full">
+    <Tooltip text={text} position={position} disabled={!isTruncated} className="block w-full">
       <p ref={ref} className={mergeClasses('truncate', className)}>
         {text}
       </p>

--- a/src/components/widgets/media-card/AuthorCard.tsx
+++ b/src/components/widgets/media-card/AuthorCard.tsx
@@ -116,7 +116,7 @@ function AuthorCard(props: AuthorCardProps) {
           <>
             {/* Permanent author name & num books overlay */}
             {!isSearching && (
-              <div cy-id="textInline" className="absolute start-0 bottom-0 z-10 w-full bg-black/60 px-2 py-1">
+              <div cy-id="textInline" className="absolute start-0 bottom-0 z-10 w-full bg-black/75 px-2 py-1">
                 <p className="truncate text-center text-[0.75em] font-semibold text-white">{displayName}</p>
                 <p className="text-center text-[0.65em] text-gray-200">
                   {numBooks} {t('LabelBooks')}

--- a/src/components/widgets/media-card/MetadataFilterCard.tsx
+++ b/src/components/widgets/media-card/MetadataFilterCard.tsx
@@ -44,16 +44,14 @@ function MetadataFilterCard({ name, count, filterKey, icon }: MetadataFilterCard
         style={{ width: `${coverWidth}px`, height: `${coverHeight}px`, fontSize: `${sizeMultiplier}rem` }}
       >
         <div className="pointer-events-none absolute inset-0 flex h-full w-full items-center justify-center">
-          <span className="material-symbols text-[8em] text-white opacity-60">{icon}</span>
+          <span className="material-symbols text-[8em] text-white opacity-40">{icon}</span>
         </div>
 
-        <div className="absolute start-0 bottom-0 z-10 w-full bg-black/60 px-2 py-1">
+        <div className="absolute start-0 bottom-0 z-10 w-full bg-black/75 px-2 py-1">
           <div className="text-[0.75em]">
             <TruncatingTooltipText text={name} position="bottom" className="text-center font-semibold text-white" />
           </div>
-          <p className="text-center text-[0.65em] text-gray-200">
-            {countLabel}
-          </p>
+          <p className="text-center text-[0.65em] text-gray-200">{countLabel}</p>
         </div>
       </div>
     </Link>

--- a/src/components/widgets/media-card/MetadataFilterCard.tsx
+++ b/src/components/widgets/media-card/MetadataFilterCard.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import TruncatingTooltipText from '@/components/ui/TruncatingTooltipText'
+import { useCardSize } from '@/contexts/CardSizeContext'
+import { useLibrary } from '@/contexts/LibraryContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { filterEncode } from '@/lib/filterUtils'
+import Link from 'next/link'
+import { memo, useMemo } from 'react'
+
+export type MetadataFilterKey = 'genres' | 'tags' | 'narrators'
+
+export interface MetadataFilterCardProps {
+  name: string
+  count: number
+  filterKey: MetadataFilterKey
+  icon: string
+}
+
+function MetadataFilterCard({ name, count, filterKey, icon }: MetadataFilterCardProps) {
+  const t = useTypeSafeTranslations()
+  const { library } = useLibrary()
+  const { sizeMultiplier } = useCardSize()
+
+  const coverHeight = useMemo(() => 100 * sizeMultiplier, [sizeMultiplier])
+  const coverWidth = useMemo(() => coverHeight * 1.5, [coverHeight])
+
+  const href = `/library/${library.id}/items?filter=${filterKey}.${filterEncode(name)}`
+
+  const countLabel = useMemo(() => {
+    if (filterKey === 'narrators') {
+      return t('LabelXBooks', { count })
+    }
+    if (library.mediaType === 'podcast') {
+      return `${count} Podcast${count === 1 ? '' : 's'}`
+    }
+    return t('LabelXBooks', { count })
+  }, [count, filterKey, library.mediaType, t])
+
+  return (
+    <Link href={href} className="block no-underline">
+      <div
+        className="bg-primary box-shadow-book relative overflow-hidden rounded-md"
+        style={{ width: `${coverWidth}px`, height: `${coverHeight}px`, fontSize: `${sizeMultiplier}rem` }}
+      >
+        <div className="pointer-events-none absolute inset-0 flex h-full w-full items-center justify-center">
+          <span className="material-symbols text-[8em] text-white opacity-60">{icon}</span>
+        </div>
+
+        <div className="absolute start-0 bottom-0 z-10 w-full bg-black/60 px-2 py-1">
+          <div className="text-[0.75em]">
+            <TruncatingTooltipText text={name} position="bottom" className="text-center font-semibold text-white" />
+          </div>
+          <p className="text-center text-[0.65em] text-gray-200">
+            {countLabel}
+          </p>
+        </div>
+      </div>
+    </Link>
+  )
+}
+
+export default memo(MetadataFilterCard)

--- a/src/lib/searchResultsToShelves.ts
+++ b/src/lib/searchResultsToShelves.ts
@@ -1,0 +1,121 @@
+import type { SearchLibraryResponse } from '@/types/api'
+import type { SearchShelf } from '@/types/search'
+import type { TypeSafeTranslations } from '@/types/translations'
+
+export function searchResultsHasResults(results: SearchLibraryResponse | null): boolean {
+  if (!results) return false
+
+  return !!(
+    results.book?.length ||
+    results.podcast?.length ||
+    results.episodes?.length ||
+    results.authors?.length ||
+    results.series?.length ||
+    results.tags?.length ||
+    results.genres?.length ||
+    results.narrators?.length
+  )
+}
+
+export function searchResultsToShelves(results: SearchLibraryResponse | null, t: TypeSafeTranslations): SearchShelf[] {
+  if (!results) return []
+
+  const shelves: SearchShelf[] = []
+
+  if (results.book?.length) {
+    shelves.push({
+      id: 'books',
+      label: t('LabelBooks'),
+      type: 'book',
+      entities: results.book.map((res) => res.libraryItem),
+      total: results.book.length
+    })
+  }
+
+  if (results.podcast?.length) {
+    shelves.push({
+      id: 'podcasts',
+      label: t('LabelPodcasts'),
+      type: 'podcast',
+      entities: results.podcast.map((res) => res.libraryItem),
+      total: results.podcast.length
+    })
+  }
+
+  if (results.episodes?.length) {
+    shelves.push({
+      id: 'episodes',
+      label: t('LabelEpisodes'),
+      type: 'episode',
+      entities: results.episodes.map((res) => res.libraryItem),
+      total: results.episodes.length
+    })
+  }
+
+  if (results.series?.length) {
+    shelves.push({
+      id: 'series',
+      label: t('LabelSeries'),
+      type: 'series',
+      entities: results.series.map((seriesObj) => ({
+        ...seriesObj.series,
+        books: seriesObj.books
+      })),
+      total: results.series.length
+    })
+  }
+
+  if (results.authors?.length) {
+    shelves.push({
+      id: 'authors',
+      label: t('LabelAuthors'),
+      type: 'authors',
+      entities: results.authors,
+      total: results.authors.length
+    })
+  }
+
+  if (results.tags?.length) {
+    shelves.push({
+      id: 'tags',
+      label: t('LabelTags'),
+      type: 'tags',
+      entities: results.tags.map((tagObj) => ({
+        name: tagObj.name,
+        type: 'tags' as const,
+        numItems: tagObj.numItems
+      })),
+      total: results.tags.length
+    })
+  }
+
+  if (results.genres?.length) {
+    shelves.push({
+      id: 'genres',
+      label: t('LabelGenres'),
+      type: 'genres',
+      entities: results.genres.map((genreObj) => ({
+        name: genreObj.name,
+        type: 'genres' as const,
+        numItems: genreObj.numItems
+      })),
+      total: results.genres.length
+    })
+  }
+
+  if (results.narrators?.length) {
+    shelves.push({
+      id: 'narrators',
+      label: t('LabelNarrators'),
+      type: 'narrators',
+      entities: results.narrators.map((n) => ({
+        name: n.name,
+        numBooks: n.numBooks,
+        type: 'narrator' as const
+      })),
+      total: results.narrators.length
+    })
+  }
+
+  return shelves
+}

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,31 @@
+import type { Author, LibraryItem, PersonalizedShelfType, Series } from '@/types/api'
+
+export type SearchShelfType = PersonalizedShelfType | 'tags' | 'genres' | 'narrators'
+
+export interface TagShelfEntity {
+  name: string
+  type: 'tags'
+  numItems: number
+}
+
+export interface GenreShelfEntity {
+  name: string
+  type: 'genres'
+  numItems: number
+}
+
+export interface NarratorShelfEntity {
+  name: string
+  numBooks: number
+  type: 'narrator'
+}
+
+export type SearchShelfEntity = LibraryItem | Series | Author | TagShelfEntity | GenreShelfEntity | NarratorShelfEntity
+
+export interface SearchShelf {
+  id: string
+  label: string
+  type: SearchShelfType
+  entities: SearchShelfEntity[]
+  total: number
+}


### PR DESCRIPTION
This implements the search page (reached by pressing enter when typing a query in the global search box).

### Notable change from Vue implementation
- Contains tag and genre results
  - Tag and genre cards derived from the old narrator card and now share the same component (`MetadataFilterCard`). Used same icons as in global search dropdown
  - Tried a more complex tag/genre card with group cover containing the most recent books, but decided against it due to visible lag - properly showing group covers for tags and genres requires a server change which is not planned right now.
  - Also decided against introducing collection and playlist results (they too require an api call which I didn't want to add right now).