### PR TITLE
Fix broken Dropdown submenu clicks

### DIFF
--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -461,6 +461,15 @@ describe('<Dropdown />', () => {
       cy.get('@onChangeSpy').should('have.been.calledWith', 'sub1')
     })
 
+    it('selects subitem on click with usePortal', () => {
+      const onChangeSpy = cy.spy().as('onChangeSpy')
+      cy.mount(<Dropdown items={itemsWithSubmenus} onChange={onChangeSpy} usePortal />)
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').eq(1).trigger('mouseover')
+      cy.get('[role="menu"] li').first().click({ force: true })
+      cy.get('@onChangeSpy').should('have.been.calledWith', 'sub1')
+    })
+
     it('closes menu after subitem selection', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} />)
       cy.get('button').click()

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useClickOutside } from '@/hooks/useClickOutside'
+import { createAdditionalInsideCheck, useClickOutside } from '@/hooks/useClickOutside'
 import { mergeClasses } from '@/lib/merge-classes'
 import { useCallback, useId, useMemo, useRef, useState } from 'react'
 import DropdownMenu, { DropdownItemLabel, DropdownMenuItem } from './DropdownMenu'
@@ -86,7 +86,10 @@ export default function Dropdown({
     setOpenSubmenuIndex(null)
   }, [])
 
-  useClickOutside(menuRef, buttonRef, closeMenu, true)
+  // data-dropdown-id is used to identify portaled submenus as "inside" the dropdown
+  const isInsideSubmenu = useMemo(() => createAdditionalInsideCheck('data-dropdown-id', dropdownId), [dropdownId])
+
+  useClickOutside(menuRef, buttonRef, closeMenu, true, isInsideSubmenu)
 
   const toggleMenu = () => {
     if (disabled) return

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -145,6 +145,7 @@ function DropdownSubmenu({
     <ul
       ref={submenuRef}
       role="menu"
+      data-dropdown-id={dropdownId}
       className="bg-primary border-dropdown-menu-border absolute z-[9999] overflow-y-auto rounded-md border py-1 shadow-lg"
       style={{
         ...floatingStyles,

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -5,13 +5,23 @@ export function useClickOutside(
   triggerRef: RefObject<HTMLElement | null> | null | undefined,
   handler: (event: MouseEvent) => void,
   /** Use capture phase so outside clicks are detected before bubble-phase stopPropagation on ancestors */
-  useCapture = false
+  useCapture = false,
+  /** Additional predicate for click targets that count as inside but are not under menuRef or triggerRef */
+  isAdditionalInside?: (target: Node) => boolean
 ): void {
   const mouseDownTargetRef = useRef<EventTarget | null>(null)
 
   const handleMouseDown = useCallback((event: MouseEvent) => {
     mouseDownTargetRef.current = event.target
   }, [])
+
+  const isInsideTarget = useCallback(
+    (target: Node | null | undefined) => {
+      if (!target) return false
+      return menuRef.current?.contains(target) || (triggerRef?.current?.contains(target) ?? false) || (isAdditionalInside?.(target) ?? false)
+    },
+    [menuRef, triggerRef, isAdditionalInside]
+  )
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
@@ -20,20 +30,14 @@ export function useClickOutside(
       const clickTarget = event.target as Node
       const startTarget = mouseDownTargetRef.current as Node
 
-      // 1. Check if the mouseup (click) is inside the modal or trigger
-      const isInside = menuRef.current.contains(clickTarget) || (triggerRef?.current?.contains(clickTarget) ?? false)
-
-      // 2. Check if the mousedown (start) was inside the modal or trigger
-      const startedInside = menuRef.current.contains(startTarget) || (triggerRef?.current?.contains(startTarget) ?? false)
-
       // ONLY trigger handler if both the start and end of the click were truly outside
-      if (!isInside && !startedInside) {
+      if (!isInsideTarget(clickTarget) && !isInsideTarget(startTarget)) {
         handler(event)
       }
 
       mouseDownTargetRef.current = null
     },
-    [menuRef, triggerRef, handler]
+    [menuRef, isInsideTarget, handler]
   )
 
   useEffect(() => {
@@ -49,4 +53,9 @@ export function useClickOutside(
       document.removeEventListener('click', handleClickOutside, useCapture)
     }
   }, [handleClickOutside, handleMouseDown, useCapture])
+}
+
+/** Build an isAdditionalInside check for elements tagged with a shared data attribute (e.g. portaled dropdown submenus). */
+export function createAdditionalInsideCheck(attribute: string, value: string): (target: Node) => boolean {
+  return (target: Node) => target instanceof Element && !!target.closest(`[${attribute}="${value}"]`)
 }


### PR DESCRIPTION
This fixes #123

### Fix

Treat portaled submenu fragments as inside the dropdown for click-outside purposes:

- Modify `useClickOutside` to accept an additional "inside" predicate function as argument, `isAdditionalInside`
- Tag submenu roots with `data-dropdown-id`
- Pass `isInsideSubmenu` to `useClickOutside` from `Dropdown` (creaed using `createAdditionalInsideCheck`)

Inlining submenus under `menuRef` (like `ContextMenuDropdown`) was considered but rejected because portaled submenus avoid clipping/positioning issues with the scrollable main menu (`overflow-y-auto`).

### Affected components

- `Dropdown` with submenus (library filter/sort, player settings, etc.)
- Not affected: `ContextMenuDropdown` (submenus stay inside menu ref), `InputDropdown`, `GlobalSearchInput` (menu ref covers portaled root)