### PR TITLE
Add EbookFilesTable, toggle primary/supplementary and read without keeping progress

### DIFF
--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -6,6 +6,7 @@ import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import AudioTracksTable from '@/components/widgets/AudioTracksTable'
 import ChaptersTable from '@/components/widgets/ChaptersTable'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
+import EbookFilesTable from '@/components/widgets/EbookFilesTable'
 import EpisodeTable from '@/components/widgets/EpisodeTable'
 import ExpandableHtml from '@/components/widgets/ExpandableHtml'
 import LibraryFilesTable from '@/components/widgets/LibraryFilesTable'
@@ -213,6 +214,9 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                     episodeDownloadsQueued={episodeDownloadsQueued}
                   />
                 )}
+
+                {/* ebook files table */}
+                {libraryItem.mediaType === 'book' && <EbookFilesTable libraryItem={libraryItem as BookLibraryItem} />}
 
                 {/* library files table */}
                 {!isPodcast && (libraryItem.libraryFiles?.length ?? 0) > 0 && <LibraryFilesTable libraryItem={libraryItem} />}

--- a/src/app/actions/ebookActions.ts
+++ b/src/app/actions/ebookActions.ts
@@ -5,3 +5,7 @@ import * as api from '@/lib/api'
 export async function updateEbookProgressAction(libraryItemId: string, payload: { ebookLocation?: string | number; ebookProgress?: number }) {
   return api.updateEbookProgress(libraryItemId, payload)
 }
+
+export async function updateEbookFileStatusAction(libraryItemId: string, fileIno: string) {
+  return api.updateEbookFileStatus(libraryItemId, fileIno)
+}

--- a/src/app/internal-api/items/[id]/ebook/[fileId]/route.ts
+++ b/src/app/internal-api/items/[id]/ebook/[fileId]/route.ts
@@ -1,0 +1,40 @@
+import { getServerBaseUrl } from '@/lib/api'
+import { attachRefreshedSessionCookies, fetchBackendWithCookieRefresh, respondProxyFailure } from '@/lib/serverBackendProxy'
+import { cookies } from 'next/headers'
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Proxy endpoint for a specific ebook file by inode
+ */
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string; fileId: string }> }) {
+  const { id, fileId } = await params
+  const cookieStore = await cookies()
+
+  try {
+    const baseUrl = getServerBaseUrl()
+    const backendUrl = `${baseUrl}/api/items/${id}/ebook/${fileId}`
+
+    const result = await fetchBackendWithCookieRefresh(backendUrl, cookieStore)
+    if (!result.ok) {
+      return respondProxyFailure(request, result)
+    }
+
+    const { upstream: response, refreshedTokens } = result
+    const fileBuffer = await response.arrayBuffer()
+    const contentType = response.headers.get('content-type') || 'application/octet-stream'
+
+    return attachRefreshedSessionCookies(
+      new NextResponse(fileBuffer, {
+        status: 200,
+        headers: {
+          'Content-Type': contentType,
+          'Cache-Control': 'private, no-cache'
+        }
+      }),
+      refreshedTokens
+    )
+  } catch (error) {
+    console.error('[EbookProxy] Error fetching ebook file:', error)
+    return NextResponse.json({ error: 'Failed to fetch ebook' }, { status: 500 })
+  }
+}

--- a/src/components/ereader/EreaderOverlay.tsx
+++ b/src/components/ereader/EreaderOverlay.tsx
@@ -24,7 +24,9 @@ interface EreaderOverlayProps {
   title: string
   ebookFormat: string
   epubsAllowScriptedContent: boolean
-  savedEbookLocation?: string
+  fileId?: string
+  keepProgress?: boolean
+  savedEbookLocation?: string | number
   savedEbookProgress?: number
   onClose: () => void
 }
@@ -35,6 +37,8 @@ export default function EreaderOverlay({
   title,
   ebookFormat,
   epubsAllowScriptedContent,
+  fileId,
+  keepProgress = true,
   savedEbookLocation,
   savedEbookProgress,
   onClose
@@ -237,10 +241,13 @@ export default function EreaderOverlay({
         </button>
         <div className="relative min-h-0 min-w-0 flex-1">
           <FoliateView
+            key={`${libraryItemId}-${fileId ?? 'primary'}-${keepProgress}`}
             ref={foliateRef}
             libraryItemId={libraryItemId}
             ebookFormat={ebookFormat}
             epubsAllowScriptedContent={epubsAllowScriptedContent}
+            fileId={fileId}
+            keepProgress={keepProgress}
             title={title}
             savedEbookLocation={savedEbookLocation}
             savedEbookProgress={savedEbookProgress}

--- a/src/components/ereader/FoliateView.tsx
+++ b/src/components/ereader/FoliateView.tsx
@@ -50,8 +50,10 @@ interface FoliateViewProps {
   libraryItemId: string
   ebookFormat: string
   epubsAllowScriptedContent: boolean
+  fileId?: string
+  keepProgress?: boolean
   title: string
-  savedEbookLocation?: string
+  savedEbookLocation?: string | number
   savedEbookProgress?: number
   settings: EreaderSettings
   onZoomChange?: (scale: number | null) => void
@@ -67,6 +69,8 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
     libraryItemId,
     ebookFormat,
     epubsAllowScriptedContent,
+    fileId,
+    keepProgress = true,
     title,
     savedEbookLocation,
     savedEbookProgress,
@@ -95,7 +99,10 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
   const zoomCtrlRef = useRef(new FixedLayoutZoomController())
   const onZoomChangeRef = useRef(onZoomChange)
   const onComicPageChangeRef = useRef(onComicPageChange)
+  const keepProgressRef = useRef(keepProgress)
   const currentComicPageIndexRef = useRef(-1)
+
+  keepProgressRef.current = keepProgress
   const currentComicImageUrlRef = useRef<string | null>(null)
   const isReadyRef = useRef(false)
   const pageBased = usesPageBasedProgress(ebookFormat)
@@ -216,6 +223,10 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
   }))
 
   const flushProgress = useCallback(async () => {
+    if (!keepProgressRef.current) {
+      pendingProgressRef.current = null
+      return
+    }
     const pending = pendingProgressRef.current
     if (!pending) return
     pendingProgressRef.current = null
@@ -231,6 +242,7 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
   const scheduleProgressSave = useCallback(
     (detail: FoliateRelocateDetail) => {
       notifyComicPageFromRelocate(detail)
+      if (!keepProgressRef.current) return
 
       const progress = progressFromRelocate(detail, ebookFormat)
       if (!progress) return
@@ -366,7 +378,8 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
           if (handleKeydown) document.removeEventListener('keydown', handleKeydown)
         }
 
-        const response = await fetch(`/internal-api/items/${libraryItemId}/ebook`, {
+        const ebookUrl = fileId ? `/internal-api/items/${libraryItemId}/ebook/${fileId}` : `/internal-api/items/${libraryItemId}/ebook`
+        const response = await fetch(ebookUrl, {
           credentials: 'include',
           headers: { Accept: 'application/json' }
         })
@@ -400,7 +413,7 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
         tocRef.current = toc
         onTocReadyRef.current?.(toc)
 
-        if (pageBased && resumePage) {
+        if (keepProgress && pageBased && resumePage) {
           await view.init({ showTextStart: true })
           const resolved = await view.goTo(resumePage - 1)
           if (resolved) {
@@ -408,7 +421,7 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
           } else {
             console.warn('Failed to resume at saved page, using start of book', resumePage)
           }
-        } else if (resumeCfi) {
+        } else if (keepProgress && resumeCfi) {
           const resumed = await resumeEpubLocation(view, resumeCfi, savedEbookProgress)
           if (resumed) lastSavedLocationRef.current = resumeCfi
         } else {
@@ -458,7 +471,18 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ebookFormat, epubsAllowScriptedContent, flushProgress, libraryItemId, scheduleProgressSave, title])
+  }, [
+    ebookFormat,
+    epubsAllowScriptedContent,
+    fileId,
+    flushProgress,
+    keepProgress,
+    libraryItemId,
+    savedEbookLocation,
+    savedEbookProgress,
+    scheduleProgressSave,
+    title
+  ])
 
   return <div ref={containerRef} className="h-full w-full" />
 })

--- a/src/components/widgets/EbookFilesTable.tsx
+++ b/src/components/widgets/EbookFilesTable.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { deleteLibraryFileAction } from '@/app/actions/audioFileActions'
+import { updateEbookFileStatusAction } from '@/app/actions/ebookActions'
+import Btn from '@/components/ui/Btn'
+import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
+import IconBtn from '@/components/ui/IconBtn'
+import SimpleDataTable from '@/components/ui/SimpleDataTable'
+import Tooltip from '@/components/ui/Tooltip'
+import CollapsibleSection from '@/components/widgets/CollapsibleSection'
+import ConfirmDialog from '@/components/widgets/ConfirmDialog'
+import { useEreader } from '@/contexts/EreaderContext'
+import { useLibrary } from '@/contexts/LibraryContext'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useUser } from '@/contexts/UserContext'
+import { useLibraryFileActions } from '@/hooks/useLibraryFileActions'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { bytesPretty } from '@/lib/string'
+import { BookLibraryItem, LibraryFile } from '@/types/api'
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
+
+const MIN_ACTIONS_WIDTH = 44
+const MIN_SIZE_WIDTH = 80
+const MIN_READ_WIDTH = 48
+const TABLE_BORDER = 2
+const PATH_MIN_WIDTH = 300
+
+const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH
+const SIZE_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_SIZE_WIDTH
+const READ_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_READ_WIDTH
+
+interface EbookFilesTableProps {
+  libraryItem: BookLibraryItem
+  keepOpen?: boolean
+  expanded?: boolean
+}
+
+export default function EbookFilesTable({ libraryItem, keepOpen = false, expanded: expandedProp = false }: EbookFilesTableProps) {
+  const t = useTypeSafeTranslations()
+  const { library } = useLibrary()
+  const { openEreader } = useEreader()
+  const { userCanDelete, userCanDownload, userCanUpdate, userIsAdminOrUp } = useUser()
+  const { showToast } = useGlobalToast()
+  const [, startDeleteTransition] = useTransition()
+  const [, startUpdateTransition] = useTransition()
+  const [expanded, setExpanded] = useState(expandedProp)
+  const [showFullPath, setShowFullPath] = useState(false)
+  const [fileToDelete, setFileToDelete] = useState<LibraryFile | null>(null)
+  const [processingIno, setProcessingIno] = useState<string | null>(null)
+
+  const { downloadFile } = useLibraryFileActions(libraryItem.id)
+
+  const ebookFiles = useMemo<LibraryFile[]>(() => (libraryItem.libraryFiles || []).filter((file) => file.fileType === 'ebook'), [libraryItem.libraryFiles])
+
+  const libraryIsAudiobooksOnly = !!library.settings?.audiobooksOnly
+  const showMoreColumn = userCanDelete || userCanDownload || (userCanUpdate && !libraryIsAudiobooksOnly)
+
+  useEffect(() => {
+    if (userIsAdminOrUp) {
+      const stored = localStorage.getItem('showFullPath')
+      setShowFullPath(stored === '1')
+    }
+  }, [userIsAdminOrUp])
+
+  useEffect(() => {
+    setExpanded(keepOpen || expandedProp)
+  }, [keepOpen, expandedProp])
+
+  const toggleFullPath = useCallback(() => {
+    setShowFullPath((prev) => {
+      const newValue = !prev
+      localStorage.setItem('showFullPath', newValue ? '1' : '0')
+      return newValue
+    })
+  }, [])
+
+  const handleReadEbook = useCallback(
+    (file: LibraryFile) => {
+      const ebookFormat = file.metadata.ext.replace(/^\./, '').toLowerCase()
+      openEreader({
+        libraryItemId: libraryItem.id,
+        title: libraryItem.media.metadata.title ?? file.metadata.filename,
+        ebookFormat,
+        epubsAllowScriptedContent: !!library.settings?.epubsAllowScriptedContent,
+        fileId: file.ino,
+        keepProgress: false
+      })
+    },
+    [library.settings?.epubsAllowScriptedContent, libraryItem.id, libraryItem.media.metadata.title, openEreader]
+  )
+
+  const handleDeleteFile = useCallback((file: LibraryFile) => {
+    setFileToDelete(file)
+  }, [])
+
+  const handleConfirmDelete = useCallback(() => {
+    if (!fileToDelete) return
+
+    startDeleteTransition(async () => {
+      setProcessingIno(fileToDelete.ino)
+      try {
+        await deleteLibraryFileAction(libraryItem.id, fileToDelete.ino)
+        showToast(t('ToastDeleteFileSuccess'), { type: 'success' })
+      } catch (error) {
+        console.error('Failed to delete file', error)
+        showToast(t('ToastDeleteFileFailed'), { type: 'error' })
+      } finally {
+        setProcessingIno(null)
+        setFileToDelete(null)
+      }
+    })
+  }, [fileToDelete, libraryItem.id, showToast, startDeleteTransition, t])
+
+  const handleUpdateEbookStatus = useCallback(
+    (file: LibraryFile) => {
+      startUpdateTransition(async () => {
+        setProcessingIno(file.ino)
+        try {
+          await updateEbookFileStatusAction(libraryItem.id, file.ino)
+          showToast(t('ToastItemUpdateSuccess'), { type: 'success' })
+        } catch (error) {
+          console.error('Failed to update ebook', error)
+          showToast(t('ToastFailedToUpdate'), { type: 'error' })
+        } finally {
+          setProcessingIno(null)
+        }
+      })
+    },
+    [libraryItem.id, showToast, startUpdateTransition, t]
+  )
+
+  const columns = useMemo(
+    () => [
+      {
+        label: t('LabelPath'),
+        accessor: (row: LibraryFile) => {
+          const isPrimary = !row.isSupplementary
+          return (
+            <span className="break-all">
+              {showFullPath ? row.metadata.path : row.metadata.relPath}
+              {isPrimary && (
+                <Tooltip text={t('LabelPrimaryEbook')} position="top" className="ms-1 inline-block">
+                  <span className="material-symbols text-success align-text-bottom text-base">check_circle</span>
+                </Tooltip>
+              )}
+            </span>
+          )
+        },
+        headerClassName: 'text-start px-2 md:px-4 min-w-[300px]',
+        cellClassName: 'text-start px-2 md:px-4 py-1 align-middle'
+      },
+      {
+        label: t('LabelSize'),
+        accessor: (row: LibraryFile) => bytesPretty(row.metadata.size),
+        headerClassName: 'text-start w-22 min-w-20 px-2',
+        cellClassName: 'text-start py-1 text-xs md:text-sm whitespace-nowrap px-2 align-middle',
+        minTableWidth: SIZE_MIN_TABLE_WIDTH
+      },
+      {
+        label: (
+          <span className="inline-flex items-center gap-1">
+            {t('LabelRead')}
+            <Tooltip text={t('LabelReadEbookWithoutProgress')} position="top" className="inline-block">
+              <span className="material-symbols align-middle text-sm">info</span>
+            </Tooltip>
+          </span>
+        ),
+        accessor: (row: LibraryFile) => (
+          <IconBtn
+            size="small"
+            outlined
+            borderless
+            ariaLabel={t('LabelReadEbookWithoutProgress')}
+            onClick={(e) => {
+              e.stopPropagation()
+              handleReadEbook(row)
+            }}
+          >
+            auto_stories
+          </IconBtn>
+        ),
+        headerClassName: 'text-start w-24 min-w-24 px-2',
+        cellClassName: 'text-start py-1 px-2 align-middle',
+        minTableWidth: READ_MIN_TABLE_WIDTH
+      },
+      ...(showMoreColumn
+        ? [
+            {
+              label: '',
+              accessor: (row: LibraryFile) => {
+                const isPrimary = !row.isSupplementary
+                const items: ContextMenuDropdownItem[] = []
+                if (userCanUpdate && !libraryIsAudiobooksOnly) {
+                  items.push({
+                    text: isPrimary ? t('LabelSetEbookAsSupplementary') : t('LabelSetEbookAsPrimary'),
+                    action: 'updateStatus'
+                  })
+                }
+                if (userCanDownload) items.push({ text: t('LabelDownload'), action: 'download' })
+                if (userCanDelete) items.push({ text: t('ButtonDelete'), action: 'delete' })
+
+                if (items.length === 0) return null
+
+                return (
+                  <ContextMenuDropdown
+                    items={items}
+                    autoWidth
+                    size="small"
+                    borderless
+                    processing={processingIno === row.ino}
+                    className="h-6 w-6 md:h-7 md:w-7"
+                    onAction={({ action }) => {
+                      if (action === 'delete') handleDeleteFile(row)
+                      else if (action === 'download') downloadFile(row.ino, row.metadata.filename)
+                      else if (action === 'updateStatus') handleUpdateEbookStatus(row)
+                    }}
+                    usePortal
+                  />
+                )
+              },
+              headerClassName: 'w-12 min-w-11',
+              cellClassName: 'text-center py-1 align-middle'
+            }
+          ]
+        : [])
+    ],
+    [
+      t,
+      showFullPath,
+      showMoreColumn,
+      userCanUpdate,
+      userCanDownload,
+      userCanDelete,
+      libraryIsAudiobooksOnly,
+      processingIno,
+      handleReadEbook,
+      handleDeleteFile,
+      handleUpdateEbookStatus,
+      downloadFile
+    ]
+  )
+
+  const headerActions = useMemo(
+    () =>
+      userIsAdminOrUp ? (
+        <Btn
+          color={showFullPath ? 'bg-button-selected-bg' : ''}
+          size="small"
+          className="mr-2 hidden md:inline-flex"
+          onClick={(e) => {
+            e.stopPropagation()
+            toggleFullPath()
+          }}
+        >
+          {t('ButtonFullPath')}
+        </Btn>
+      ) : null,
+    [userIsAdminOrUp, showFullPath, toggleFullPath, t]
+  )
+
+  if (ebookFiles.length === 0) {
+    return null
+  }
+
+  return (
+    <>
+      <CollapsibleSection
+        title={t('HeaderEbookFiles')}
+        count={ebookFiles.length}
+        expanded={expanded}
+        onExpandedChange={setExpanded}
+        keepOpen={keepOpen}
+        headerActions={headerActions}
+      >
+        <SimpleDataTable data={ebookFiles} columns={columns} getRowKey={(row) => row.ino} />
+      </CollapsibleSection>
+
+      <ConfirmDialog isOpen={!!fileToDelete} message={t('MessageConfirmDeleteFile')} onClose={() => setFileToDelete(null)} onConfirm={handleConfirmDelete} />
+    </>
+  )
+}

--- a/src/contexts/EreaderContext.tsx
+++ b/src/contexts/EreaderContext.tsx
@@ -9,11 +9,15 @@ export interface OpenEreaderParams {
   title: string
   ebookFormat: string
   epubsAllowScriptedContent: boolean
+  /** When set, load this specific ebook file instead of the primary ebook */
+  fileId?: string
+  /** When false, open without resuming saved progress (defaults to true) */
+  keepProgress?: boolean
 }
 
 interface EreaderSession extends OpenEreaderParams {
   /** Snapshot at open time so progress saves do not re-trigger the reader. */
-  savedEbookLocation?: string
+  savedEbookLocation?: string | number
   savedEbookProgress?: number
 }
 
@@ -30,11 +34,13 @@ export function EreaderProvider({ children }: { children: ReactNode }) {
 
   const openEreader = useCallback(
     (params: OpenEreaderParams) => {
-      const progress = user.mediaProgress.find((p) => p.libraryItemId === params.libraryItemId)
+      const keepProgress = params.keepProgress !== false
+      const progress = keepProgress ? user.mediaProgress.find((p) => p.libraryItemId === params.libraryItemId) : undefined
       setSession({
         ...params,
-        savedEbookLocation: progress?.ebookLocation,
-        savedEbookProgress: progress?.ebookProgress
+        keepProgress,
+        savedEbookLocation: keepProgress ? progress?.ebookLocation : undefined,
+        savedEbookProgress: keepProgress ? progress?.ebookProgress : undefined
       })
     },
     [user.mediaProgress]
@@ -62,6 +68,8 @@ export function EreaderProvider({ children }: { children: ReactNode }) {
           title={session.title}
           ebookFormat={session.ebookFormat}
           epubsAllowScriptedContent={session.epubsAllowScriptedContent}
+          fileId={session.fileId}
+          keepProgress={session.keepProgress !== false}
           savedEbookLocation={session.savedEbookLocation}
           savedEbookProgress={session.savedEbookProgress}
           onClose={closeEreader}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -813,6 +813,15 @@ export async function updateMediaFinished(libraryItemId: string, payload: { isFi
 }
 
 /**
+ * Toggle primary/supplementary status for an ebook file
+ */
+export async function updateEbookFileStatus(libraryItemId: string, fileIno: string): Promise<void> {
+  return apiRequest<void>(`/api/items/${libraryItemId}/ebook/${fileIno}/status`, {
+    method: 'PATCH'
+  })
+}
+
+/**
  * Update ebook reading progress for a library item
  */
 export async function updateEbookProgress(libraryItemId: string, payload: { ebookLocation?: string | number; ebookProgress?: number }): Promise<void> {

--- a/src/lib/ereader/ereaderEbook.ts
+++ b/src/lib/ereader/ereaderEbook.ts
@@ -44,7 +44,7 @@ export type EbookProgressUpdate = {
 }
 
 /** Parse a 1-based page from saved progress */
-export function parseResumePage(location: string | undefined, format: string): number | undefined {
+export function parseResumePage(location: string | number | undefined, format: string): number | undefined {
   if (!location || !usesPageBasedProgress(format)) return undefined
 
   const page = Number(location)
@@ -52,8 +52,9 @@ export function parseResumePage(location: string | undefined, format: string): n
   return Math.floor(page)
 }
 
-export function parseResumeCfi(location: string | undefined, format: string): string | undefined {
-  if (!location || usesPageBasedProgress(format)) return undefined
+export function parseResumeCfi(location: string | number | undefined, format: string): string | undefined {
+  if (location == null || usesPageBasedProgress(format)) return undefined
+  if (typeof location !== 'string') return undefined
   return location.startsWith('epubcfi') ? location : undefined
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -787,7 +787,7 @@ export interface MediaProgress {
   currentTime: number
   isFinished: boolean
   hideFromContinueListening?: boolean
-  ebookLocation?: string
+  ebookLocation?: string | number
   ebookProgress: number
   finishedAt?: number
   lastUpdate: number


### PR DESCRIPTION
The ebook files table allows for opening supplementary ebook files and setting ebooks as primary/supplementary.

This implements a new proxy endpoint for fetching a specific ebook file by inode. The ereader can be opened with the `keepProgress` flag set to false and an ebook file id (inode).

This also fixes a bug when an epub has saved progress from a PDF. PDF uses page number and epub uses CFI. This can happen when switching the primary ebook to an epub from a pdf. 

<img width="596" height="244" alt="image" src="https://github.com/user-attachments/assets/e5e1a449-f65d-4435-8b04-c07a0abc11d9" />

