### PR TITLE
Implement tools page

### DIFF
--- a/src/app/(main)/library/[library]/item/[item]/tools/page.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/tools/page.tsx
@@ -15,7 +15,7 @@ export default async function ToolsPage({ params }: { params: Promise<{ item: st
   const itemPath = `/library/${libraryItem.libraryId}/item/${libraryItem.id}`
   const bookItem = libraryItem.mediaType === 'book' ? (libraryItem as BookLibraryItem) : null
 
-  if (!isUserAdminOrUp(currentUser.user) || !bookItem || !(bookItem.media.tracks?.length)) {
+  if (!isUserAdminOrUp(currentUser.user) || !bookItem || !bookItem.media.tracks?.length) {
     redirect(itemPath)
   }
 

--- a/src/app/(main)/library/[library]/item/[item]/tools/page.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/tools/page.tsx
@@ -1,0 +1,23 @@
+import AudiobookTools from '@/components/widgets/audiobook-tools/AudiobookTools'
+import { getCurrentUser, getData, getLibraryItem } from '@/lib/api'
+import { isUserAdminOrUp } from '@/lib/userPermissions'
+import type { BookLibraryItem } from '@/types/api'
+import { redirect } from 'next/navigation'
+
+export default async function ToolsPage({ params }: { params: Promise<{ item: string; library: string }> }) {
+  const { item: itemId } = await params
+  const [libraryItem, currentUser] = await getData(getLibraryItem(itemId, true), getCurrentUser())
+
+  if (!libraryItem || !currentUser) {
+    redirect('/')
+  }
+
+  const itemPath = `/library/${libraryItem.libraryId}/item/${libraryItem.id}`
+  const bookItem = libraryItem.mediaType === 'book' ? (libraryItem as BookLibraryItem) : null
+
+  if (!isUserAdminOrUp(currentUser.user) || !bookItem || !(bookItem.media.tracks?.length)) {
+    redirect(itemPath)
+  }
+
+  return <AudiobookTools libraryItem={bookItem} />
+}

--- a/src/app/actions/toolsActions.ts
+++ b/src/app/actions/toolsActions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import type { M4bEncodeOptions } from '@/types/api'
+import type { M4bEncodeOptions, MetadataObject } from '@/types/api'
 import * as api from '@/lib/api'
 
 /**
@@ -20,7 +20,7 @@ export async function getTasksAction() {
 /**
  * Server Action: Get metadata object for embedding preview
  */
-export async function getMetadataObjectAction(libraryItemId: string) {
+export async function getMetadataObjectAction(libraryItemId: string): Promise<MetadataObject> {
   return api.getMetadataObject(libraryItemId)
 }
 

--- a/src/app/actions/toolsActions.ts
+++ b/src/app/actions/toolsActions.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import type { M4bEncodeOptions } from '@/types/api'
 import * as api from '@/lib/api'
 
 /**
@@ -14,4 +15,32 @@ export async function embedMetadataQuickAction(libraryItemId: string) {
  */
 export async function getTasksAction() {
   return api.getTasks()
+}
+
+/**
+ * Server Action: Get metadata object for embedding preview
+ */
+export async function getMetadataObjectAction(libraryItemId: string) {
+  return api.getMetadataObject(libraryItemId)
+}
+
+/**
+ * Server Action: Embed metadata into audio files with optional backup
+ */
+export async function embedMetadataAction(libraryItemId: string, backup: boolean) {
+  return api.embedMetadata(libraryItemId, backup)
+}
+
+/**
+ * Server Action: Start M4B encode for a library item
+ */
+export async function encodeM4bAction(libraryItemId: string, options: M4bEncodeOptions) {
+  return api.encodeM4b(libraryItemId, options)
+}
+
+/**
+ * Server Action: Cancel an in-progress M4B encode
+ */
+export async function cancelM4bEncodeAction(libraryItemId: string) {
+  return api.cancelM4bEncode(libraryItemId)
 }

--- a/src/components/widgets/NotificationWidget.tsx
+++ b/src/components/widgets/NotificationWidget.tsx
@@ -19,7 +19,9 @@ function getActionLink(task: Task): string {
     case 'download-podcast-episode':
       return libraryId ? `/library/${libraryId}/podcast/download-queue` : ''
     case 'encode-m4b':
+      return libraryId && libraryItemId ? `/library/${libraryId}/item/${libraryItemId}/tools?tool=m4b` : ''
     case 'embed-metadata':
+      return libraryId && libraryItemId ? `/library/${libraryId}/item/${libraryItemId}/tools?tool=embed` : ''
     case 'scan-item':
       return libraryId && libraryItemId ? `/library/${libraryId}/item/${libraryItemId}` : ''
     default:

--- a/src/components/widgets/Tools.tsx
+++ b/src/components/widgets/Tools.tsx
@@ -1,3 +1,8 @@
+/**
+ * Not currently wired into the production app (components catalog only).
+ * Migrated from the Vue Edit modal Tools tab; superseded by the item-page
+ * /tools manage page (AudiobookTools).
+ */
 'use client'
 
 import { embedMetadataQuickAction } from '@/app/actions/toolsActions'
@@ -16,12 +21,6 @@ interface ToolsProps {
   className?: string
 }
 
-/**
- * Tools component for audiobook management
- *
- * Provides quick access to metadata embedding and M4B creation tools.
- * Only Quick Embed is functional - other tools link to management pages.
- */
 export default function Tools({ libraryItem, className }: ToolsProps) {
   const t = useTypeSafeTranslations()
   const { queuedEmbedLIds, taskProgress, getTasksByLibraryItemId } = useTasks()
@@ -45,7 +44,7 @@ export default function Tools({ libraryItem, className }: ToolsProps) {
     if (!isBookLibraryItem(libraryItem)) {
       return []
     }
-    return libraryItem.media.tracks || []
+    return libraryItem.media.tracks ?? []
   }, [libraryItem])
 
   const itemTasks = useMemo(() => getTasksByLibraryItemId(libraryItemId), [getTasksByLibraryItemId, libraryItemId])
@@ -123,7 +122,7 @@ export default function Tools({ libraryItem, className }: ToolsProps) {
               </div>
               <div className="w-full sm:w-[180px]">
                 <Btn
-                  to={`/library/${libraryItem.libraryId}/item/${libraryItemId}/manage?tool=m4b`}
+                  to={`/library/${libraryItem.libraryId}/item/${libraryItemId}/tools?tool=m4b`}
                   className="flex w-full items-center justify-center whitespace-nowrap"
                   aria-describedby={elementIds.m4bDescription}
                 >
@@ -150,7 +149,7 @@ export default function Tools({ libraryItem, className }: ToolsProps) {
               <div className="flex w-full flex-col items-end sm:w-auto">
                 <div className="w-full sm:w-[180px]">
                   <Btn
-                    to={`/library/${libraryItem.libraryId}/item/${libraryItemId}/manage?tool=embed`}
+                    to={`/library/${libraryItem.libraryId}/item/${libraryItemId}/tools?tool=embed`}
                     className="flex w-full items-center justify-center whitespace-nowrap"
                     aria-describedby={elementIds.embedDescription}
                   >

--- a/src/components/widgets/audiobook-tools/AudioTracksProgressTable.tsx
+++ b/src/components/widgets/audiobook-tools/AudioTracksProgressTable.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { bytesPretty } from '@/lib/string'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { AudioTrack } from '@/types/api'
+
+interface AudioTracksProgressTableProps {
+  tracks: AudioTrack[]
+  audioFilesEncoding: Record<string, string>
+  audioFilesFinished: Record<string, boolean>
+}
+
+export default function AudioTracksProgressTable({ tracks, audioFilesEncoding, audioFilesFinished }: AudioTracksProgressTableProps) {
+  const t = useTypeSafeTranslations()
+
+  return (
+    <div>
+      <p className="mb-2 font-semibold">{t('HeaderAudioTracks')}</p>
+      <div className="border-border bg-bg w-full border">
+        <div className="bg-primary/25 flex px-4 py-2">
+          <div className="text-foreground-muted w-10 text-xs font-semibold">#</div>
+          <div className="text-foreground-muted grow text-xs font-semibold uppercase">{t('LabelFilename')}</div>
+          <div className="text-foreground-muted hidden w-20 text-xs font-semibold uppercase lg:block">{t('LabelChannels')}</div>
+          <div className="text-foreground-muted hidden w-16 text-xs font-semibold uppercase md:block">{t('LabelCodec')}</div>
+          <div className="text-foreground-muted hidden w-16 text-xs font-semibold uppercase md:block">{t('LabelBitrate')}</div>
+          <div className="text-foreground-muted w-16 text-xs font-semibold uppercase">{t('LabelSize')}</div>
+          <div className="w-24" />
+        </div>
+        {tracks.map((file) => (
+          <div key={file.ino} className={`flex px-4 py-2 text-xs sm:text-sm ${file.index % 2 === 0 ? 'bg-primary/25' : ''}`}>
+            <div className="w-10 min-w-10">{file.index}</div>
+            <div className="grow break-all">{file.metadata.filename}</div>
+            <div className="text-foreground-muted hidden w-20 min-w-20 lg:block">
+              {file.channels || 'unknown'} ({file.channelLayout || 'unknown'})
+            </div>
+            <div className="text-foreground-muted hidden w-16 min-w-16 md:block">{file.codec || 'unknown'}</div>
+            <div className="text-foreground-muted hidden w-16 min-w-16 md:block">{bytesPretty(file.bitRate || 0, 0)}</div>
+            <div className="text-foreground-muted w-16 min-w-16">{bytesPretty(file.metadata.size)}</div>
+            <div className="w-24 min-w-24">
+              <div className="flex justify-center">
+                {audioFilesFinished[file.ino] ? (
+                  <span className="material-symbols text-success text-xl leading-none">check_circle</span>
+                ) : audioFilesEncoding[file.ino] ? (
+                  <span className="text-success font-mono leading-none">{audioFilesEncoding[file.ino]}</span>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/AudiobookTools.tsx
+++ b/src/components/widgets/audiobook-tools/AudiobookTools.tsx
@@ -1,0 +1,142 @@
+'use client'
+
+import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import Dropdown from '@/components/ui/Dropdown'
+import IconBtn from '@/components/ui/IconBtn'
+import ConfirmDialog from '@/components/widgets/ConfirmDialog'
+import AudioTracksProgressTable from '@/components/widgets/audiobook-tools/AudioTracksProgressTable'
+import ChaptersPreviewTable from '@/components/widgets/audiobook-tools/ChaptersPreviewTable'
+import EmbedMetadataPanel from '@/components/widgets/audiobook-tools/EmbedMetadataPanel'
+import M4bEncodePanel from '@/components/widgets/audiobook-tools/M4bEncodePanel'
+import ToolsInfoNotes from '@/components/widgets/audiobook-tools/ToolsInfoNotes'
+import MetadataPreviewTable from '@/components/widgets/audiobook-tools/MetadataPreviewTable'
+import { useMediaContext } from '@/contexts/MediaContext'
+import { useAudiobookTools } from '@/hooks/useAudiobookTools'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { mergeClasses } from '@/lib/merge-classes'
+import type { BookLibraryItem } from '@/types/api'
+import Link from 'next/link'
+
+interface AudiobookToolsProps {
+  libraryItem: BookLibraryItem
+}
+
+export default function AudiobookTools({ libraryItem: initialLibraryItem }: AudiobookToolsProps) {
+  const t = useTypeSafeTranslations()
+  const { streamLibraryItem } = useMediaContext()
+  const isStreaming = streamLibraryItem?.id === initialLibraryItem.id
+
+  const tools = useAudiobookTools({ initialLibraryItem })
+
+  return (
+    <div className={mergeClasses('bg-bg relative min-h-full overflow-y-auto p-8', isStreaming && 'streaming')}>
+      <div className="mb-6 flex items-center justify-center">
+        <div className="w-full max-w-2xl">
+          <div className="mb-4 flex items-center">
+            <Link href={`/library/${tools.libraryItem.libraryId}/item/${tools.libraryItem.id}`} className="hover:underline">
+              <h1 className="text-lg lg:text-xl">{tools.title}</h1>
+            </Link>
+            <IconBtn ariaLabel={t('ButtonEdit')} borderless size="small" className="mx-4" onClick={() => tools.setIsEditModalOpen(true)}>
+              edit
+            </IconBtn>
+          </div>
+        </div>
+        <div className="w-full max-w-2xl">
+          <div className="flex justify-end">
+            <Dropdown
+              value={tools.selectedTool}
+              items={tools.toolDropdownItems}
+              disabled={tools.processing}
+              className="max-w-sm"
+              onChange={(value) => tools.setSelectedTool(value === 'm4b' ? 'm4b' : 'embed')}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-2 flex justify-center">
+        <div className="w-full max-w-2xl">
+          <p className="text-lg">{t('HeaderMetadataToEmbed')}</p>
+        </div>
+        <div className="w-full max-w-2xl" />
+      </div>
+
+      <div className="flex flex-wrap justify-center gap-4 lg:flex-nowrap">
+        <div className="w-full max-w-2xl">
+          <MetadataPreviewTable metadataObject={tools.metadataObject} />
+        </div>
+        <div className="w-full max-w-2xl">
+          <ChaptersPreviewTable chapters={tools.metadataChapters} />
+        </div>
+      </div>
+
+      <div className="my-8 h-px w-full bg-white/10" />
+
+      <div className="mx-auto w-full max-w-4xl">
+        {tools.isEmbedTool ? (
+          <EmbedMetadataPanel
+            isMetadataEmbedQueued={tools.isMetadataEmbedQueued}
+            queuedEmbedCount={tools.queuedEmbedCount}
+            processing={tools.processing}
+            progress={tools.progress}
+            isTaskFinished={tools.isTaskFinished}
+            taskFailed={tools.taskFailed}
+            taskError={tools.taskError}
+            shouldBackupAudioFiles={tools.shouldBackupAudioFiles}
+            onBackupChange={tools.toggleBackupAudioFiles}
+            onStartEmbed={tools.handleEmbedClick}
+          />
+        ) : (
+          <M4bEncodePanel
+            tracks={tools.tracks}
+            processing={tools.processing}
+            progress={tools.progress}
+            isTaskFinished={tools.isTaskFinished}
+            taskFailed={tools.taskFailed}
+            taskError={tools.taskError}
+            isCancelingEncode={tools.isCancelingEncode}
+            encodeTaskHasEncodingOptions={tools.encodeTaskHasEncodingOptions}
+            encodingOptions={tools.encodingOptions}
+            onEncodingOptionsChange={tools.handleEncodingOptionsChange}
+            onStartEncode={tools.handleEncodeM4bClick}
+            onCancelEncode={tools.handleCancelEncodeClick}
+          />
+        )}
+
+        <ToolsInfoNotes
+          selectedTool={tools.selectedTool}
+          libraryItemRelPath={tools.libraryItemRelPath}
+          libraryItemId={tools.libraryItem.id}
+          shouldBackupAudioFiles={tools.shouldBackupAudioFiles}
+          trackCount={tools.tracks.length}
+        />
+      </div>
+
+      <div className="mx-auto w-full max-w-4xl">
+        <AudioTracksProgressTable
+          tracks={tools.tracks}
+          audioFilesEncoding={tools.audioFilesEncoding}
+          audioFilesFinished={tools.audioFilesFinished}
+        />
+      </div>
+
+      {tools.confirmState && (
+        <ConfirmDialog
+          isOpen={tools.confirmState.isOpen}
+          message={tools.confirmState.message}
+          yesButtonText={tools.confirmState.yesButtonText}
+          yesButtonClassName={tools.confirmState.yesButtonClassName}
+          onClose={() => tools.setConfirmState(null)}
+          onConfirm={() => tools.confirmState?.onConfirm()}
+        />
+      )}
+
+      <LibraryItemEditModal
+        isOpen={tools.isEditModalOpen}
+        libraryItem={tools.libraryItem}
+        onClose={() => tools.setIsEditModalOpen(false)}
+        onSaved={tools.handleLibraryItemSaved}
+      />
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/AudiobookTools.tsx
+++ b/src/components/widgets/audiobook-tools/AudiobookTools.tsx
@@ -8,8 +8,8 @@ import AudioTracksProgressTable from '@/components/widgets/audiobook-tools/Audio
 import ChaptersPreviewTable from '@/components/widgets/audiobook-tools/ChaptersPreviewTable'
 import EmbedMetadataPanel from '@/components/widgets/audiobook-tools/EmbedMetadataPanel'
 import M4bEncodePanel from '@/components/widgets/audiobook-tools/M4bEncodePanel'
-import ToolsInfoNotes from '@/components/widgets/audiobook-tools/ToolsInfoNotes'
 import MetadataPreviewTable from '@/components/widgets/audiobook-tools/MetadataPreviewTable'
+import ToolsInfoNotes from '@/components/widgets/audiobook-tools/ToolsInfoNotes'
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useAudiobookTools } from '@/hooks/useAudiobookTools'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
@@ -70,7 +70,7 @@ export default function AudiobookTools({ libraryItem: initialLibraryItem }: Audi
         </div>
       </div>
 
-      <div className="my-8 h-px w-full bg-white/10" />
+      <div className="bg-foreground/10 my-8 h-px w-full" />
 
       <div className="mx-auto w-full max-w-4xl">
         {tools.isEmbedTool ? (
@@ -113,11 +113,7 @@ export default function AudiobookTools({ libraryItem: initialLibraryItem }: Audi
       </div>
 
       <div className="mx-auto w-full max-w-4xl">
-        <AudioTracksProgressTable
-          tracks={tools.tracks}
-          audioFilesEncoding={tools.audioFilesEncoding}
-          audioFilesFinished={tools.audioFilesFinished}
-        />
+        <AudioTracksProgressTable tracks={tools.tracks} audioFilesEncoding={tools.audioFilesEncoding} audioFilesFinished={tools.audioFilesFinished} />
       </div>
 
       {tools.confirmState && (
@@ -131,12 +127,7 @@ export default function AudiobookTools({ libraryItem: initialLibraryItem }: Audi
         />
       )}
 
-      <LibraryItemEditModal
-        isOpen={tools.isEditModalOpen}
-        libraryItem={tools.libraryItem}
-        onClose={() => tools.setIsEditModalOpen(false)}
-        onSaved={tools.handleLibraryItemSaved}
-      />
+      <LibraryItemEditModal isOpen={tools.isEditModalOpen} libraryItem={tools.libraryItem} onClose={() => tools.setIsEditModalOpen(false)} />
     </div>
   )
 }

--- a/src/components/widgets/audiobook-tools/ChaptersPreviewTable.tsx
+++ b/src/components/widgets/audiobook-tools/ChaptersPreviewTable.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { secondsToTimestamp } from '@/lib/datefns'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { Chapter } from '@/types/api'
+
+interface ChaptersPreviewTableProps {
+  chapters: Chapter[]
+}
+
+export default function ChaptersPreviewTable({ chapters }: ChaptersPreviewTableProps) {
+  const t = useTypeSafeTranslations()
+
+  return (
+    <div className="border-border bg-bg w-full border">
+      <div className="bg-primary/25 flex px-4 py-2">
+        <div className="text-foreground-muted grow text-xs font-semibold uppercase">{t('LabelChapterTitle')}</div>
+        <div className="text-foreground-muted w-16 min-w-16 text-xs font-semibold uppercase">{t('LabelStart')}</div>
+        <div className="text-foreground-muted w-16 min-w-16 text-xs font-semibold uppercase">{t('LabelEnd')}</div>
+      </div>
+      <div className="max-h-72 w-full overflow-auto">
+        {!chapters.length ? (
+          <p className="text-foreground-muted py-5 text-center">{t('MessageNoChapters')}</p>
+        ) : (
+          chapters.map((chapter, index) => (
+            <div key={`${chapter.start}-${chapter.title}`} className={`flex px-4 py-1 text-sm ${index % 2 === 1 ? 'bg-primary/25' : ''}`}>
+              <div className="grow font-semibold">{chapter.title}</div>
+              <div className="w-16 min-w-16">{secondsToTimestamp(chapter.start)}</div>
+              <div className="w-16 min-w-16">{secondsToTimestamp(chapter.end)}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/EmbedMetadataPanel.tsx
+++ b/src/components/widgets/audiobook-tools/EmbedMetadataPanel.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import Btn from '@/components/ui/Btn'
+import Checkbox from '@/components/ui/Checkbox'
+import Alert from '@/components/widgets/Alert'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+
+interface EmbedMetadataPanelProps {
+  isMetadataEmbedQueued: boolean
+  queuedEmbedCount: number
+  processing: boolean
+  progress: string
+  isTaskFinished: boolean
+  taskFailed: boolean
+  taskError: string | null
+  shouldBackupAudioFiles: boolean
+  onBackupChange: (value: boolean) => void
+  onStartEmbed: () => void
+}
+
+export default function EmbedMetadataPanel({
+  isMetadataEmbedQueued,
+  queuedEmbedCount,
+  processing,
+  progress,
+  isTaskFinished,
+  taskFailed,
+  taskError,
+  shouldBackupAudioFiles,
+  onBackupChange,
+  onStartEmbed
+}: EmbedMetadataPanelProps) {
+  const t = useTypeSafeTranslations()
+
+  if (isMetadataEmbedQueued) {
+    return (
+      <Alert type="warning" className="mb-4">
+        <p className="text-lg">{t('MessageEmbedQueue', { 0: queuedEmbedCount })}</p>
+      </Alert>
+    )
+  }
+
+  return (
+    <div className="mb-4 flex w-full items-center justify-end">
+      {!isTaskFinished && (
+        <Checkbox
+          value={shouldBackupAudioFiles}
+          disabled={processing}
+          label={t('LabelBackupAudioFiles')}
+          checkboxBgClass="bg-bg"
+          labelClass="ps-2 text-base md:text-lg"
+          onChange={onBackupChange}
+        />
+      )}
+
+      <div className="grow" />
+
+      {!isTaskFinished ? (
+        <Btn color="bg-primary" loading={processing} progress={progress} onClick={onStartEmbed}>
+          {t('ButtonStartMetadataEmbed')}
+        </Btn>
+      ) : taskFailed ? (
+        <p className="text-error text-lg font-semibold">
+          {t('MessageEmbedFailed')} {taskError}
+        </p>
+      ) : (
+        <p className="text-success text-lg font-semibold">{t('MessageEmbedFinished')}</p>
+      )}
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/EncoderOptionsCard.tsx
+++ b/src/components/widgets/audiobook-tools/EncoderOptionsCard.tsx
@@ -3,9 +3,8 @@
 import TextInput from '@/components/ui/TextInput'
 import ToggleButtonGroup from '@/components/ui/ToggleButtonGroup'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { M4bEncodeOptions } from '@/types/api'
 import { mergeClasses } from '@/lib/merge-classes'
-import type { AudioFile } from '@/types/api'
+import type { AudioFile, M4bEncodeOptions } from '@/types/api'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 interface EncoderOptionsCardProps {
@@ -192,7 +191,7 @@ export default function EncoderOptionsCard({ audioTracks, disabled = false, onEn
         {!showAdvancedView ? (
           <div className="flex flex-wrap justify-start gap-4 sm:justify-center sm:gap-8">
             <div className="flex flex-col items-start gap-2">
-              <p className="w-40 text-sm">{t('LabelCodec')}</p>
+              <p className="w-40 text-sm font-semibold">{t('LabelCodec')}</p>
               <ToggleButtonGroup items={CODEC_ITEMS} value={selectedCodec} onChange={(value) => setSelectedCodec(String(value))} disabled={disabled} />
               <p className="text-foreground-muted text-xs">
                 {t('LabelCurrently')} <span className="text-foreground">{currentCodec}</span>
@@ -200,14 +199,14 @@ export default function EncoderOptionsCard({ audioTracks, disabled = false, onEn
               </p>
             </div>
             <div className="flex flex-col items-start gap-2">
-              <p className="w-40 text-sm">{t('LabelBitrate')}</p>
+              <p className="w-40 text-sm font-semibold">{t('LabelBitrate')}</p>
               <ToggleButtonGroup items={BITRATE_ITEMS} value={selectedBitrate} onChange={(value) => setSelectedBitrate(String(value))} disabled={disabled} />
               <p className="text-foreground-muted text-xs">
                 {t('LabelCurrently')} <span className="text-foreground">{currentBitrate} KB/s</span>
               </p>
             </div>
             <div className="flex flex-col items-start gap-2">
-              <p className="w-40 text-sm">{t('LabelChannels')}</p>
+              <p className="w-40 text-sm font-semibold">{t('LabelChannels')}</p>
               <ToggleButtonGroup items={CHANNELS_ITEMS} value={selectedChannels} onChange={(value) => setSelectedChannels(Number(value))} disabled={disabled} />
               <p className="text-foreground-muted text-xs">
                 {t('LabelCurrently')}{' '}

--- a/src/components/widgets/audiobook-tools/EncoderOptionsCard.tsx
+++ b/src/components/widgets/audiobook-tools/EncoderOptionsCard.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import TextInput from '@/components/ui/TextInput'
+import ToggleButtonGroup from '@/components/ui/ToggleButtonGroup'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { M4bEncodeOptions } from '@/types/api'
+import { mergeClasses } from '@/lib/merge-classes'
+import type { AudioFile } from '@/types/api'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+interface EncoderOptionsCardProps {
+  audioTracks: AudioFile[]
+  disabled?: boolean
+  onEncodingOptionsChange: (options: M4bEncodeOptions) => void
+}
+
+const CODEC_ITEMS = [
+  { text: 'Copy', value: 'copy' },
+  { text: 'AAC', value: 'aac' },
+  { text: 'OPUS', value: 'opus' }
+]
+
+const BITRATE_ITEMS = [
+  { text: '32k', value: '32k' },
+  { text: '64k', value: '64k' },
+  { text: '128k', value: '128k' },
+  { text: '192k', value: '192k' }
+]
+
+const CHANNELS_ITEMS = [
+  { text: '1 (mono)', value: 1 },
+  { text: '2 (stereo)', value: 2 }
+]
+
+function buildEncodingOptions(
+  showAdvancedView: boolean,
+  selectedCodec: string,
+  selectedBitrate: string,
+  selectedChannels: number,
+  customCodec: string,
+  customBitrate: string,
+  customChannels: string
+): M4bEncodeOptions {
+  if (showAdvancedView) {
+    return {
+      codec: customCodec || selectedCodec || 'aac',
+      bitrate: customBitrate || selectedBitrate || '128k',
+      channels: customChannels || selectedChannels || 2
+    }
+  }
+
+  return {
+    codec: selectedCodec || 'aac',
+    bitrate: selectedBitrate || '128k',
+    channels: selectedChannels || 2
+  }
+}
+
+export default function EncoderOptionsCard({ audioTracks, disabled = false, onEncodingOptionsChange }: EncoderOptionsCardProps) {
+  const t = useTypeSafeTranslations()
+  const [showAdvancedView, setShowAdvancedView] = useState(false)
+  const [selectedCodec, setSelectedCodec] = useState('aac')
+  const [selectedBitrate, setSelectedBitrate] = useState('128k')
+  const [selectedChannels, setSelectedChannels] = useState<number>(2)
+  const [customCodec, setCustomCodec] = useState('aac')
+  const [customBitrate, setCustomBitrate] = useState('128k')
+  const [customChannels, setCustomChannels] = useState('2')
+  const [currentCodec, setCurrentCodec] = useState('')
+  const [currentBitrate, setCurrentBitrate] = useState('')
+  const [currentChannels, setCurrentChannels] = useState<number | ''>('')
+  const [currentChannelLayout, setCurrentChannelLayout] = useState('')
+  const [isCodecsDifferent, setIsCodecsDifferent] = useState(false)
+
+  const encodingOptions = useMemo(
+    () => buildEncodingOptions(showAdvancedView, selectedCodec, selectedBitrate, selectedChannels, customCodec, customBitrate, customChannels),
+    [customBitrate, customChannels, customCodec, selectedBitrate, selectedChannels, selectedCodec, showAdvancedView]
+  )
+
+  useEffect(() => {
+    onEncodingOptionsChange(encodingOptions)
+  }, [encodingOptions, onEncodingOptionsChange])
+
+  const setPreset = useCallback((codec: string, bitrateKb: number | '', channels: number | '', codecsDifferent: boolean) => {
+    if (codec === 'aac' && !codecsDifferent) {
+      setSelectedCodec('copy')
+    } else {
+      setSelectedCodec('aac')
+    }
+
+    if (!bitrateKb) {
+      setSelectedBitrate('128k')
+    } else {
+      const bitratesToMatch = [32, 64, 128, 192]
+      const closestBitrate = bitratesToMatch.find((bitrate) => bitrate >= bitrateKb) || 192
+      setSelectedBitrate(`${closestBitrate}k`)
+    }
+
+    if (!channels || Number.isNaN(channels)) {
+      setSelectedChannels(2)
+    } else {
+      setSelectedChannels(Math.max(Math.min(Number(channels), 2), 1))
+    }
+  }, [])
+
+  const setCurrentValues = useCallback(() => {
+    if (audioTracks.length === 0) return
+
+    const codec = audioTracks[0].codec
+    let channels = audioTracks[0].channels
+    const channelLayout = audioTracks[0].channelLayout
+    let codecsDifferent = false
+    let totalBitrate = 0
+
+    for (const track of audioTracks) {
+      const trackBitrate = !Number.isNaN(track.bitRate) ? track.bitRate : 0
+      totalBitrate += trackBitrate
+
+      if (track.channels > channels) channels = track.channels
+      if (track.codec !== codec) {
+        codecsDifferent = true
+      }
+    }
+
+    setCurrentCodec(codec)
+    setCurrentChannels(channels)
+    setCurrentChannelLayout(channelLayout)
+    setIsCodecsDifferent(codecsDifferent)
+    setCurrentBitrate(String(Math.round(totalBitrate / audioTracks.length / 1000)))
+
+    setPreset(codec, Math.round(totalBitrate / audioTracks.length / 1000), channels, codecsDifferent)
+  }, [audioTracks, setPreset])
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setCustomBitrate(localStorage.getItem('embedMetadataBitrate') || '128k')
+      setCustomChannels(localStorage.getItem('embedMetadataChannels') || '2')
+      setCustomCodec(localStorage.getItem('embedMetadataCodec') || 'aac')
+    }
+    setCurrentValues()
+  }, [setCurrentValues])
+
+  const handleCustomBitrateChange = useCallback((value: string) => {
+    setCustomBitrate(value)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('embedMetadataBitrate', value)
+    }
+  }, [])
+
+  const handleCustomChannelsChange = useCallback((value: string) => {
+    setCustomChannels(value)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('embedMetadataChannels', value)
+    }
+  }, [])
+
+  const handleCustomCodecChange = useCallback((value: string) => {
+    setCustomCodec(value)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('embedMetadataCodec', value)
+    }
+  }, [])
+
+  const presetTabClass = useMemo(
+    () =>
+      mergeClasses(
+        'flex h-8 w-1/2 items-center justify-center rounded-tl-md border border-border relative disabled:cursor-not-allowed',
+        !showAdvancedView ? 'text-foreground bg-bg hover:bg-bg/60 border-b-bg' : 'text-foreground-muted hover:text-foreground bg-primary/70 hover:bg-primary/60'
+      ),
+    [showAdvancedView]
+  )
+
+  const advancedTabClass = useMemo(
+    () =>
+      mergeClasses(
+        'flex h-8 w-1/2 items-center justify-center -ml-px rounded-tr-md border border-border relative disabled:cursor-not-allowed',
+        showAdvancedView ? 'text-foreground bg-bg hover:bg-bg/60 border-b-bg' : 'text-foreground-muted hover:text-foreground bg-primary/70 hover:bg-primary/60'
+      ),
+    [showAdvancedView]
+  )
+
+  return (
+    <div className="w-full py-2">
+      <div className="-mb-px flex">
+        <button type="button" disabled={disabled} className={presetTabClass} onClick={() => setShowAdvancedView(false)}>
+          <p className="text-sm">{t('HeaderPresets')}</p>
+        </button>
+        <button type="button" disabled={disabled} className={advancedTabClass} onClick={() => setShowAdvancedView(true)}>
+          <p className="text-sm">{t('HeaderAdvanced')}</p>
+        </button>
+      </div>
+      <div className="border-border bg-bg mr-px rounded-b-md border p-4 md:p-8">
+        {!showAdvancedView ? (
+          <div className="flex flex-wrap justify-start gap-4 sm:justify-center sm:gap-8">
+            <div className="flex flex-col items-start gap-2">
+              <p className="w-40 text-sm">{t('LabelCodec')}</p>
+              <ToggleButtonGroup items={CODEC_ITEMS} value={selectedCodec} onChange={(value) => setSelectedCodec(String(value))} disabled={disabled} />
+              <p className="text-foreground-muted text-xs">
+                {t('LabelCurrently')} <span className="text-foreground">{currentCodec}</span>
+                {isCodecsDifferent && <span className="text-warning"> (mixed)</span>}
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-2">
+              <p className="w-40 text-sm">{t('LabelBitrate')}</p>
+              <ToggleButtonGroup items={BITRATE_ITEMS} value={selectedBitrate} onChange={(value) => setSelectedBitrate(String(value))} disabled={disabled} />
+              <p className="text-foreground-muted text-xs">
+                {t('LabelCurrently')} <span className="text-foreground">{currentBitrate} KB/s</span>
+              </p>
+            </div>
+            <div className="flex flex-col items-start gap-2">
+              <p className="w-40 text-sm">{t('LabelChannels')}</p>
+              <ToggleButtonGroup items={CHANNELS_ITEMS} value={selectedChannels} onChange={(value) => setSelectedChannels(Number(value))} disabled={disabled} />
+              <p className="text-foreground-muted text-xs">
+                {t('LabelCurrently')}{' '}
+                <span className="text-foreground">
+                  {currentChannels} ({currentChannelLayout})
+                </span>
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="mb-4 flex flex-wrap justify-start gap-4 sm:justify-center sm:gap-8">
+              <div className="w-40">
+                <TextInput label={t('LabelAudioCodec')} value={customCodec} disabled={disabled} onChange={handleCustomCodecChange} />
+              </div>
+              <div className="w-40">
+                <TextInput label={t('LabelAudioBitrate')} value={customBitrate} disabled={disabled} onChange={handleCustomBitrateChange} />
+              </div>
+              <div className="w-40">
+                <TextInput label={t('LabelAudioChannels')} type="number" value={customChannels} disabled={disabled} onChange={handleCustomChannelsChange} />
+              </div>
+            </div>
+            <p className="text-warning text-xs sm:text-center sm:text-sm">{t('LabelEncodingWarningAdvancedSettings')}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/M4bEncodePanel.tsx
+++ b/src/components/widgets/audiobook-tools/M4bEncodePanel.tsx
@@ -71,11 +71,7 @@ export default function M4bEncodePanel({
         </div>
       ) : (
         <div className="mb-4">
-          <EncoderOptionsCard
-            audioTracks={tracks}
-            disabled={processing || isTaskFinished}
-            onEncodingOptionsChange={onEncodingOptionsChange}
-          />
+          <EncoderOptionsCard audioTracks={tracks} disabled={processing || isTaskFinished} onEncodingOptionsChange={onEncodingOptionsChange} />
         </div>
       )}
     </>

--- a/src/components/widgets/audiobook-tools/M4bEncodePanel.tsx
+++ b/src/components/widgets/audiobook-tools/M4bEncodePanel.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import Btn from '@/components/ui/Btn'
+import TextInput from '@/components/ui/TextInput'
+import EncoderOptionsCard from '@/components/widgets/audiobook-tools/EncoderOptionsCard'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { AudioTrack, M4bEncodeOptions } from '@/types/api'
+
+interface M4bEncodePanelProps {
+  tracks: AudioTrack[]
+  processing: boolean
+  progress: string
+  isTaskFinished: boolean
+  taskFailed: boolean
+  taskError: string | null
+  isCancelingEncode: boolean
+  encodeTaskHasEncodingOptions: boolean
+  encodingOptions: M4bEncodeOptions
+  onEncodingOptionsChange: (options: M4bEncodeOptions) => void
+  onStartEncode: () => void
+  onCancelEncode: () => void
+}
+
+export default function M4bEncodePanel({
+  tracks,
+  processing,
+  progress,
+  isTaskFinished,
+  taskFailed,
+  taskError,
+  isCancelingEncode,
+  encodeTaskHasEncodingOptions,
+  encodingOptions,
+  onEncodingOptionsChange,
+  onStartEncode,
+  onCancelEncode
+}: M4bEncodePanelProps) {
+  const t = useTypeSafeTranslations()
+
+  return (
+    <>
+      <div className="mb-4 flex w-full items-center">
+        <div className="grow" />
+
+        {!isTaskFinished && processing && (
+          <Btn color="bg-error" loading={isCancelingEncode} className="me-2" onClick={onCancelEncode}>
+            {t('ButtonCancelEncode')}
+          </Btn>
+        )}
+
+        {!isTaskFinished ? (
+          <Btn color="bg-primary" loading={processing} progress={progress} onClick={onStartEncode}>
+            {t('ButtonStartM4BEncode')}
+          </Btn>
+        ) : taskFailed ? (
+          <p className="text-error text-lg font-semibold">
+            {t('MessageM4BFailed')} {taskError}
+          </p>
+        ) : (
+          <p className="text-success text-lg font-semibold">{t('MessageM4BFinished')}</p>
+        )}
+      </div>
+
+      {encodeTaskHasEncodingOptions ? (
+        <div className="border-border mb-4 border-b pb-4">
+          <div className="-mx-2 flex flex-wrap">
+            <TextInput label={t('LabelAudioBitrate')} value={encodingOptions.bitrate} readOnly className="m-2 max-w-40" />
+            <TextInput label={t('LabelAudioChannels')} value={String(encodingOptions.channels)} readOnly className="m-2 max-w-40" />
+            <TextInput label={t('LabelAudioCodec')} value={encodingOptions.codec} readOnly className="m-2 max-w-40" />
+          </div>
+        </div>
+      ) : (
+        <div className="mb-4">
+          <EncoderOptionsCard
+            audioTracks={tracks}
+            disabled={processing || isTaskFinished}
+            onEncodingOptionsChange={onEncodingOptionsChange}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/widgets/audiobook-tools/MetadataPreviewTable.tsx
+++ b/src/components/widgets/audiobook-tools/MetadataPreviewTable.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { MetadataObject } from '@/types/api'
+
+interface MetadataPreviewTableProps {
+  metadataObject: MetadataObject | null
+}
+
+export default function MetadataPreviewTable({ metadataObject }: MetadataPreviewTableProps) {
+  const t = useTypeSafeTranslations()
+  const entries = metadataObject ? Object.entries(metadataObject) : []
+
+  return (
+    <div className="border-border bg-bg w-full border">
+      <div className="flex px-4 py-2">
+        <div className="text-foreground-muted w-28 min-w-28 text-xs font-semibold uppercase">{t('LabelMetaTag')}</div>
+        <div className="text-foreground-muted grow text-xs font-semibold uppercase">{t('LabelValue')}</div>
+      </div>
+      <div className="max-h-72 w-full overflow-auto">
+        {entries.map(([key, value], index) => (
+          <div key={key} className={`flex px-4 py-1 text-sm ${index % 2 === 0 ? 'bg-primary/25' : ''}`}>
+            <div className="w-28 min-w-28 font-semibold">{key}</div>
+            <div className="grow break-words">{value}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/ToolsInfoNotes.tsx
+++ b/src/components/widgets/audiobook-tools/ToolsInfoNotes.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { AudiobookTool } from '@/hooks/useAudiobookTools'
+
+interface ToolsInfoNotesProps {
+  selectedTool: AudiobookTool
+  libraryItemRelPath: string
+  libraryItemId: string
+  shouldBackupAudioFiles: boolean
+  trackCount: number
+}
+
+function InfoNote({ children }: { children: ReactNode }) {
+  return (
+    <div className="mb-2 flex items-start">
+      <span className="material-symbols text-warning pt-1 text-base">star</span>
+      <p className="text-foreground-muted ms-2">{children}</p>
+    </div>
+  )
+}
+
+export default function ToolsInfoNotes({ selectedTool, libraryItemRelPath, libraryItemId, shouldBackupAudioFiles, trackCount }: ToolsInfoNotesProps) {
+  const t = useTypeSafeTranslations()
+  const isEmbedTool = selectedTool === 'embed'
+  const isM4BTool = selectedTool === 'm4b'
+
+  return (
+    <div className="mb-4">
+      {isEmbedTool ? (
+        <InfoNote>{t('LabelEncodingInfoEmbedded')}</InfoNote>
+      ) : (
+        <InfoNote>
+          {t('LabelEncodingFinishedM4B')}{' '}
+          <span className="rounded-md bg-neutral-600 px-1 py-0.5 font-mono text-sm text-white">.../{libraryItemRelPath}/</span>.
+        </InfoNote>
+      )}
+
+      {(shouldBackupAudioFiles || isM4BTool) && (
+        <InfoNote>
+          {t('LabelEncodingBackupLocation')}{' '}
+          <span className="rounded-md bg-neutral-600 px-1 py-0.5 font-mono text-sm text-white">/metadata/cache/items/{libraryItemId}/</span>.{' '}
+          {t('LabelEncodingClearItemCache')}
+        </InfoNote>
+      )}
+
+      {isEmbedTool && trackCount > 1 && <InfoNote>{t('LabelEncodingChaptersNotEmbedded')}</InfoNote>}
+
+      {isM4BTool && (
+        <>
+          <InfoNote>{t('LabelEncodingTimeWarning')}</InfoNote>
+          <InfoNote>{t('LabelEncodingWatcherDisabled')}</InfoNote>
+        </>
+      )}
+
+      <InfoNote>{t('LabelEncodingStartedNavigation')}</InfoNote>
+    </div>
+  )
+}

--- a/src/components/widgets/audiobook-tools/ToolsInfoNotes.tsx
+++ b/src/components/widgets/audiobook-tools/ToolsInfoNotes.tsx
@@ -32,8 +32,7 @@ export default function ToolsInfoNotes({ selectedTool, libraryItemRelPath, libra
         <InfoNote>{t('LabelEncodingInfoEmbedded')}</InfoNote>
       ) : (
         <InfoNote>
-          {t('LabelEncodingFinishedM4B')}{' '}
-          <span className="rounded-md bg-neutral-600 px-1 py-0.5 font-mono text-sm text-white">.../{libraryItemRelPath}/</span>.
+          {t('LabelEncodingFinishedM4B')} <span className="rounded-md bg-neutral-600 px-1 py-0.5 font-mono text-sm text-white">.../{libraryItemRelPath}/</span>.
         </InfoNote>
       )}
 

--- a/src/components/widgets/media-card/useMediaCardActions.ts
+++ b/src/components/widgets/media-card/useMediaCardActions.ts
@@ -32,8 +32,8 @@ import {
   isBookMedia,
   isPersonalizedSeriesRef
 } from '@/types/api'
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import { useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import { MediaCardMoreMenuItem } from './MediaCardMoreMenu'
 
 interface UseMediaCardActionsProps {
@@ -248,6 +248,10 @@ export function useMediaCardActions({
         onOpenCoverEdit?.()
       } else if (action === 'editChapters') {
         router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}/chapters`)
+      } else if (action === 'makeM4b') {
+        router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}/tools?tool=m4b`)
+      } else if (action === 'embedMetadata') {
+        router.push(`/library/${libraryItem.libraryId}/item/${libraryItem.id}/tools?tool=embed`)
       } else if (action === 'download') {
         downloadLibraryItem(libraryItem.id)
       } else if (action === 'sendToDevice') {
@@ -477,6 +481,17 @@ export function useMediaCardActions({
       items.push({
         text: t('ButtonEditChapters'),
         func: 'editChapters'
+      })
+    }
+
+    if (userIsAdminOrUp && libraryItem.mediaType === 'book' && isBookMedia(media) && numTracks > 0 && !episodeForQueue) {
+      items.push({
+        text: t('LabelToolsMakeM4b'),
+        func: 'makeM4b'
+      })
+      items.push({
+        text: t('LabelToolsEmbedMetadata'),
+        func: 'embedMetadata'
       })
     }
 

--- a/src/hooks/useAudiobookTools.ts
+++ b/src/hooks/useAudiobookTools.ts
@@ -1,0 +1,246 @@
+'use client'
+
+import { cancelM4bEncodeAction, embedMetadataAction, encodeM4bAction, getMetadataObjectAction } from '@/app/actions/toolsActions'
+import type { ConfirmState } from '@/components/widgets/ConfirmDialog'
+import { useSocketEvent } from '@/contexts/SocketContext'
+import { useTasks } from '@/contexts/TasksContext'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { BookLibraryItem, M4bEncodeOptions, PodcastLibraryItem } from '@/types/api'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
+
+export type AudiobookTool = 'embed' | 'm4b'
+
+function readBackupPreference(): boolean {
+  if (typeof window === 'undefined') return true
+  const stored = localStorage.getItem('embedMetadataShouldBackup')
+  return stored !== '0'
+}
+
+interface UseAudiobookToolsOptions {
+  initialLibraryItem: BookLibraryItem
+}
+
+export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptions) {
+  const t = useTypeSafeTranslations()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { showToast } = useGlobalToast()
+  const [isPending, startTransition] = useTransition()
+
+  const [libraryItem, setLibraryItem] = useState(initialLibraryItem)
+  const [metadataObject, setMetadataObject] = useState<Record<string, string> | null>(null)
+  const [shouldBackupAudioFiles, setShouldBackupAudioFiles] = useState(readBackupPreference)
+  const [processing, setProcessing] = useState(false)
+  const [isCancelingEncode, setIsCancelingEncode] = useState(false)
+  const [confirmState, setConfirmState] = useState<ConfirmState | null>(null)
+  const [isEditModalOpen, setIsEditModalOpen] = useState(false)
+  const [encodingOptions, setEncodingOptions] = useState<M4bEncodeOptions>({
+    bitrate: '128k',
+    channels: '2',
+    codec: 'aac'
+  })
+
+  const { queuedEmbedLIds, getTasksByLibraryItemId, getTaskProgress, getAudioFilesEncoding, getAudioFilesFinished } = useTasks()
+
+  const libraryItemId = libraryItem.id
+  const itemPath = `/library/${libraryItem.libraryId}/item/${libraryItemId}`
+  const toolsBasePath = `${itemPath}/tools`
+
+  const selectedTool: AudiobookTool = searchParams.get('tool') === 'm4b' ? 'm4b' : 'embed'
+  const isEmbedTool = selectedTool === 'embed'
+  const isM4BTool = selectedTool === 'm4b'
+
+  const media = libraryItem.media
+  const mediaMetadata = media.metadata
+  const tracks = useMemo(() => media.tracks ?? [], [media.tracks])
+  const metadataChapters = media.chapters || []
+
+  const itemTasks = useMemo(() => getTasksByLibraryItemId(libraryItemId), [getTasksByLibraryItemId, libraryItemId])
+  const embedTask = useMemo(() => itemTasks.find((task) => task.action === 'embed-metadata'), [itemTasks])
+  const encodeTask = useMemo(() => itemTasks.find((task) => task.action === 'encode-m4b'), [itemTasks])
+  const task = isEmbedTool ? embedTask : isM4BTool ? encodeTask : undefined
+
+  const isTaskFinished = !!task?.isFinished
+  const taskFailed = isTaskFinished && !!task?.isFailed
+  const taskError = taskFailed ? task?.error || 'Unknown Error' : null
+  const progress = getTaskProgress(libraryItemId) || '0%'
+  const audioFilesEncoding = getAudioFilesEncoding(libraryItemId) || {}
+  const audioFilesFinished = getAudioFilesFinished(libraryItemId) || {}
+  const isMetadataEmbedQueued = queuedEmbedLIds.includes(libraryItemId)
+
+  const encodeTaskHasEncodingOptions = useMemo(() => {
+    if (!isM4BTool || !encodeTask?.data?.encodeOptions) return false
+    return Object.keys(encodeTask.data.encodeOptions).length > 0
+  }, [encodeTask, isM4BTool])
+
+  const fetchMetadataObject = useCallback(async () => {
+    try {
+      const result = await getMetadataObjectAction(libraryItemId)
+      setMetadataObject(result)
+    } catch (error) {
+      console.error('Failed to fetch metadata object', error)
+    }
+  }, [libraryItemId])
+
+  useEffect(() => {
+    void fetchMetadataObject()
+  }, [fetchMetadataObject])
+
+  useEffect(() => {
+    if (task) {
+      setProcessing(!task.isFinished)
+    }
+  }, [task])
+
+  useEffect(() => {
+    if (!encodeTaskHasEncodingOptions || !encodeTask?.data?.encodeOptions) return
+    const options = encodeTask.data.encodeOptions
+    setEncodingOptions({
+      bitrate: options.bitrate || '128k',
+      channels: options.channels ?? '2',
+      codec: options.codec || 'aac'
+    })
+  }, [encodeTask, encodeTaskHasEncodingOptions])
+
+  const handleItemUpdated = useCallback(
+    (updatedItem: BookLibraryItem | PodcastLibraryItem) => {
+      if (updatedItem.id === libraryItemId && updatedItem.mediaType === 'book') {
+        setLibraryItem(updatedItem)
+        void fetchMetadataObject()
+      }
+    },
+    [fetchMetadataObject, libraryItemId]
+  )
+
+  useSocketEvent<BookLibraryItem | PodcastLibraryItem>('item_updated', handleItemUpdated, [handleItemUpdated])
+
+  const setSelectedTool = useCallback(
+    (tool: AudiobookTool) => {
+      router.replace(`${toolsBasePath}?tool=${tool}`)
+    },
+    [toolsBasePath, router]
+  )
+
+  const toggleBackupAudioFiles = useCallback((value: boolean) => {
+    setShouldBackupAudioFiles(value)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('embedMetadataShouldBackup', value ? '1' : '0')
+    }
+  }, [])
+
+  const handleEncodingOptionsChange = useCallback((options: M4bEncodeOptions) => {
+    setEncodingOptions(options)
+  }, [])
+
+  const startEmbedMetadata = useCallback(() => {
+    startTransition(async () => {
+      try {
+        setProcessing(true)
+        await embedMetadataAction(libraryItemId, shouldBackupAudioFiles)
+      } catch (error) {
+        console.error('Audio metadata embed failed', error)
+        setProcessing(false)
+      }
+    })
+  }, [libraryItemId, shouldBackupAudioFiles])
+
+  const handleEmbedClick = useCallback(() => {
+    setConfirmState({
+      isOpen: true,
+      message: t('MessageConfirmEmbedMetadataInAudioFiles', { 0: tracks.length }),
+      yesButtonText: t('ButtonYes'),
+      yesButtonClassName: 'bg-primary',
+      onConfirm: () => {
+        setConfirmState(null)
+        startEmbedMetadata()
+      }
+    })
+  }, [tracks.length, startEmbedMetadata, t])
+
+  const handleEncodeM4bClick = useCallback(() => {
+    startTransition(async () => {
+      try {
+        setProcessing(true)
+        await encodeM4bAction(libraryItemId, encodingOptions)
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : 'Unknown Error'
+        showToast(errorMsg, { type: 'error' })
+        setProcessing(false)
+      }
+    })
+  }, [encodingOptions, libraryItemId, showToast])
+
+  const handleCancelEncodeClick = useCallback(() => {
+    setIsCancelingEncode(true)
+    startTransition(async () => {
+      try {
+        await cancelM4bEncodeAction(libraryItemId)
+        showToast(t('ToastEncodeCancelSucces'), { type: 'success' })
+      } catch (error) {
+        console.error('Failed to cancel encode', error)
+        showToast(t('ToastEncodeCancelFailed'), { type: 'error' })
+      } finally {
+        setIsCancelingEncode(false)
+      }
+    })
+  }, [libraryItemId, showToast, t])
+
+  const handleLibraryItemSaved = useCallback(
+    (updatedItem: BookLibraryItem | PodcastLibraryItem) => {
+      if (updatedItem.mediaType !== 'book') return
+      setLibraryItem(updatedItem)
+      void fetchMetadataObject()
+      setIsEditModalOpen(false)
+    },
+    [fetchMetadataObject]
+  )
+
+  const toolDropdownItems = useMemo(
+    () => [
+      { text: t('LabelToolsEmbedMetadata'), value: 'embed' as const },
+      { text: t('LabelToolsM4bEncoder'), value: 'm4b' as const }
+    ],
+    [t]
+  )
+
+  return {
+    libraryItem,
+    itemPath,
+    title: mediaMetadata.title ?? '',
+    libraryItemRelPath: libraryItem.relPath,
+    mediaMetadata,
+    tracks,
+    metadataChapters,
+    metadataObject,
+    selectedTool,
+    isEmbedTool,
+    isM4BTool,
+    toolDropdownItems,
+    setSelectedTool,
+    shouldBackupAudioFiles,
+    toggleBackupAudioFiles,
+    processing: processing || isPending,
+    isCancelingEncode,
+    progress,
+    isTaskFinished,
+    taskFailed,
+    taskError,
+    isMetadataEmbedQueued,
+    queuedEmbedCount: queuedEmbedLIds.length,
+    encodeTaskHasEncodingOptions,
+    encodingOptions,
+    handleEncodingOptionsChange,
+    audioFilesEncoding,
+    audioFilesFinished,
+    confirmState,
+    setConfirmState,
+    isEditModalOpen,
+    setIsEditModalOpen,
+    handleEmbedClick,
+    handleEncodeM4bClick,
+    handleCancelEncodeClick,
+    handleLibraryItemSaved
+  }
+}

--- a/src/hooks/useAudiobookTools.ts
+++ b/src/hooks/useAudiobookTools.ts
@@ -12,12 +12,6 @@ import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
 export type AudiobookTool = 'embed' | 'm4b'
 
-function readBackupPreference(): boolean {
-  if (typeof window === 'undefined') return true
-  const stored = localStorage.getItem('embedMetadataShouldBackup')
-  return stored !== '0'
-}
-
 interface UseAudiobookToolsOptions {
   initialLibraryItem: BookLibraryItem
 }
@@ -31,7 +25,7 @@ export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptio
 
   const [libraryItem, setLibraryItem] = useState(initialLibraryItem)
   const [metadataObject, setMetadataObject] = useState<MetadataObject | null>(null)
-  const [shouldBackupAudioFiles, setShouldBackupAudioFiles] = useState(readBackupPreference)
+  const [shouldBackupAudioFiles, setShouldBackupAudioFiles] = useState(true)
   const [processing, setProcessing] = useState(false)
   const [isCancelingEncode, setIsCancelingEncode] = useState(false)
   const [confirmState, setConfirmState] = useState<ConfirmState | null>(null)
@@ -43,6 +37,13 @@ export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptio
   })
 
   const { queuedEmbedLIds, getTasksByLibraryItemId, getTaskProgress, getAudioFilesEncoding, getAudioFilesFinished } = useTasks()
+
+  useEffect(() => {
+    const stored = localStorage.getItem('embedMetadataShouldBackup')
+    if (stored !== null) {
+      setShouldBackupAudioFiles(stored !== '0')
+    }
+  }, [])
 
   const libraryItemId = libraryItem.id
   const itemPath = `/library/${libraryItem.libraryId}/item/${libraryItemId}`
@@ -125,9 +126,7 @@ export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptio
 
   const toggleBackupAudioFiles = useCallback((value: boolean) => {
     setShouldBackupAudioFiles(value)
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('embedMetadataShouldBackup', value ? '1' : '0')
-    }
+    localStorage.setItem('embedMetadataShouldBackup', value ? '1' : '0')
   }, [])
 
   const handleEncodingOptionsChange = useCallback((options: M4bEncodeOptions) => {

--- a/src/hooks/useAudiobookTools.ts
+++ b/src/hooks/useAudiobookTools.ts
@@ -6,7 +6,7 @@ import { useSocketEvent } from '@/contexts/SocketContext'
 import { useTasks } from '@/contexts/TasksContext'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { BookLibraryItem, M4bEncodeOptions, PodcastLibraryItem } from '@/types/api'
+import type { BookLibraryItem, M4bEncodeOptions, MetadataObject, PodcastLibraryItem } from '@/types/api'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
@@ -30,7 +30,7 @@ export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptio
   const [isPending, startTransition] = useTransition()
 
   const [libraryItem, setLibraryItem] = useState(initialLibraryItem)
-  const [metadataObject, setMetadataObject] = useState<Record<string, string> | null>(null)
+  const [metadataObject, setMetadataObject] = useState<MetadataObject | null>(null)
   const [shouldBackupAudioFiles, setShouldBackupAudioFiles] = useState(readBackupPreference)
   const [processing, setProcessing] = useState(false)
   const [isCancelingEncode, setIsCancelingEncode] = useState(false)

--- a/src/hooks/useAudiobookTools.ts
+++ b/src/hooks/useAudiobookTools.ts
@@ -187,16 +187,6 @@ export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptio
     })
   }, [libraryItemId, showToast, t])
 
-  const handleLibraryItemSaved = useCallback(
-    (updatedItem: BookLibraryItem | PodcastLibraryItem) => {
-      if (updatedItem.mediaType !== 'book') return
-      setLibraryItem(updatedItem)
-      void fetchMetadataObject()
-      setIsEditModalOpen(false)
-    },
-    [fetchMetadataObject]
-  )
-
   const toolDropdownItems = useMemo(
     () => [
       { text: t('LabelToolsEmbedMetadata'), value: 'embed' as const },
@@ -240,7 +230,6 @@ export function useAudiobookTools({ initialLibraryItem }: UseAudiobookToolsOptio
     setIsEditModalOpen,
     handleEmbedClick,
     handleEncodeM4bClick,
-    handleCancelEncodeClick,
-    handleLibraryItemSaved
+    handleCancelEncodeClick
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -51,6 +51,7 @@ import {
   ListeningStats,
   M4bEncodeOptions,
   MediaItemShare,
+  MetadataObject,
   MetadataProvidersResponse,
   MutateBackupsResponse,
   NotificationFormPayload,
@@ -1121,8 +1122,8 @@ export async function embedMetadataQuick(libraryItemId: string): Promise<void> {
  * Get the metadata object that would be embedded into audio files
  * @param libraryItemId - Library item ID
  */
-export async function getMetadataObject(libraryItemId: string): Promise<Record<string, string>> {
-  return apiRequest<Record<string, string>>(`/api/items/${libraryItemId}/metadata-object`)
+export async function getMetadataObject(libraryItemId: string): Promise<MetadataObject> {
+  return apiRequest<MetadataObject>(`/api/items/${libraryItemId}/metadata-object`)
 }
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { cache } from 'react'
 import {
+  AudibleChapterSearchResult,
   AudioBookmark,
   AuthenticationSettings,
   AuthenticationSettingsPatch,
@@ -11,7 +12,6 @@ import {
   AuthorQuickMatchPayload,
   AuthorResponse,
   AuthorUpdateResponse,
-  AudibleChapterSearchResult,
   BookSearchResult,
   Chapter,
   Collection,
@@ -49,6 +49,7 @@ import {
   LibraryItem,
   LibraryStatsResponse,
   ListeningStats,
+  M4bEncodeOptions,
   MediaItemShare,
   MetadataProvidersResponse,
   MutateBackupsResponse,
@@ -1113,6 +1114,51 @@ export async function clearPodcastDownloadQueue(libraryItemId: string): Promise<
 export async function embedMetadataQuick(libraryItemId: string): Promise<void> {
   return apiRequest<void>(`/api/tools/item/${libraryItemId}/embed-metadata`, {
     method: 'POST'
+  })
+}
+
+/**
+ * Get the metadata object that would be embedded into audio files
+ * @param libraryItemId - Library item ID
+ */
+export async function getMetadataObject(libraryItemId: string): Promise<Record<string, string>> {
+  return apiRequest<Record<string, string>>(`/api/items/${libraryItemId}/metadata-object`)
+}
+
+/**
+ * Embed metadata into audio files with optional backup
+ * @param libraryItemId - Library item ID
+ * @param backup - Whether to backup audio files before embedding
+ */
+export async function embedMetadata(libraryItemId: string, backup: boolean): Promise<void> {
+  return apiRequest<void>(`/api/tools/item/${libraryItemId}/embed-metadata?backup=${backup ? 1 : 0}`, {
+    method: 'POST'
+  })
+}
+
+/**
+ * Start M4B encode for a library item
+ * @param libraryItemId - Library item ID
+ * @param options - Encoding options (bitrate, channels, codec)
+ */
+export async function encodeM4b(libraryItemId: string, options: M4bEncodeOptions): Promise<void> {
+  const params = new URLSearchParams({
+    bitrate: options.bitrate,
+    channels: String(options.channels),
+    codec: options.codec
+  })
+  return apiRequest<void>(`/api/tools/item/${libraryItemId}/encode-m4b?${params.toString()}`, {
+    method: 'POST'
+  })
+}
+
+/**
+ * Cancel an in-progress M4B encode for a library item
+ * @param libraryItemId - Library item ID
+ */
+export async function cancelM4bEncode(libraryItemId: string): Promise<void> {
+  return apiRequest<void>(`/api/tools/item/${libraryItemId}/encode-m4b`, {
+    method: 'DELETE'
   })
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1379,6 +1379,9 @@ export interface UpdateLibraryItemMediaResponse {
 // TASKS & PROGRESS TRACKING
 // ============================================================================
 
+/** FFmpeg metadata tags that would be embedded into audio files (empty values omitted). */
+export type MetadataObject = Record<string, string>
+
 export interface M4bEncodeOptions {
   bitrate: string
   channels: string | number

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1379,12 +1379,19 @@ export interface UpdateLibraryItemMediaResponse {
 // TASKS & PROGRESS TRACKING
 // ============================================================================
 
+export interface M4bEncodeOptions {
+  bitrate: string
+  channels: string | number
+  codec: string
+}
+
 export interface Task {
   id: string
   action: string // 'embed-metadata' | 'encode-m4b'
   data?: {
     libraryId?: string
     libraryItemId?: string
+    encodeOptions?: M4bEncodeOptions
     [key: string]: unknown
   }
   title: string | null


### PR DESCRIPTION
This implements the tools page. Similar to the chapters page, the embed and encode m4b tools (sharing the same page) are wired into the book page and media card through context menu actions.

Based on our discussion on discord I decided not to automatically re-scan after m4b encoding, since this requires careful server scrutiny and potential fixes.

Also, similarly to the chapter edit PR, I did not look at mobile layout, since the tools page is dense and likely requires some redesign on mobile, which is out of scope for this migration PR.