### PR TITLE
Fix RTL issues in ereader TOC drawer

### DIFF
--- a/src/components/ereader/EreaderTocDrawer.tsx
+++ b/src/components/ereader/EreaderTocDrawer.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import type { FoliateSearchSection } from '@/components/ereader/foliate'
 import TextInput from '@/components/ui/TextInput'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import type { FoliateSearchSection } from '@/components/ereader/foliate'
 import type { EreaderTheme } from '@/lib/ereader/ereaderSettings'
 import { EREADER_THEME_SEARCH_INPUT } from '@/lib/ereader/ereaderSettings'
 import type { EreaderTocItem } from '@/lib/ereader/ereaderToc'
@@ -146,11 +146,16 @@ function SearchResults({
     <ul>
       {results.map((section) => (
         <li key={section.id} className="py-1">
-          {section.label ? <p className="opacity-80">{section.label}</p> : null}
+          {section.label ? (
+            <p dir="auto" className="block w-full text-start opacity-80">
+              {section.label}
+            </p>
+          ) : null}
           {section.hits.map((hit) => (
             <button
               key={hit.id}
               type="button"
+              dir="auto"
               className="block w-full py-1 ps-4 text-start text-sm opacity-50 hover:opacity-100"
               onClick={() => onGoTo(hit.cfi)}
             >
@@ -166,7 +171,7 @@ function SearchResults({
 function TocEntry({ item, onGoTo }: { item: EreaderTocItem; onGoTo: (href: string) => void }) {
   return (
     <li className="py-1">
-      <button type="button" className="text-start opacity-80 hover:opacity-100" onClick={() => onGoTo(item.href)}>
+      <button type="button" dir="auto" className="block w-full text-start opacity-80 hover:opacity-100" onClick={() => onGoTo(item.href)}>
         {item.label}
       </button>
       {item.subitems && item.subitems.length > 0 && (


### PR DESCRIPTION
This fixes a couple of RTL issues in the ereader TOC drawer, so that Hebrew/Arabic chapter titles and search results are aligned properly to the right.

- It adds `dir="auto"` to the TOC/result buttons
- It applies `w-full` style to the buttons so the right alignment shows even when the interface language is not RTL.

screenshots:
TOC before:
<img width="571" height="639" alt="image" src="https://github.com/user-attachments/assets/9cf07400-ec42-4e55-aab2-d243f2424756" />

TOC after:
<img width="564" height="630" alt="image" src="https://github.com/user-attachments/assets/9a3ff743-1a6f-4487-b7e1-4b3b16c493cc" />

Search results before:
<img width="576" height="898" alt="image" src="https://github.com/user-attachments/assets/f99837f6-9fa0-4e07-a98f-682caad75dc7" />

Search results after:
<img width="555" height="898" alt="image" src="https://github.com/user-attachments/assets/e543c33e-ebb4-4b34-b54b-5fe931cb3f91" />

