### PR TITLE
Podcast download queue page

### DIFF
--- a/cypress/tests/components/ui/Checkbox.cy.tsx
+++ b/cypress/tests/components/ui/Checkbox.cy.tsx
@@ -115,7 +115,7 @@ describe('<Checkbox />', () => {
       const onChangeSpy = cy.spy().as('onChangeSpy')
       cy.mount(<Checkbox onChange={onChangeSpy} />)
       cy.get('input[type="checkbox"]').click()
-      cy.get('@onChangeSpy').should('have.been.calledWith', true)
+      cy.get('@onChangeSpy').should('have.been.calledWith', true, false)
     })
 
     it('calls onChange when label is clicked', () => {
@@ -124,7 +124,7 @@ describe('<Checkbox />', () => {
       // realClick simulates a real pointer event at the label's coordinates,
       // which hits the input overlay on top and triggers onChange.
       cy.get('[cy-id="checkbox-label"]').realClick()
-      cy.get('@onChangeSpy').should('have.been.calledWith', true)
+      cy.get('@onChangeSpy').should('have.been.calledWith', true, false)
     })
 
     it('handles controlled component behavior', () => {
@@ -132,7 +132,7 @@ describe('<Checkbox />', () => {
       cy.mount(<Checkbox value={false} onChange={onChangeSpy} />)
       cy.get('input[type="checkbox"]').should('not.be.checked')
       cy.get('input[type="checkbox"]').click()
-      cy.get('@onChangeSpy').should('have.been.calledWith', true)
+      cy.get('@onChangeSpy').should('have.been.calledWith', true, false)
       // Value should not change until parent updates it
       cy.get('input[type="checkbox"]').should('not.be.checked')
     })

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -6,6 +6,7 @@ import NotificationWidget from '@/components/widgets/NotificationWidget'
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import Image from 'next/image'
 import Link from 'next/link'
@@ -46,63 +47,59 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
     <div className="bg-primary relative h-16 w-full">
       <header
         cy-id="appbar"
-        className="box-shadow-appbar absolute start-0 top-0 bottom-0 z-60 flex h-full w-full items-center justify-start gap-2 px-2 py-1 md:gap-4 md:px-6"
+        className="box-shadow-appbar absolute start-0 top-0 bottom-0 z-60 flex h-full w-full min-w-0 items-center justify-start gap-1 max-md:overflow-x-hidden px-2 py-1 md:gap-4 md:px-6"
       >
         <Link
           href={redirectUrl}
           aria-label={`audiobookshelf - ${t('ButtonHome')}`}
-          className="text-foreground hover:text-foreground/80 flex items-center justify-start gap-2 text-sm md:gap-4"
+          className="text-foreground hover:text-foreground/80 flex shrink-0 items-center justify-start gap-2 text-sm md:gap-4"
         >
           <Image src="/images/icon.svg" alt="" width={40} height={40} priority className="h-8 w-8 min-w-8 sm:h-10 sm:w-10 sm:min-w-10" />
           <span className="hidden text-xl hover:underline md:block">audiobookshelf</span>
         </Link>
 
-        {/* Libraries Dropdown or Library Books Button */}
-        {libraries && currentLibraryId && !isSearchMode && <LibrariesDropdown currentLibraryId={currentLibraryId} libraries={libraries} />}
-
-        {/* In search mode: show libraries dropdown on desktop, library_books button on mobile */}
-        {isSearchMode && currentLibrary && (
+        {libraries && currentLibraryId && (
           <>
-            {/* Desktop: show libraries dropdown */}
-            <div className="hidden md:block">
-              <LibrariesDropdown currentLibraryId={currentLibraryId!} libraries={libraries!} />
+            <div
+              className={mergeClasses(
+                'min-w-0 flex-1 overflow-hidden md:w-fit md:flex-none md:shrink-0',
+                isSearchMode && 'hidden md:block'
+              )}
+            >
+              <LibrariesDropdown currentLibraryId={currentLibraryId} libraries={libraries} />
             </div>
-            {/* Mobile: show library_books button */}
-            <div className="md:hidden">
-              <Tooltip text={currentLibrary.name} position="bottom">
-                <IconBtn borderless ariaLabel={t('ButtonLibrary')} onClick={handleSearchModeToggle} className="text-foreground hover:text-foreground/80">
-                  library_books
-                </IconBtn>
-              </Tooltip>
-            </div>
-          </>
-        )}
 
-        {/* Search Input mobile and desktop */}
-        {currentLibrary && (
-          <div className="min-w-24 flex-1">
-            {isSearchMode ? (
-              <GlobalSearchInput autoFocus onSubmit={handleSearchSubmit} libraryId={currentLibraryId} />
-            ) : (
-              <div className="hidden md:block">
-                <GlobalSearchInput onSubmit={handleSearchSubmit} libraryId={currentLibraryId} />
+            {isSearchMode && currentLibrary && (
+              <div className="shrink-0 md:hidden">
+                <Tooltip text={currentLibrary.name} position="bottom">
+                  <IconBtn borderless ariaLabel={t('ButtonLibrary')} onClick={handleSearchModeToggle} className="text-foreground hover:text-foreground/80">
+                    library_books
+                  </IconBtn>
+                </Tooltip>
               </div>
             )}
-          </div>
-        )}
-
-        <div className="flex-grow" />
-
-        {!isSearchMode && currentLibrary && (
-          <>
-            {/* Mobile only - Search Icon toggles search mode */}
-            <IconBtn borderless ariaLabel={t('ButtonSearch')} onClick={handleSearchModeToggle} className="md:hidden">
-              search
-            </IconBtn>
           </>
         )}
 
-        <div className="flex min-w-0 items-center gap-1">
+        {/* Search Input — only mount flex slot when search is visible (avoids min-width on mobile) */}
+        {currentLibrary &&
+          (isSearchMode ? (
+            <div className="min-w-0 flex-1">
+              <GlobalSearchInput autoFocus onSubmit={handleSearchSubmit} libraryId={currentLibraryId} />
+            </div>
+          ) : (
+            <div className="hidden min-w-0 flex-1 md:block md:min-w-24">
+              <GlobalSearchInput onSubmit={handleSearchSubmit} libraryId={currentLibraryId} />
+            </div>
+          ))}
+
+        {!isSearchMode && currentLibrary && (
+          <IconBtn borderless ariaLabel={t('ButtonSearch')} onClick={handleSearchModeToggle} className="shrink-0 md:hidden">
+            search
+          </IconBtn>
+        )}
+
+        <div className="flex shrink-0 items-center gap-0.5 md:gap-1">
           <NotificationWidget />
 
           {isAdmin && (

--- a/src/app/(main)/AppBarNav.tsx
+++ b/src/app/(main)/AppBarNav.tsx
@@ -46,7 +46,7 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
 
   return (
     <>
-      <div className="relative">
+      <div className="relative shrink-0">
         {/* Desktop - Username Dropdown */}
         <Btn
           size="small"

--- a/src/app/(main)/LibrariesDropdown.tsx
+++ b/src/app/(main)/LibrariesDropdown.tsx
@@ -63,13 +63,14 @@ export default function LibrariesDropdown({ libraries, currentLibraryId }: Libra
   }))
 
   return (
-    <div className="relative">
+    <div className="relative min-w-0">
       <Dropdown
         items={libraryItems}
         menuMaxHeight="80vh"
         size="small"
         disabled={isPending}
         value={currentLibraryId}
+        usePortal
         onChange={(value) => {
           const lib = libraries.find((l) => l.id === value)
           if (!lib || lib.id === currentLibraryId) return

--- a/src/app/(main)/SideRail.tsx
+++ b/src/app/(main)/SideRail.tsx
@@ -2,6 +2,7 @@
 
 import VersionFooter from '@/components/app/VersionFooter'
 import { useLibrary } from '@/contexts/LibraryContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { mergeClasses } from '@/lib/merge-classes'
 import Link from 'next/link'
@@ -11,6 +12,7 @@ export default function SideRail({ serverVersion, installSource }: { serverVersi
   const pathname = usePathname()
   const t = useTypeSafeTranslations()
   const { library } = useLibrary()
+  const { userIsAdminOrUp } = useUser()
 
   const currentLibraryId = library?.id ?? ''
   const currentLibraryMediaType = library?.mediaType ?? 'book'
@@ -105,13 +107,15 @@ export default function SideRail({ serverVersion, installSource }: { serverVersi
       icon: <span className="abs-icons icon-podcast text-xl"></span>,
       label: t('ButtonAdd'),
       href: `/library/${currentLibraryId}/add-podcast`,
-      mediaType: 'podcast'
+      mediaType: 'podcast',
+      adminOnly: true
     },
     {
       icon: <span className="material-symbols text-2xl">&#xf090;</span>,
       label: t('ButtonDownloadQueue'),
       href: `/library/${currentLibraryId}/download-queue`,
-      mediaType: 'podcast'
+      mediaType: 'podcast',
+      adminOnly: true
     },
     {
       icon: <span className="material-symbols text-2xl">warning</span>,
@@ -121,7 +125,12 @@ export default function SideRail({ serverVersion, installSource }: { serverVersi
     }
   ]
 
-  const filteredButtons = buttons.filter((button) => (!button.mediaType || button.mediaType === currentLibraryMediaType) && !button.hidden)
+  const filteredButtons = buttons.filter(
+    (button) =>
+      (!button.mediaType || button.mediaType === currentLibraryMediaType) &&
+      !button.hidden &&
+      (!button.adminOnly || userIsAdminOrUp)
+  )
 
   return (
     <div className="bg-bg box-shadow-side z-10 hidden h-full max-h-[calc(100vh-4rem)] w-20 min-w-20 md:block">

--- a/src/app/(main)/library/[library]/(podcast)/download-queue/DownloadQueueClient.tsx
+++ b/src/app/(main)/library/[library]/(podcast)/download-queue/DownloadQueueClient.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import CurrentDownloadRow from '@/components/widgets/CurrentDownloadRow'
+import PodcastDownloadQueueTable from '@/components/widgets/PodcastDownloadQueueTable'
+import { useLibraryDownloadQueueSocket } from '@/hooks/useLibraryDownloadQueueSocket'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { PodcastEpisodeDownload } from '@/types/api'
+
+interface DownloadQueueClientProps {
+  initialQueue: PodcastEpisodeDownload[]
+  initialCurrentDownload?: PodcastEpisodeDownload
+}
+
+export default function DownloadQueueClient({ initialQueue, initialCurrentDownload }: DownloadQueueClientProps) {
+  const t = useTypeSafeTranslations()
+  const { episodesDownloading, episodeDownloadsQueued } = useLibraryDownloadQueueSocket({
+    initialQueue,
+    initialCurrentDownload
+  })
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-4">
+      <p className="mb-2 text-xl font-semibold md:px-0">{t('HeaderCurrentDownloads')}</p>
+      {!episodesDownloading.length && <p className="py-4 text-lg md:px-0">{t('MessageNoDownloadsInProgress')}</p>}
+      {episodesDownloading.map((episode) => (
+        <CurrentDownloadRow key={episode.id} episode={episode} />
+      ))}
+
+      {episodeDownloadsQueued.length > 0 && <PodcastDownloadQueueTable queue={episodeDownloadsQueued} />}
+    </div>
+  )
+}

--- a/src/app/(main)/library/[library]/(podcast)/download-queue/page.tsx
+++ b/src/app/(main)/library/[library]/(podcast)/download-queue/page.tsx
@@ -1,3 +1,24 @@
-export default function DownloadQueuePage() {
-  return <div className="w-full p-8">Download Queue</div>
+import { getData, getEpisodeDownloadQueue, getLibraries } from '@/lib/api'
+import { redirect } from 'next/navigation'
+import DownloadQueueClient from './DownloadQueueClient'
+
+export const dynamic = 'force-dynamic'
+
+export default async function DownloadQueuePage({ params }: { params: Promise<{ library: string }> }) {
+  const { library: libraryId } = await params
+  const [librariesResponse, queueResponse] = await getData(getLibraries(), getEpisodeDownloadQueue(libraryId))
+
+  const library = librariesResponse?.libraries?.find((l) => l.id === libraryId)
+  if (library?.mediaType === 'book') {
+    redirect(`/library/${libraryId}`)
+  }
+
+  const initialQueue = queueResponse?.queue ?? []
+  const initialCurrentDownload = queueResponse?.currentDownload
+
+  return (
+    <div className="w-full min-w-0 py-6 sm:px-4 md:p-12">
+      <DownloadQueueClient initialQueue={initialQueue} initialCurrentDownload={initialCurrentDownload} />
+    </div>
+  )
 }

--- a/src/app/(main)/library/[library]/LibraryLayoutWrapper.tsx
+++ b/src/app/(main)/library/[library]/LibraryLayoutWrapper.tsx
@@ -22,7 +22,7 @@ export default function LibraryLayoutWrapper({ children }: LibraryLayoutWrapperP
   const serverVersion = serverSettings?.version || 'Error'
   const installSource = Source || 'Unknown'
   const isLibraryItemPage = pathname.includes('/item/')
-  const showCoverSizeWidget = !isLibraryItemPage && !pathname.endsWith('/latest')
+  const showCoverSizeWidget = !isLibraryItemPage && !pathname.endsWith('/latest') && !pathname.endsWith('/download-queue')
 
   useEffect(() => {
     if (library) {

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -72,7 +72,9 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
     mediaId: libraryItem.media?.id,
     isPodcast,
     onItemUpdated: handleItemUpdated,
-    initialRssFeed: initialLibraryItem.rssFeed ?? null
+    initialRssFeed: initialLibraryItem.rssFeed ?? null,
+    initialEpisodeDownloadsQueued: initialLibraryItem.episodeDownloadsQueued ?? [],
+    initialEpisodesDownloading: initialLibraryItem.episodesDownloading ?? []
   })
 
   const handleClearDownloadQueue = useCallback(async () => {

--- a/src/app/(main)/library/[library]/item/[item]/page.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/page.tsx
@@ -4,7 +4,7 @@ import LibraryItemClient from './LibraryItemClient'
 
 export default async function ItemPage({ params }: { params: Promise<{ item: string; library: string }> }) {
   const { item: itemId } = await params
-  const [libraryItem] = await getData(getLibraryItem(itemId, true, 'rssfeed,share'))
+  const [libraryItem] = await getData(getLibraryItem(itemId, true, 'downloads,rssfeed,share'))
 
   // TODO: Handle loading data error?
   if (!libraryItem) {

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -124,33 +124,6 @@ input[type='number'] {
   appearance: textfield;
 }
 
-.tracksTable {
-  border-collapse: collapse;
-  width: 100%;
-  border: 1px solid #474747;
-}
-
-.tracksTable tr:nth-child(even) {
-  background-color: #2e2e2e;
-}
-
-.tracksTable tr {
-  background-color: #373838;
-}
-
-.tracksTable tr:hover:not(:has(th)) {
-  background-color: #474747;
-}
-
-.tracksTable td {
-  padding: 4px 8px;
-}
-
-.tracksTable th {
-  padding: 4px 8px;
-  font-size: 0.75rem;
-}
-
 .arrow-down {
   width: 0;
   height: 0;

--- a/src/components/modals/EpisodeFeedModal.tsx
+++ b/src/components/modals/EpisodeFeedModal.tsx
@@ -6,10 +6,11 @@ import TextInput from '@/components/ui/TextInput'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatDuration } from '@/lib/formatDuration'
+import { applyShiftClickSelection } from '@/lib/shiftClickSelection'
 import { bytesPretty } from '@/lib/string'
 import { PodcastEpisodeDownload, PodcastLibraryItem, RssPodcastEpisode } from '@/types/api'
 import { useFormatter } from 'next-intl'
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 
 export interface EpisodeFeedModalProps {
   isOpen: boolean
@@ -51,6 +52,7 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
   const [sortDescending, setSortDescending] = useState(true)
   const [selectedEpisodes, setSelectedEpisodes] = useState<Set<string>>(new Set())
   const [selectAll, setSelectAll] = useState(false)
+  const lastSelectedEpisodeUrlRef = useRef<string | null>(null)
 
   const itemEpisodes = useMemo(() => libraryItem.media.episodes || [], [libraryItem.media.episodes])
 
@@ -120,6 +122,25 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
     })
   }, [episodesCleaned, search])
 
+  const episodeListKeys = useMemo(() => episodesList.map((episode) => episode.cleanUrl), [episodesList])
+
+  const selectableEpisodeUrlSet = useMemo(() => {
+    const set = new Set<string>()
+    for (const episode of episodesList) {
+      if (!episode.isDownloaded && !episode.isDownloading) {
+        set.add(episode.cleanUrl)
+      }
+    }
+    return set
+  }, [episodesList])
+
+  // Anchor is only meaningful while the episode is still visible in the filtered list.
+  useEffect(() => {
+    if (lastSelectedEpisodeUrlRef.current && !episodeListKeys.includes(lastSelectedEpisodeUrlRef.current)) {
+      lastSelectedEpisodeUrlRef.current = null
+    }
+  }, [episodeListKeys])
+
   const allDownloaded = useMemo(() => {
     if (episodesCleaned.length === 0) return false
     return !episodesCleaned.some((episode) => !episode.isDownloaded)
@@ -132,6 +153,7 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
       setSortDescending(true)
       setSelectedEpisodes(new Set())
       setSelectAll(false)
+      lastSelectedEpisodeUrlRef.current = null
     }
   }, [isOpen])
 
@@ -154,6 +176,7 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
   const toggleSelectAll = useCallback(
     (checked: boolean) => {
       setSelectAll(checked)
+      lastSelectedEpisodeUrlRef.current = null
       setSelectedEpisodes((prev) => {
         const next = new Set(prev)
         for (const episode of episodesList) {
@@ -171,19 +194,32 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
     [episodesList]
   )
 
-  const toggleSelectEpisode = useCallback((episode: RssPodcastEpisode & { cleanUrl: string; isDownloaded: boolean; isDownloading: boolean }) => {
-    if (episode.isDownloaded || episode.isDownloading) return
+  const selectEpisode = useCallback(
+    (episode: (typeof episodesList)[number], isSelected: boolean, shiftKey = false, rowIndex?: number) => {
+      if (episode.isDownloaded || episode.isDownloading) return
 
-    setSelectedEpisodes((prev) => {
-      const next = new Set(prev)
-      if (next.has(episode.cleanUrl)) {
-        next.delete(episode.cleanUrl)
-      } else {
-        next.add(episode.cleanUrl)
-      }
-      return next
-    })
-  }, [])
+      const index = rowIndex ?? episodesList.findIndex((e) => e.cleanUrl === episode.cleanUrl)
+      if (index < 0) return
+
+      let anchorUpdate: string | null = lastSelectedEpisodeUrlRef.current
+      setSelectedEpisodes((prev) => {
+        const { nextSelected, anchorKey } = applyShiftClickSelection({
+          prevSelected: prev,
+          clickedKey: episode.cleanUrl,
+          clickedIndex: index,
+          shiftKey,
+          anchorKey: lastSelectedEpisodeUrlRef.current,
+          orderedKeys: episodeListKeys,
+          selectClicked: isSelected,
+          isKeySelectable: (key) => selectableEpisodeUrlSet.has(key)
+        })
+        anchorUpdate = anchorKey
+        return nextSelected
+      })
+      lastSelectedEpisodeUrlRef.current = anchorUpdate
+    },
+    [episodesList, episodeListKeys, selectableEpisodeUrlSet]
+  )
 
   const handleSubmit = useCallback(
     (e?: React.FormEvent) => {
@@ -212,6 +248,7 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
           showToast(errorMessage || t('ToastFailedToDownloadEpisodes'), { type: 'error' })
           setSelectedEpisodes(new Set())
           setSelectAll(false)
+          lastSelectedEpisodeUrlRef.current = null
         }
       })
     },
@@ -268,7 +305,7 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
         )}
 
         <div className="w-full grow overflow-x-hidden overflow-y-auto">
-          {episodesList.map((episode) => {
+          {episodesList.map((episode, index) => {
             const isSelected = selectedEpisodes.has(episode.cleanUrl)
             let bgClass = 'even:bg-table-row-bg-even hover:bg-table-row-bg-hover'
             let textClass = 'text-foreground'
@@ -289,7 +326,10 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
               <div
                 key={episode.guid || episode.cleanUrl}
                 className={`border-border relative flex cursor-pointer items-center border-b last:border-0 ${bgClass}`}
-                onClick={() => toggleSelectEpisode(episode)}
+                onClick={(e) => {
+                  if (episode.isDownloaded || episode.isDownloading) return
+                  selectEpisode(episode, !isSelected, e.shiftKey, index)
+                }}
               >
                 <div className="flex w-12 flex-none items-center justify-center p-3 sm:w-16">
                   {episode.isDownloaded ? (
@@ -297,14 +337,12 @@ export default function EpisodeFeedModal({ isOpen, onClose, libraryItem, episode
                   ) : episode.isDownloading ? (
                     <span className="material-symbols text-warning text-xl">download</span>
                   ) : (
-                    <div
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        toggleSelectEpisode(episode)
-                      }}
-                      className="flex items-center justify-center"
-                    >
-                      <Checkbox value={isSelected} size="small" />
+                    <div onClick={(e) => e.stopPropagation()} className="flex items-center justify-center">
+                      <Checkbox
+                        value={isSelected}
+                        size="small"
+                        onChange={(checked, shiftKey) => selectEpisode(episode, checked, shiftKey, index)}
+                      />
                     </div>
                   )}
                 </div>

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -15,7 +15,7 @@ interface CheckboxProps {
   disabled?: boolean
   partial?: boolean
   ariaLabel?: string
-  onChange?: (value: boolean) => void
+  onChange?: (value: boolean, shiftKey: boolean) => void
   className?: string
 }
 
@@ -34,6 +34,7 @@ export default function Checkbox({
   className = ''
 }: CheckboxProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const shiftKeyRef = useRef(false)
 
   const checkboxId = useId()
 
@@ -51,13 +52,19 @@ export default function Checkbox({
   const svgSizeClass = size === 'small' ? 'w-3 h-3' : size === 'medium' ? 'w-3.5 h-3.5' : 'w-4 h-4'
   const svgClass = mergeClasses('pointer-events-none', disabled ? 'fill-checkbox-disabled' : 'fill-current', checkColorClass, svgSizeClass)
 
+  const handlePointerDown = (e: React.PointerEvent) => {
+    shiftKeyRef.current = e.shiftKey
+  }
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!disabled) {
-      onChange?.(e.target.checked)
+      onChange?.(e.target.checked, shiftKeyRef.current)
+      shiftKeyRef.current = false
     }
   }
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    shiftKeyRef.current = e.shiftKey
     if (e.key === 'Enter') {
       e.preventDefault()
       if (!disabled) {
@@ -68,7 +75,7 @@ export default function Checkbox({
 
   return (
     <InputWrapper disabled={disabled} borderless size={size} className={mergeClasses('bg-transparent', className)} inputRef={inputRef}>
-      <div cy-id="checkbox-and-label-wrapper" className="flex items-center justify-start px-1 py-1">
+      <div cy-id="checkbox-and-label-wrapper" className="flex items-center justify-start px-1 py-1" onPointerDown={handlePointerDown}>
         <div cy-id="checkbox-wrapper" className={checkboxWrapperClassName}>
           <div
             cy-id="checkbox-div"

--- a/src/components/ui/LazyTruncatingTooltipText.tsx
+++ b/src/components/ui/LazyTruncatingTooltipText.tsx
@@ -30,7 +30,7 @@ export default function LazyTruncatingTooltipText({ text, className, position = 
       openOnClick={useClickTooltip}
       className="block w-full min-w-0 overflow-hidden"
     >
-      <p ref={ref} className={mergeClasses('min-w-0 truncate select-none', className)}>
+      <p ref={ref} dir="auto" className={mergeClasses('min-w-0 truncate text-start select-none', className)}>
         {text}
       </p>
     </LazyTooltip>

--- a/src/components/ui/TruncatingTooltipText.tsx
+++ b/src/components/ui/TruncatingTooltipText.tsx
@@ -17,7 +17,7 @@ export default function TruncatingTooltipText({ text, className, position = 'top
   const { ref, isTruncated } = useTruncation(text, false)
   return (
     <Tooltip text={text} position={position} disabled={!isTruncated} className="block w-full">
-      <p ref={ref} className={mergeClasses('truncate', className)}>
+      <p ref={ref} dir="auto" className={mergeClasses('truncate', className)}>
         {text}
       </p>
     </Tooltip>

--- a/src/components/widgets/CurrentDownloadRow.tsx
+++ b/src/components/widgets/CurrentDownloadRow.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import PreviewCover from '@/components/covers/PreviewCover'
+import BonusIndicator from '@/components/widgets/BonusIndicator'
+import ExplicitIndicator from '@/components/widgets/ExplicitIndicator'
+import TrailerIndicator from '@/components/widgets/TrailerIndicator'
+import { useBookCoverAspectRatio, useLibrary } from '@/contexts/LibraryContext'
+import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
+import type { PodcastEpisodeDownload } from '@/types/api'
+import { formatDistanceToNow } from 'date-fns'
+import Link from 'next/link'
+import { useMemo } from 'react'
+
+interface CurrentDownloadRowProps {
+  episode: PodcastEpisodeDownload
+}
+
+export default function CurrentDownloadRow({ episode }: CurrentDownloadRowProps) {
+  const { library } = useLibrary()
+  const bookCoverAspectRatio = useBookCoverAspectRatio()
+
+  const coverSrc = useMemo(() => getLibraryItemCoverUrl(episode.libraryItemId), [episode.libraryItemId])
+  const itemHref = `/library/${library.id}/item/${episode.libraryItemId}`
+  const publishedDateLabel = episode.publishedAt
+    ? formatDistanceToNow(new Date(episode.publishedAt), { addSuffix: true })
+    : null
+
+  return (
+    <div className="relative flex py-5">
+      <div className="hidden shrink-0 md:block">
+        <PreviewCover src={coverSrc} width={96} bookCoverAspectRatio={bookCoverAspectRatio} showResolution={false} />
+      </div>
+
+      <div className="max-w-2xl grow ps-4">
+        <div className="mb-2 flex md:hidden">
+          <PreviewCover src={coverSrc} width={48} bookCoverAspectRatio={bookCoverAspectRatio} showResolution={false} />
+          <div className="grow px-2">
+            <div className="flex items-center">
+              <Link href={itemHref} className="text-foreground-muted hover:text-foreground text-sm hover:underline">
+                {episode.podcastTitle}
+              </Link>
+              {episode.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}
+            </div>
+            {publishedDateLabel && <p className="text-foreground-subdued mb-1 text-xs">{publishedDateLabel}</p>}
+          </div>
+        </div>
+
+        <div className="hidden md:block">
+          <div className="flex items-center">
+            <Link href={itemHref} className="text-foreground-muted hover:text-foreground text-sm hover:underline">
+              {episode.podcastTitle}
+            </Link>
+            {episode.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}
+          </div>
+          {publishedDateLabel && <p className="text-foreground-subdued mb-1 text-xs">{publishedDateLabel}</p>}
+        </div>
+
+        {(episode.season || episode.episode) && (
+          <div className="text-foreground flex items-center font-semibold">
+            <span>#</span>
+            {episode.season && <span>{episode.season}x</span>}
+            {episode.episode && <span>{episode.episode}</span>}
+          </div>
+        )}
+
+        <div className="mb-2 flex items-center">
+          <span className="text-foreground text-sm font-semibold md:text-base">{episode.episodeDisplayTitle}</span>
+          {episode.episodeType === 'bonus' && <BonusIndicator className="ms-1 shrink-0" />}
+          {episode.episodeType === 'trailer' && <TrailerIndicator className="ms-1 shrink-0" />}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/EpisodeRow.tsx
+++ b/src/components/widgets/EpisodeRow.tsx
@@ -25,7 +25,7 @@ export interface EpisodeRowProps {
   isSelectionMode: boolean
   dateFormat: string
   onView: (episode: PodcastEpisode) => void
-  onSelect: (episode: PodcastEpisode, isSelected: boolean) => void
+  onSelect: (episode: PodcastEpisode, isSelected: boolean, shiftKey?: boolean, rowIndex?: number) => void
   onEdit?: (episode: PodcastEpisode) => void
   onMatch?: (episode: PodcastEpisode) => void
   onRemove?: (episode: PodcastEpisode, hardDelete: boolean) => void
@@ -47,7 +47,8 @@ export default function EpisodeRow({
   onMatch,
   onRemove,
   onDownloadFile,
-  onShowMoreInfo
+  onShowMoreInfo,
+  rowIndex
 }: EpisodeRowProps) {
   const t = useTypeSafeTranslations()
   const { userCanUpdate, userCanDelete, userCanDownload, userIsAdminOrUp } = useUser()
@@ -176,7 +177,11 @@ export default function EpisodeRow({
               }}
               onClick={(e) => e.stopPropagation()}
             >
-              <Checkbox value={isSelected} checkboxBgClass="bg-primary" onChange={(checked) => onSelect(episode, checked)} />
+              <Checkbox
+                value={isSelected}
+                checkboxBgClass="bg-primary"
+                onChange={(checked, shiftKey) => onSelect(episode, checked, shiftKey, rowIndex)}
+              />
             </div>
           </div>
 

--- a/src/components/widgets/EpisodeTable.tsx
+++ b/src/components/widgets/EpisodeTable.tsx
@@ -20,8 +20,9 @@ import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getPodcastEpisodeNavigationContext } from '@/lib/episodeEditNavigation'
 import { buildPodcastEpisodeProgressMap } from '@/lib/mediaProgress'
 import { mergeClasses } from '@/lib/merge-classes'
+import { applyShiftClickSelection } from '@/lib/shiftClickSelection'
 import { PodcastEpisode, PodcastEpisodeDownload, PodcastLibraryItem, RssPodcastEpisode } from '@/types/api'
-import { useCallback, useMemo, useState, useTransition } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 
 interface EpisodeTableProps {
   libraryItem: PodcastLibraryItem
@@ -56,6 +57,7 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
   )
 
   const [selectedEpisodes, setSelectedEpisodes] = useState<Set<string>>(new Set())
+  const lastSelectedEpisodeIdRef = useRef<string | null>(null)
   const [viewedEpisode, setViewedEpisode] = useState<PodcastEpisode | null>(null)
   const [editedEpisode, setEditedEpisode] = useState<PodcastEpisode | null>(null)
   const [matchedEpisode, setMatchedEpisode] = useState<PodcastEpisode | null>(null)
@@ -66,6 +68,15 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
 
   const { filterKey, setFilterKey, sortKey, setSortKey, sortDesc, setSortDesc, search, setSearch, isSearching, filteredEpisodes, hasMounted } =
     useEpisodeFilterAndSort({ libraryItemId: libraryItem.id, episodes, getMediaItemProgress })
+
+  const filteredEpisodeIds = useMemo(() => filteredEpisodes.map((episode) => episode.id), [filteredEpisodes])
+
+  // Anchor is only meaningful while the episode is still visible in the filtered list.
+  useEffect(() => {
+    if (lastSelectedEpisodeIdRef.current && !filteredEpisodeIds.includes(lastSelectedEpisodeIdRef.current)) {
+      lastSelectedEpisodeIdRef.current = null
+    }
+  }, [filteredEpisodeIds])
 
   const handleCloseViewModal = useCallback(() => {
     if (viewedEpisode) {
@@ -91,20 +102,33 @@ export default function EpisodeTable({ libraryItem, dateFormat = 'MM/dd/yyyy', e
     })
   }, [filteredEpisodes, getMediaItemProgress])
 
-  const handleSelectEpisode = useCallback((episode: PodcastEpisode, isSelected: boolean) => {
-    setSelectedEpisodes((prev) => {
-      const next = new Set(prev)
-      if (isSelected) {
-        next.add(episode.id)
-      } else {
-        next.delete(episode.id)
-      }
-      return next
-    })
-  }, [])
+  const handleSelectEpisode = useCallback(
+    (episode: PodcastEpisode, isSelected: boolean, shiftKey = false, rowIndex?: number) => {
+      const index = rowIndex ?? filteredEpisodes.findIndex((e) => e.id === episode.id)
+      if (index < 0) return
+
+      let anchorUpdate: string | null = lastSelectedEpisodeIdRef.current
+      setSelectedEpisodes((prev) => {
+        const { nextSelected, anchorKey } = applyShiftClickSelection({
+          prevSelected: prev,
+          clickedKey: episode.id,
+          clickedIndex: index,
+          shiftKey,
+          anchorKey: lastSelectedEpisodeIdRef.current,
+          orderedKeys: filteredEpisodeIds,
+          selectClicked: isSelected
+        })
+        anchorUpdate = anchorKey
+        return nextSelected
+      })
+      lastSelectedEpisodeIdRef.current = anchorUpdate
+    },
+    [filteredEpisodes, filteredEpisodeIds]
+  )
 
   const handleClearSelection = useCallback(() => {
     setSelectedEpisodes(new Set())
+    lastSelectedEpisodeIdRef.current = null
   }, [])
 
   const handleViewEpisode = useCallback((episode: PodcastEpisode) => {

--- a/src/components/widgets/Indicator.tsx
+++ b/src/components/widgets/Indicator.tsx
@@ -1,4 +1,7 @@
-import Tooltip from '@/components/ui/Tooltip'
+'use client'
+
+import LazyTooltip from '@/components/ui/LazyTooltip'
+import { usePrimaryInputCanHover } from '@/contexts/SortableCompilationContext'
 import { mergeClasses } from '@/lib/merge-classes'
 import React from 'react'
 
@@ -12,9 +15,16 @@ interface IndicatorProps {
 
 const Indicator = ({ tooltipText, children, className, ariaLabel, role = 'note' }: IndicatorProps) => {
   const effectiveAriaLabel = ariaLabel || tooltipText
+  const primaryInputCanHover = usePrimaryInputCanHover()
 
   return (
-    <Tooltip text={tooltipText} position="top">
+    <LazyTooltip
+      text={tooltipText}
+      position="top"
+      activateOnFocus={false}
+      openOnClick={!primaryInputCanHover}
+      className="inline-flex items-center"
+    >
       {typeof children === 'string' ? (
         <span className={mergeClasses('material-symbols text-sm', className)} role={role} aria-label={effectiveAriaLabel}>
           {children}
@@ -24,7 +34,7 @@ const Indicator = ({ tooltipText, children, className, ariaLabel, role = 'note' 
           {children}
         </div>
       )}
-    </Tooltip>
+    </LazyTooltip>
   )
 }
 

--- a/src/components/widgets/NotificationWidget.tsx
+++ b/src/components/widgets/NotificationWidget.tsx
@@ -17,7 +17,7 @@ function getActionLink(task: Task): string {
 
   switch (task.action) {
     case 'download-podcast-episode':
-      return libraryId ? `/library/${libraryId}/podcast/download-queue` : ''
+      return libraryId ? `/library/${libraryId}/download-queue` : ''
     case 'encode-m4b':
       return libraryId && libraryItemId ? `/library/${libraryId}/item/${libraryItemId}/tools?tool=m4b` : ''
     case 'embed-metadata':
@@ -91,7 +91,7 @@ export default function NotificationWidget({ className = '' }: NotificationWidge
       <button
         ref={triggerRef}
         type="button"
-        className="text-foreground hover:text-foreground/80 relative flex h-10 w-10 cursor-pointer items-center justify-center"
+        className="text-foreground hover:text-foreground/80 relative flex h-9 w-9 shrink-0 cursor-pointer items-center justify-center md:h-10 md:w-10"
         aria-haspopup="listbox"
         aria-expanded={showMenu}
         onClick={clickShowMenu}

--- a/src/components/widgets/PodcastDownloadQueueTable.tsx
+++ b/src/components/widgets/PodcastDownloadQueueTable.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import LazyTruncatingTooltipText from '@/components/ui/LazyTruncatingTooltipText'
+import BonusIndicator from '@/components/widgets/BonusIndicator'
+import ExplicitIndicator from '@/components/widgets/ExplicitIndicator'
+import TrailerIndicator from '@/components/widgets/TrailerIndicator'
+import { useLibrary } from '@/contexts/LibraryContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import type { PodcastEpisodeDownload } from '@/types/api'
+import { formatDistanceToNow } from 'date-fns'
+import Link from 'next/link'
+import { useMemo } from 'react'
+
+interface PodcastDownloadQueueTableProps {
+  queue: PodcastEpisodeDownload[]
+}
+
+interface PodcastQueueGroup {
+  libraryItemId: string
+  podcastTitle?: string
+  podcastExplicit?: boolean
+  items: PodcastEpisodeDownload[]
+}
+
+function groupQueueByPodcast(queue: PodcastEpisodeDownload[]): PodcastQueueGroup[] {
+  const groups = new Map<string, PodcastQueueGroup>()
+
+  for (const item of queue) {
+    const existing = groups.get(item.libraryItemId)
+    if (existing) {
+      existing.items.push(item)
+    } else {
+      groups.set(item.libraryItemId, {
+        libraryItemId: item.libraryItemId,
+        podcastTitle: item.podcastTitle,
+        podcastExplicit: item.podcastExplicit,
+        items: [item]
+      })
+    }
+  }
+
+  return Array.from(groups.values())
+}
+
+function EpisodeNumberAndType({ item }: { item: PodcastEpisodeDownload }) {
+  return (
+    <div className="flex shrink-0 items-center">
+      {item.season && <span>{item.season}x</span>}
+      {item.episode && <span>{item.episode}</span>}
+      {item.episodeType === 'bonus' && <BonusIndicator className="ms-1 shrink-0" />}
+      {item.episodeType === 'trailer' && <TrailerIndicator className="ms-1 shrink-0" />}
+    </div>
+  )
+}
+
+function QueueTableRow({ item, libraryId }: { item: PodcastEpisodeDownload; libraryId: string }) {
+  const publishedDateLabel = item.publishedAt ? formatDistanceToNow(new Date(item.publishedAt), { addSuffix: true }) : null
+
+  return (
+    <tr>
+      <td dir="auto" className="px-4">
+        <div className="flex items-center">
+          <Link
+            href={`/library/${libraryId}/item/${item.libraryItemId}`}
+            className="text-foreground-muted hover:text-foreground text-start text-sm hover:underline"
+          >
+            {item.podcastTitle}
+          </Link>
+          {item.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}
+        </div>
+      </td>
+      <td>
+        <EpisodeNumberAndType item={item} />
+      </td>
+      <td dir="auto" className="px-4">
+        {item.episodeDisplayTitle}
+      </td>
+      <td className="text-xs">
+        <div className="flex items-center">{publishedDateLabel && <p>{publishedDateLabel}</p>}</div>
+      </td>
+    </tr>
+  )
+}
+
+function MobileEpisodeRow({ item }: { item: PodcastEpisodeDownload }) {
+  const title = item.episodeDisplayTitle ?? ''
+
+  return (
+    <tr>
+      <td className="w-12 shrink-0 px-2 py-2 align-middle">
+        <EpisodeNumberAndType item={item} />
+      </td>
+      <td dir="auto" className="max-w-0 min-w-0 px-2 py-2 align-middle">
+        {title ? <LazyTruncatingTooltipText text={title} className="text-sm" position="top" /> : null}
+      </td>
+    </tr>
+  )
+}
+
+export default function PodcastDownloadQueueTable({ queue }: PodcastDownloadQueueTableProps) {
+  const t = useTypeSafeTranslations()
+  const { library } = useLibrary()
+
+  const groupedQueue = useMemo(() => groupQueueByPodcast(queue), [queue])
+
+  return (
+    <div className="my-2 w-full min-w-0">
+      <div className="bg-primary flex w-full items-center px-4 py-2 md:px-6">
+        <p className="pe-2 md:pe-4">{t('HeaderDownloadQueue')}</p>
+        <div className="flex h-5 w-5 items-center justify-center rounded-full bg-white/10 md:h-7 md:w-7">
+          <span className="font-mono text-sm">{queue.length}</span>
+        </div>
+      </div>
+
+      {/* Mobile: grouped subtables with # and episode title columns */}
+      <div className="w-full min-w-0 md:hidden">
+        {groupedQueue.map((group) => {
+          return (
+            <div key={group.libraryItemId} className="w-full min-w-0">
+              <div className="bg-primary/50 flex w-full min-w-0 items-center gap-1 px-4 py-2">
+                {group.podcastTitle ? (
+                  <div className="min-w-0 flex-1 overflow-hidden">
+                    <LazyTruncatingTooltipText text={group.podcastTitle} className="text-foreground text-sm font-semibold" position="top" />
+                  </div>
+                ) : null}
+                {group.podcastExplicit && <ExplicitIndicator className="shrink-0" />}
+                <span className="text-foreground-subdued shrink-0 font-mono text-xs">({group.items.length})</span>
+              </div>
+              <table className="tracksTable w-full min-w-0 table-fixed text-sm">
+                <thead>
+                  <tr>
+                    <th className="w-12 px-2 text-left">#</th>
+                    <th className="min-w-0 px-2 text-left">{t('LabelEpisodeTitle')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {group.items.map((item) => (
+                    <MobileEpisodeRow key={item.id} item={item} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Desktop: full table */}
+      <div className="hidden w-full md:block">
+        <table className="tracksTable text-sm">
+          <thead>
+            <tr>
+              <th className="min-w-48 px-4 text-left">{t('LabelPodcast')}</th>
+              <th className="w-32 min-w-32 text-left">{t('LabelEpisode')}</th>
+              <th className="px-4 text-left">{t('LabelEpisodeTitle')}</th>
+              <th className="w-48 px-4 text-left">{t('LabelPubDate')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {queue.map((item) => (
+              <QueueTableRow key={item.id} item={item} libraryId={library.id} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/widgets/PodcastDownloadQueueTable.tsx
+++ b/src/components/widgets/PodcastDownloadQueueTable.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import LazyTruncatingTooltipText from '@/components/ui/LazyTruncatingTooltipText'
+import SimpleDataTable, { DataTableColumn } from '@/components/ui/SimpleDataTable'
 import BonusIndicator from '@/components/widgets/BonusIndicator'
 import ExplicitIndicator from '@/components/widgets/ExplicitIndicator'
 import TrailerIndicator from '@/components/widgets/TrailerIndicator'
@@ -53,55 +54,75 @@ function EpisodeNumberAndType({ item }: { item: PodcastEpisodeDownload }) {
   )
 }
 
-function QueueTableRow({ item, libraryId }: { item: PodcastEpisodeDownload; libraryId: string }) {
-  const publishedDateLabel = item.publishedAt ? formatDistanceToNow(new Date(item.publishedAt), { addSuffix: true }) : null
-
-  return (
-    <tr>
-      <td dir="auto" className="px-4">
-        <div className="flex items-center">
-          <Link
-            href={`/library/${libraryId}/item/${item.libraryItemId}`}
-            className="text-foreground-muted hover:text-foreground text-start text-sm hover:underline"
-          >
-            {item.podcastTitle}
-          </Link>
-          {item.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}
-        </div>
-      </td>
-      <td>
-        <EpisodeNumberAndType item={item} />
-      </td>
-      <td dir="auto" className="px-4">
-        {item.episodeDisplayTitle}
-      </td>
-      <td className="text-xs">
-        <div className="flex items-center">{publishedDateLabel && <p>{publishedDateLabel}</p>}</div>
-      </td>
-    </tr>
-  )
-}
-
-function MobileEpisodeRow({ item }: { item: PodcastEpisodeDownload }) {
-  const title = item.episodeDisplayTitle ?? ''
-
-  return (
-    <tr>
-      <td className="w-12 shrink-0 px-2 py-2 align-middle">
-        <EpisodeNumberAndType item={item} />
-      </td>
-      <td dir="auto" className="max-w-0 min-w-0 px-2 py-2 align-middle">
-        {title ? <LazyTruncatingTooltipText text={title} className="text-sm" position="top" /> : null}
-      </td>
-    </tr>
-  )
-}
-
 export default function PodcastDownloadQueueTable({ queue }: PodcastDownloadQueueTableProps) {
   const t = useTypeSafeTranslations()
   const { library } = useLibrary()
 
   const groupedQueue = useMemo(() => groupQueueByPodcast(queue), [queue])
+
+  const desktopColumns = useMemo<DataTableColumn<PodcastEpisodeDownload>[]>(
+    () => [
+      {
+        label: t('LabelPodcast'),
+        accessor: (item) => (
+          <div className="flex items-center">
+            <Link
+              href={`/library/${library.id}/item/${item.libraryItemId}`}
+              className="text-foreground-muted hover:text-foreground text-start text-sm hover:underline"
+            >
+              {item.podcastTitle}
+            </Link>
+            {item.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}
+          </div>
+        ),
+        headerClassName: 'min-w-48 px-4',
+        cellClassName: 'px-4'
+      },
+      {
+        label: t('LabelEpisode'),
+        accessor: (item) => <EpisodeNumberAndType item={item} />,
+        headerClassName: 'w-32 min-w-32',
+        cellClassName: ''
+      },
+      {
+        label: t('LabelEpisodeTitle'),
+        accessor: (item) => item.episodeDisplayTitle,
+        headerClassName: 'px-4',
+        cellClassName: 'px-4'
+      },
+      {
+        label: t('LabelPubDate'),
+        accessor: (item) => {
+          const publishedDateLabel = item.publishedAt ? formatDistanceToNow(new Date(item.publishedAt), { addSuffix: true }) : null
+          return publishedDateLabel ? <p>{publishedDateLabel}</p> : null
+        },
+        headerClassName: 'w-48 px-4',
+        cellClassName: 'text-xs px-4'
+      }
+    ],
+    [t, library.id]
+  )
+
+  const mobileColumns = useMemo<DataTableColumn<PodcastEpisodeDownload>[]>(
+    () => [
+      {
+        label: '#',
+        accessor: (item) => <EpisodeNumberAndType item={item} />,
+        headerClassName: 'w-12 px-2',
+        cellClassName: 'w-12 shrink-0 px-2 align-middle'
+      },
+      {
+        label: t('LabelEpisodeTitle'),
+        accessor: (item) => {
+          const title = item.episodeDisplayTitle ?? ''
+          return title ? <LazyTruncatingTooltipText text={title} className="text-sm" position="top" /> : null
+        },
+        headerClassName: 'min-w-0 px-2',
+        cellClassName: 'max-w-0 min-w-0 px-2 align-middle'
+      }
+    ],
+    [t]
+  )
 
   return (
     <div className="my-2 w-full min-w-0">
@@ -126,19 +147,7 @@ export default function PodcastDownloadQueueTable({ queue }: PodcastDownloadQueu
                 {group.podcastExplicit && <ExplicitIndicator className="shrink-0" />}
                 <span className="text-foreground-subdued shrink-0 font-mono text-xs">({group.items.length})</span>
               </div>
-              <table className="tracksTable w-full min-w-0 table-fixed text-sm">
-                <thead>
-                  <tr>
-                    <th className="w-12 px-2 text-left">#</th>
-                    <th className="min-w-0 px-2 text-left">{t('LabelEpisodeTitle')}</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {group.items.map((item) => (
-                    <MobileEpisodeRow key={item.id} item={item} />
-                  ))}
-                </tbody>
-              </table>
+              <SimpleDataTable data={group.items} columns={mobileColumns} getRowKey={(item) => item.id} tableClassName="table-fixed" className="min-w-0" />
             </div>
           )
         })}
@@ -146,21 +155,7 @@ export default function PodcastDownloadQueueTable({ queue }: PodcastDownloadQueu
 
       {/* Desktop: full table */}
       <div className="hidden w-full md:block">
-        <table className="tracksTable text-sm">
-          <thead>
-            <tr>
-              <th className="min-w-48 px-4 text-left">{t('LabelPodcast')}</th>
-              <th className="w-32 min-w-32 text-left">{t('LabelEpisode')}</th>
-              <th className="px-4 text-left">{t('LabelEpisodeTitle')}</th>
-              <th className="w-48 px-4 text-left">{t('LabelPubDate')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {queue.map((item) => (
-              <QueueTableRow key={item.id} item={item} libraryId={library.id} />
-            ))}
-          </tbody>
-        </table>
+        <SimpleDataTable data={queue} columns={desktopColumns} getRowKey={(item) => item.id} />
       </div>
     </div>
   )

--- a/src/hooks/useItemPageSocket.ts
+++ b/src/hooks/useItemPageSocket.ts
@@ -10,6 +10,8 @@ interface UseItemPageSocketOptions {
   isPodcast: boolean
   onItemUpdated?: (libraryItem: BookLibraryItem | PodcastLibraryItem) => void
   initialRssFeed?: RssFeed | null
+  initialEpisodeDownloadsQueued?: PodcastEpisodeDownload[]
+  initialEpisodesDownloading?: PodcastEpisodeDownload[]
 }
 
 interface UseItemPageSocketReturn {
@@ -33,12 +35,14 @@ export function useItemPageSocket({
   mediaId,
   isPodcast,
   onItemUpdated,
-  initialRssFeed = null
+  initialRssFeed = null,
+  initialEpisodeDownloadsQueued = [],
+  initialEpisodesDownloading = []
 }: UseItemPageSocketOptions): UseItemPageSocketReturn {
   const [rssFeed, setRssFeed] = useState<RssFeed | null>(initialRssFeed ?? null)
   const [mediaItemShare, setMediaItemShare] = useState<MediaItemShare | null>(null)
-  const [episodesDownloading, setEpisodesDownloading] = useState<PodcastEpisodeDownload[]>([])
-  const [episodeDownloadsQueued, setEpisodeDownloadsQueued] = useState<PodcastEpisodeDownload[]>([])
+  const [episodesDownloading, setEpisodesDownloading] = useState<PodcastEpisodeDownload[]>(initialEpisodesDownloading)
+  const [episodeDownloadsQueued, setEpisodeDownloadsQueued] = useState<PodcastEpisodeDownload[]>(initialEpisodeDownloadsQueued)
 
   // Item updated event
   const handleItemUpdated = useCallback(

--- a/src/hooks/useLibraryDownloadQueueSocket.ts
+++ b/src/hooks/useLibraryDownloadQueueSocket.ts
@@ -1,0 +1,80 @@
+'use client'
+
+import { useLibrary } from '@/contexts/LibraryContext'
+import { useSocketEvent } from '@/contexts/SocketContext'
+import type { PodcastEpisodeDownload } from '@/types/api'
+import { useCallback, useState } from 'react'
+
+/** TODO(debug): set to false before merge — keeps rows in PodcastDownloadQueueTable */
+const DEBUG_KEEP_QUEUE_TABLE_ITEMS = false
+
+interface UseLibraryDownloadQueueSocketOptions {
+  initialQueue: PodcastEpisodeDownload[]
+  initialCurrentDownload?: PodcastEpisodeDownload
+}
+
+interface UseLibraryDownloadQueueSocketReturn {
+  episodesDownloading: PodcastEpisodeDownload[]
+  episodeDownloadsQueued: PodcastEpisodeDownload[]
+}
+
+export function useLibraryDownloadQueueSocket({
+  initialQueue,
+  initialCurrentDownload
+}: UseLibraryDownloadQueueSocketOptions): UseLibraryDownloadQueueSocketReturn {
+  const { library } = useLibrary()
+  const libraryId = library.id
+
+  const [episodesDownloading, setEpisodesDownloading] = useState<PodcastEpisodeDownload[]>(() => (initialCurrentDownload ? [initialCurrentDownload] : []))
+  const [episodeDownloadsQueued, setEpisodeDownloadsQueued] = useState<PodcastEpisodeDownload[]>(initialQueue)
+
+  const handleEpisodeDownloadQueued = useCallback(
+    (data: PodcastEpisodeDownload) => {
+      if (data.libraryId === libraryId) {
+        setEpisodeDownloadsQueued((prev) => [...prev, data])
+      }
+    },
+    [libraryId]
+  )
+
+  const handleEpisodeDownloadStarted = useCallback(
+    (data: PodcastEpisodeDownload) => {
+      if (data.libraryId === libraryId) {
+        if (!DEBUG_KEEP_QUEUE_TABLE_ITEMS) {
+          setEpisodeDownloadsQueued((prev) => prev.filter((d) => d.id !== data.id))
+        }
+        setEpisodesDownloading((prev) => [...prev, data])
+      }
+    },
+    [libraryId]
+  )
+
+  const handleEpisodeDownloadFinished = useCallback(
+    (data: PodcastEpisodeDownload) => {
+      if (data.libraryId === libraryId) {
+        if (!DEBUG_KEEP_QUEUE_TABLE_ITEMS) {
+          setEpisodeDownloadsQueued((prev) => prev.filter((d) => d.id !== data.id))
+        }
+        setEpisodesDownloading((prev) => prev.filter((d) => d.id !== data.id))
+      }
+    },
+    [libraryId]
+  )
+
+  const handleEpisodeDownloadQueueCleared = useCallback((libraryItemId: string) => {
+    if (DEBUG_KEEP_QUEUE_TABLE_ITEMS) {
+      return
+    }
+    setEpisodeDownloadsQueued((prev) => prev.filter((d) => d.libraryItemId !== libraryItemId))
+  }, [])
+
+  useSocketEvent<PodcastEpisodeDownload>('episode_download_queued', handleEpisodeDownloadQueued, [libraryId])
+  useSocketEvent<PodcastEpisodeDownload>('episode_download_started', handleEpisodeDownloadStarted, [libraryId])
+  useSocketEvent<PodcastEpisodeDownload>('episode_download_finished', handleEpisodeDownloadFinished, [libraryId])
+  useSocketEvent<string>('episode_download_queue_cleared', handleEpisodeDownloadQueueCleared, [libraryId])
+
+  return {
+    episodesDownloading,
+    episodeDownloadsQueued
+  }
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,6 +41,7 @@ import {
   GetNotificationsResponse,
   GetOpenListeningSessionsResponse,
   GetPlaylistsResponse,
+  GetEpisodeDownloadQueueResponse,
   GetRecentEpisodesResponse,
   GetPodcastTitlesResponse,
   GetRssFeedsResponse,
@@ -625,6 +626,10 @@ export const getLibraryPlaylists = cache(async (libraryId: string, queryParams?:
 
 export const getRecentEpisodes = cache(async (libraryId: string, limit = 50, page = 0): Promise<GetRecentEpisodesResponse> => {
   return apiRequest<GetRecentEpisodesResponse>(`/api/libraries/${libraryId}/recent-episodes?limit=${limit}&page=${page}`)
+})
+
+export const getEpisodeDownloadQueue = cache(async (libraryId: string): Promise<GetEpisodeDownloadQueueResponse> => {
+  return apiRequest<GetEpisodeDownloadQueueResponse>(`/api/libraries/${libraryId}/episode-downloads`)
 })
 
 export const getApiKeys = cache(async (): Promise<GetApiKeysResponse> => {

--- a/src/lib/coverUtils.ts
+++ b/src/lib/coverUtils.ts
@@ -9,7 +9,7 @@ import type { LibraryItem } from '@/types/api'
  */
 export function getLibraryItemCoverUrl(libraryItemId: string, timestamp?: number | null, raw: boolean = false): string {
   const params = new URLSearchParams()
-  params.set('ts', String(timestamp || Date.now()))
+  params.set('ts', String(timestamp ?? 0))
   if (raw) {
     params.set('raw', '1')
   }

--- a/src/lib/shiftClickSelection.ts
+++ b/src/lib/shiftClickSelection.ts
@@ -1,0 +1,76 @@
+export interface ShiftClickSelectionParams {
+  prevSelected: Set<string>
+  clickedKey: string
+  clickedIndex: number
+  shiftKey: boolean
+  anchorKey: string | null
+  /** Item keys in current display order (filter + sort). */
+  orderedKeys: readonly string[]
+  /** Desired selection state for the clicked item when not range-selecting. */
+  selectClicked: boolean
+  /** When false, the key is skipped during shift-range operations. */
+  isKeySelectable?: (key: string) => boolean
+}
+
+export interface ShiftClickSelectionResult {
+  nextSelected: Set<string>
+  anchorKey: string | null
+}
+
+/**
+ * Applies single-click or shift-click range selection over an ordered list.
+ * Range behavior matches LazyBookshelf: if any selectable item in the range is
+ * unselected, select all selectable items in the range; otherwise deselect them.
+ */
+export function applyShiftClickSelection({
+  prevSelected,
+  clickedKey,
+  clickedIndex,
+  shiftKey,
+  anchorKey,
+  orderedKeys,
+  selectClicked,
+  isKeySelectable = () => true
+}: ShiftClickSelectionParams): ShiftClickSelectionResult {
+  const next = new Set(prevSelected)
+
+  const anchorIndex = anchorKey ? orderedKeys.indexOf(anchorKey) : -1
+
+  if (shiftKey && anchorIndex >= 0 && clickedIndex >= 0 && clickedIndex < orderedKeys.length) {
+    const loopStart = Math.min(clickedIndex, anchorIndex)
+    const loopEnd = Math.max(clickedIndex, anchorIndex)
+
+    let isSelecting = false
+    for (let i = loopStart; i <= loopEnd; i++) {
+      const key = orderedKeys[i]
+      if (!isKeySelectable(key)) continue
+      if (!next.has(key)) {
+        isSelecting = true
+        break
+      }
+    }
+
+    for (let i = loopStart; i <= loopEnd; i++) {
+      const key = orderedKeys[i]
+      if (!isKeySelectable(key)) continue
+      if (isSelecting) {
+        next.add(key)
+      } else {
+        next.delete(key)
+      }
+    }
+
+    return {
+      nextSelected: next,
+      anchorKey: isSelecting ? clickedKey : null
+    }
+  }
+
+  if (selectClicked) {
+    next.add(clickedKey)
+    return { nextSelected: next, anchorKey: clickedKey }
+  }
+
+  next.delete(clickedKey)
+  return { nextSelected: next, anchorKey: null }
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -715,6 +715,11 @@ export interface RecentPodcastEpisode extends PodcastEpisode {
   podcast: PodcastMedia
 }
 
+export interface GetEpisodeDownloadQueueResponse {
+  currentDownload?: PodcastEpisodeDownload
+  queue: PodcastEpisodeDownload[]
+}
+
 export interface GetRecentEpisodesResponse {
   episodes: RecentPodcastEpisode[]
   limit: number


### PR DESCRIPTION
This migrates the podcast download queue page.

### Notable changes from Vue implementation

- **Route**: `/library/{id}/download-queue` instead of `/library/{id}/podcast/download-queue`.
- **Data loading**: React server-fetches on page load
- **Queue cleared**: React also listens for `episode_download_queue_cleared` and removes queued rows for the cleared podcast
- **Notification link**: React `NotificationWidget` now links to `/library/{id}/download-queue` (was incorrect on Vue)
- **Mobile queue table**: React groups queued episodes by podcast with a subtable per show. Only Episode and Episode title columns are shown

Other fixes include:
- RTL fix for `[Lazy]TruncatingTooltipText`
- Make `Indicator` use LazyTooltip
- Fix `AppBar` overflow on mobile when notification icon is displayed
- Make Add and Queue side rail buttons only available to admins and up.

Also added:
- Shift+click range selection in `EpisodeTable` and `EpisodeFeedModal`

*Note: If you to inspect the download queue table, you can set `const DEBUG_KEEP_QUEUE_TABLE_ITEMS = true` in `useLibraryDownloadQueueSocket.ts`. This keeps rows from disappeating from the table.*
