### PR TITLE
Keep library home shelves in sync with socket events

### DIFF
--- a/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
@@ -13,7 +13,7 @@ import { useSocketEvent } from '@/contexts/SocketContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { filterEncode } from '@/lib/filterUtils'
-import { Author, BookshelfView } from '@/types/api'
+import { Author, AuthorsNumBooksUpdatedPayload, BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -53,6 +53,16 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
     [author.id]
   )
 
+  const handleAuthorsNumBooksUpdated = useCallback(
+    (payload: AuthorsNumBooksUpdatedPayload) => {
+      const update = payload.authors.find((a) => a.id === author.id)
+      if (update) {
+        setAuthor((prev) => ({ ...prev, numBooks: update.numBooks }))
+      }
+    },
+    [author.id]
+  )
+
   const handleAuthorRemoved = useCallback(
     (data: Author | { id: string; libraryId: string }) => {
       const id = 'id' in data ? data.id : (data as Author).id
@@ -65,6 +75,7 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
   )
 
   useSocketEvent<Author>('author_updated', handleAuthorUpdated)
+  useSocketEvent<AuthorsNumBooksUpdatedPayload>('authors_num_books_updated', handleAuthorsNumBooksUpdated)
   useSocketEvent<Author | { id: string; libraryId: string }>('author_removed', handleAuthorRemoved)
 
   return (

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -44,6 +44,7 @@ import LibraryEmptyState from './LibraryEmptyState'
 
 interface LibraryClientProps {
   personalized: PersonalizedShelf[]
+  libraryItemCount: number
 }
 
 /**
@@ -106,7 +107,7 @@ function applyUserUpdatedToShelves(
   return changed ? prunePersonalizedShelves(nextShelves) : shelves
 }
 
-export default function LibraryClient({ personalized }: LibraryClientProps) {
+export default function LibraryClient({ personalized, libraryItemCount: libraryItemCountProp }: LibraryClientProps) {
   const t = useTypeSafeTranslations()
   const [, startScanTransition] = useTransition()
   const { sizeMultiplier } = useCardSize()
@@ -114,12 +115,17 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   const { library, setContextMenuItems, setContextMenuActionHandler, homeBookshelfView } = useLibrary()
 
   const [shelves, setShelves] = useState(personalized)
+  const [libraryItemCount, setLibraryItemCount] = useState(libraryItemCountProp)
 
   const visibleShelves = useMemo(() => prunePersonalizedShelves(shelves), [shelves])
 
   useEffect(() => {
     setShelves(personalized)
   }, [personalized])
+
+  useEffect(() => {
+    setLibraryItemCount(libraryItemCountProp)
+  }, [libraryItemCountProp])
 
   /**
    * Updates entities within shelves of matching types.
@@ -228,6 +234,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
     (payload: LibraryItemRemovedPayload) => {
       if (payload.libraryId !== library.id) return
       setShelves((prev) => applyLibraryItemRemovalToShelves(prev, payload.id))
+      setLibraryItemCount((prev) => Math.max(0, prev - 1))
     },
     [library.id]
   )
@@ -235,6 +242,7 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   const handleItemAdded = useCallback(
     (libraryItem: LibraryItem) => {
       if (libraryItem.libraryId !== library.id) return
+      setLibraryItemCount((prev) => prev + 1)
       refetchPersonalizedShelves()
     },
     [library.id, refetchPersonalizedShelves]
@@ -244,6 +252,8 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
     (libraryItems: LibraryItem[]) => {
       const itemsInLibrary = libraryItems.filter((item) => item.libraryId === library.id)
       if (itemsInLibrary.length === 0) return
+
+      setLibraryItemCount((prev) => prev + itemsInLibrary.length)
 
       // First items added to an empty library — refetch full personalized shelves
       if (prunePersonalizedShelves(shelvesRef.current).length === 0) {
@@ -345,7 +355,11 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
       {/* empty state with scan button if user is admin or root */}
       {visibleShelves.length === 0 && (
         <div className="py-8">
-          <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(user.type)} />
+          <LibraryEmptyState
+            library={library}
+            showScanButton={['admin', 'root'].includes(user.type)}
+            variant={libraryItemCount === 0 ? 'library-empty' : 'no-home-shelves'}
+          />
         </div>
       )}
 

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -17,14 +17,15 @@ import {
   applyAuthorAddedToNewestAuthorsShelf,
   applyAuthorRemovalToShelves,
   applyAuthorUpdateToShelves,
+  applyEpisodeRemovalFromShelves,
   applyLibraryItemRemovalToShelves,
   applyLibraryItemsAddedToRecentlyAddedShelf,
   prunePersonalizedShelves
 } from '@/lib/personalizedShelfUtils'
 import {
   Author,
-  AuthorsNumBooksUpdatedPayload,
   AuthorRemovedPayload,
+  AuthorsNumBooksUpdatedPayload,
   BookMetadata,
   BookshelfView,
   EpisodeAddedPayload,
@@ -239,6 +240,10 @@ export default function LibraryClient({ personalized, libraryItemCount: libraryI
     [library.id]
   )
 
+  const handleEpisodeDeleted = useCallback((libraryItemId: string, episodeId: string) => {
+    setShelves((prev) => applyEpisodeRemovalFromShelves(prev, libraryItemId, episodeId))
+  }, [])
+
   const handleItemAdded = useCallback(
     (libraryItem: LibraryItem) => {
       if (libraryItem.libraryId !== library.id) return
@@ -420,6 +425,11 @@ export default function LibraryClient({ personalized, libraryItemCount: libraryI
                       entityIndex={entityIndex}
                       continueListeningShelf={continueListeningShelf}
                       continueSeriesShelf={shelf.type === 'book' && continueSeriesShelf}
+                      onDeleteSuccess={
+                        shelf.type === 'episode' && libraryItem.recentEpisode
+                          ? () => handleEpisodeDeleted(libraryItem.id, libraryItem.recentEpisode!.id)
+                          : undefined
+                      }
                     />
                   </div>
                 )

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { fetchLibraryPersonalizedAction } from '@/app/actions/libraryActions'
 import BookShelfRow from '@/components/widgets/BookShelfRow'
 import ItemSlider from '@/components/widgets/ItemSlider'
 import { AuthorCard } from '@/components/widgets/media-card/AuthorCard'
@@ -13,10 +14,22 @@ import { useLibraryItemUpdated } from '@/hooks/useLibraryItemUpdated'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { applyLibraryItemUpdateToShelves } from '@/lib/libraryItemUpdatedUtils'
 import {
+  applyAuthorAddedToNewestAuthorsShelf,
+  applyAuthorRemovalToShelves,
+  applyAuthorUpdateToNewestAuthorsShelf,
+  applyAuthorUpdateToShelves,
+  applyLibraryItemRemovalToShelves,
+  applyLibraryItemsAddedToRecentlyAddedShelf,
+  prunePersonalizedShelves
+} from '@/lib/personalizedShelfUtils'
+import {
   Author,
+  AuthorRemovedPayload,
   BookMetadata,
   BookshelfView,
+  EpisodeAddedPayload,
   LibraryItem,
+  LibraryItemRemovedPayload,
   MediaItemShare,
   MediaProgress,
   PersonalizedShelf,
@@ -25,7 +38,7 @@ import {
   Series,
   isPersonalizedSeriesRef
 } from '@/types/api'
-import { useCallback, useEffect, useState, useTransition } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { requestScanLibrary } from '../../settings/libraries/actions'
 import LibraryEmptyState from './LibraryEmptyState'
 
@@ -90,7 +103,7 @@ function applyUserUpdatedToShelves(
     }
   }
 
-  return changed ? nextShelves : shelves
+  return changed ? prunePersonalizedShelves(nextShelves) : shelves
 }
 
 export default function LibraryClient({ personalized }: LibraryClientProps) {
@@ -101,6 +114,8 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   const { library, setContextMenuItems, setContextMenuActionHandler, homeBookshelfView } = useLibrary()
 
   const [shelves, setShelves] = useState(personalized)
+
+  const visibleShelves = useMemo(() => prunePersonalizedShelves(shelves), [shelves])
 
   useEffect(() => {
     setShelves(personalized)
@@ -196,8 +211,96 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
     setShelves((prev) => applyLibraryItemUpdateToShelves(prev, updatedItem))
   }, [])
 
+  const shelvesRef = useRef(shelves)
+  shelvesRef.current = shelves
+
+  const refetchPersonalizedShelves = useCallback(() => {
+    void fetchLibraryPersonalizedAction(library.id)
+      .then((nextShelves) => {
+        setShelves(nextShelves)
+      })
+      .catch((error) => {
+        console.error('Failed to fetch personalized shelves', error)
+      })
+  }, [library.id])
+
+  const handleItemRemoved = useCallback(
+    (payload: LibraryItemRemovedPayload) => {
+      if (payload.libraryId !== library.id) return
+      setShelves((prev) => applyLibraryItemRemovalToShelves(prev, payload.id))
+    },
+    [library.id]
+  )
+
+  const handleItemAdded = useCallback(
+    (libraryItem: LibraryItem) => {
+      if (libraryItem.libraryId !== library.id) return
+      refetchPersonalizedShelves()
+    },
+    [library.id, refetchPersonalizedShelves]
+  )
+
+  const handleItemsAdded = useCallback(
+    (libraryItems: LibraryItem[]) => {
+      const itemsInLibrary = libraryItems.filter((item) => item.libraryId === library.id)
+      if (itemsInLibrary.length === 0) return
+
+      // First items added to an empty library — refetch full personalized shelves
+      if (prunePersonalizedShelves(shelvesRef.current).length === 0) {
+        refetchPersonalizedShelves()
+        return
+      }
+
+      setShelves((prev) => applyLibraryItemsAddedToRecentlyAddedShelf(prev, itemsInLibrary))
+    },
+    [library.id, refetchPersonalizedShelves]
+  )
+
+  const handleEpisodeAdded = useCallback(
+    (payload: EpisodeAddedPayload) => {
+      if (payload.libraryItem?.libraryId !== library.id) return
+      refetchPersonalizedShelves()
+    },
+    [library.id, refetchPersonalizedShelves]
+  )
+
+  const handleAuthorUpdated = useCallback(
+    (author: Author) => {
+      if (author.libraryId !== undefined && author.libraryId !== library.id) return
+      setShelves((prev) => {
+        let next = applyAuthorUpdateToShelves(prev, author)
+        next = applyAuthorUpdateToNewestAuthorsShelf(next, author)
+        return next
+      })
+    },
+    [library.id]
+  )
+
+  const handleAuthorAdded = useCallback(
+    (author: Author) => {
+      if (author.libraryId !== undefined && author.libraryId !== library.id) return
+      setShelves((prev) => applyAuthorAddedToNewestAuthorsShelf(prev, author))
+    },
+    [library.id]
+  )
+
+  const handleAuthorRemoved = useCallback(
+    (payload: AuthorRemovedPayload) => {
+      if (payload.libraryId !== library.id) return
+      setShelves((prev) => applyAuthorRemovalToShelves(prev, payload.id))
+    },
+    [library.id]
+  )
+
   useLibraryItemUpdated(library.id, handleItemUpdated)
 
+  useSocketEvent<LibraryItemRemovedPayload>('item_removed', handleItemRemoved)
+  useSocketEvent<LibraryItem>('item_added', handleItemAdded)
+  useSocketEvent<LibraryItem[]>('items_added', handleItemsAdded)
+  useSocketEvent<EpisodeAddedPayload>('episode_added', handleEpisodeAdded)
+  useSocketEvent<Author>('author_added', handleAuthorAdded)
+  useSocketEvent<Author>('author_updated', handleAuthorUpdated)
+  useSocketEvent<AuthorRemovedPayload>('author_removed', handleAuthorRemoved)
   useSocketEvent<MediaItemShare>('share_open', handleShareOpen)
   useSocketEvent<MediaItemShare>('share_closed', handleShareClosed)
   useSocketEvent<RssFeed>('rss_feed_open', handleRssFeedOpen)
@@ -240,14 +343,14 @@ export default function LibraryClient({ personalized }: LibraryClientProps) {
   return (
     <div className="pb-20" style={{ fontSize: sizeMultiplier + 'rem' }}>
       {/* empty state with scan button if user is admin or root */}
-      {shelves.length === 0 && (
+      {visibleShelves.length === 0 && (
         <div className="py-8">
           <LibraryEmptyState library={library} showScanButton={['admin', 'root'].includes(user.type)} />
         </div>
       )}
 
       {/* bookshelf rows */}
-      {shelves.map((shelf) => {
+      {visibleShelves.map((shelf) => {
         const Wrapper = homeBookshelfView === BookshelfView.STANDARD ? BookShelfRow : ItemSlider
         const continueListeningShelf = shelf.id === 'continue-listening' || shelf.id === 'continue-reading'
         const continueSeriesShelf = shelf.id === 'continue-series'

--- a/src/app/(main)/library/[library]/LibraryClient.tsx
+++ b/src/app/(main)/library/[library]/LibraryClient.tsx
@@ -16,7 +16,6 @@ import { applyLibraryItemUpdateToShelves } from '@/lib/libraryItemUpdatedUtils'
 import {
   applyAuthorAddedToNewestAuthorsShelf,
   applyAuthorRemovalToShelves,
-  applyAuthorUpdateToNewestAuthorsShelf,
   applyAuthorUpdateToShelves,
   applyLibraryItemRemovalToShelves,
   applyLibraryItemsAddedToRecentlyAddedShelf,
@@ -24,6 +23,7 @@ import {
 } from '@/lib/personalizedShelfUtils'
 import {
   Author,
+  AuthorsNumBooksUpdatedPayload,
   AuthorRemovedPayload,
   BookMetadata,
   BookshelfView,
@@ -277,9 +277,19 @@ export default function LibraryClient({ personalized, libraryItemCount: libraryI
   const handleAuthorUpdated = useCallback(
     (author: Author) => {
       if (author.libraryId !== undefined && author.libraryId !== library.id) return
+      setShelves((prev) => applyAuthorUpdateToShelves(prev, author))
+    },
+    [library.id]
+  )
+
+  const handleAuthorsNumBooksUpdated = useCallback(
+    (payload: AuthorsNumBooksUpdatedPayload) => {
+      if (payload.libraryId !== library.id || payload.authors.length === 0) return
       setShelves((prev) => {
-        let next = applyAuthorUpdateToShelves(prev, author)
-        next = applyAuthorUpdateToNewestAuthorsShelf(next, author)
+        let next = prev
+        for (const author of payload.authors) {
+          next = applyAuthorUpdateToShelves(next, author)
+        }
         return next
       })
     },
@@ -310,6 +320,7 @@ export default function LibraryClient({ personalized, libraryItemCount: libraryI
   useSocketEvent<EpisodeAddedPayload>('episode_added', handleEpisodeAdded)
   useSocketEvent<Author>('author_added', handleAuthorAdded)
   useSocketEvent<Author>('author_updated', handleAuthorUpdated)
+  useSocketEvent<AuthorsNumBooksUpdatedPayload>('authors_num_books_updated', handleAuthorsNumBooksUpdated)
   useSocketEvent<AuthorRemovedPayload>('author_removed', handleAuthorRemoved)
   useSocketEvent<MediaItemShare>('share_open', handleShareOpen)
   useSocketEvent<MediaItemShare>('share_closed', handleShareClosed)

--- a/src/app/(main)/library/[library]/LibraryEmptyState.tsx
+++ b/src/app/(main)/library/[library]/LibraryEmptyState.tsx
@@ -5,12 +5,15 @@ import { Library } from '@/types/api'
 import { useMemo, useTransition } from 'react'
 import { requestScanLibrary } from '../../settings/libraries/actions'
 
+export type LibraryEmptyStateVariant = 'library-empty' | 'no-home-shelves'
+
 interface LibraryEmptyStateProps {
   library: Library
   showScanButton: boolean
+  variant?: LibraryEmptyStateVariant
 }
 
-export default function LibraryEmptyState({ library, showScanButton }: LibraryEmptyStateProps) {
+export default function LibraryEmptyState({ library, showScanButton, variant = 'library-empty' }: LibraryEmptyStateProps) {
   const t = useTypeSafeTranslations()
   const [isPending, startTransition] = useTransition()
   const { getTasksByLibraryId } = useTasks()
@@ -27,6 +30,19 @@ export default function LibraryEmptyState({ library, showScanButton }: LibraryEm
         console.error('Failed to scan library', error)
       }
     })
+  }
+
+  if (variant === 'no-home-shelves') {
+    const browseLabel = library.mediaType === 'podcast' ? t('LabelPodcasts') : t('LabelBooks')
+
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-10">
+        <p className="mb-2 max-w-lg text-center text-xl">{t('MessageNoHomeShelves')}</p>
+        <Btn size="small" color="bg-success" to={`/library/${library.id}/items`}>
+          {browseLabel}
+        </Btn>
+      </div>
+    )
   }
 
   return (

--- a/src/app/(main)/library/[library]/page.tsx
+++ b/src/app/(main)/library/[library]/page.tsx
@@ -1,10 +1,10 @@
-import { getData, getLibraryPersonalized } from '@/lib/api'
+import { getData, getLibraryPersonalized, getLibraryStats } from '@/lib/api'
 import LibraryClient from './LibraryClient'
 
 export default async function LibraryPage({ params }: { params: Promise<{ library: string }> }) {
   const { library: libraryId } = await params
 
-  const [personalized] = await getData(getLibraryPersonalized(libraryId))
+  const [[personalized], [stats]] = await Promise.all([getData(getLibraryPersonalized(libraryId)), getData(getLibraryStats(libraryId))])
 
   if (!personalized) {
     console.error('Error getting personalized data')
@@ -13,7 +13,7 @@ export default async function LibraryPage({ params }: { params: Promise<{ librar
 
   return (
     <div className="w-full">
-      <LibraryClient personalized={personalized} />
+      <LibraryClient personalized={personalized} libraryItemCount={stats?.totalItems ?? 0} />
     </div>
   )
 }

--- a/src/app/actions/libraryActions.ts
+++ b/src/app/actions/libraryActions.ts
@@ -1,6 +1,14 @@
 'use server'
 
-import { getLibraryAuthors, getLibraryCollections, getLibraryFilterData, getLibraryItems, getLibraryPlaylists, getLibrarySeries } from '@/lib/api'
+import {
+  getLibraryAuthors,
+  getLibraryCollections,
+  getLibraryFilterData,
+  getLibraryItems,
+  getLibraryPersonalized,
+  getLibraryPlaylists,
+  getLibrarySeries
+} from '@/lib/api'
 
 export async function fetchLibraryItemsAction(libraryId: string, query: string) {
   return getLibraryItems(libraryId, query)
@@ -8,6 +16,10 @@ export async function fetchLibraryItemsAction(libraryId: string, query: string) 
 
 export async function fetchLibraryFilterDataAction(libraryId: string) {
   return getLibraryFilterData(libraryId)
+}
+
+export async function fetchLibraryPersonalizedAction(libraryId: string) {
+  return getLibraryPersonalized(libraryId)
 }
 
 export async function fetchSeriesAction(libraryId: string, query: string) {

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -92,6 +92,8 @@ export interface MediaCardProps {
   entityIndex?: number
   /** Wired by sortable bookshelf hosts (`SortableBookshelfCard`, `DragOverlay`, etc.). */
   dragOptions?: SortableBookshelfCardOptions
+  /** Called after a library item or episode delete succeeds. */
+  onDeleteSuccess?: () => void
 }
 
 const LONG_PRESS_MS = 450
@@ -129,7 +131,8 @@ function MediaCard(props: MediaCardProps) {
     selectionAnchorKey,
     shelfEntities,
     entityIndex,
-    dragOptions
+    dragOptions,
+    onDeleteSuccess
   } = props
 
   const sortableBookshelfOverlay = useSortableBookshelfOverlay()
@@ -392,6 +395,7 @@ function MediaCard(props: MediaCardProps) {
     initialShare: libraryItem.mediaItemShare ?? null,
     onOpenMatch: handleOpenMatch,
     onOpenCoverEdit: handleOpenCoverEdit,
+    onDeleteSuccess,
     playerControls: playerHandler.controls
   })
 

--- a/src/components/widgets/media-card/SelectableShelfMediaCard.tsx
+++ b/src/components/widgets/media-card/SelectableShelfMediaCard.tsx
@@ -26,6 +26,7 @@ interface SelectableShelfMediaCardProps {
   continueListeningShelf?: boolean
   continueSeriesShelf?: boolean
   selectionEnabled?: boolean
+  onDeleteSuccess?: () => void
 }
 
 export default function SelectableShelfMediaCard({
@@ -43,7 +44,8 @@ export default function SelectableShelfMediaCard({
   entityIndex,
   continueListeningShelf,
   continueSeriesShelf,
-  selectionEnabled = true
+  selectionEnabled = true,
+  onDeleteSuccess
 }: SelectableShelfMediaCardProps) {
   const episode = cardType === 'episode' ? libraryItem.recentEpisode : undefined
   const { isSelectionMode, selected, onSelect, selectionKey } = useBookshelfCardSelection(libraryItem, entityIndex, shelfEntities, episode, {
@@ -67,7 +69,8 @@ export default function SelectableShelfMediaCard({
     isSelectionMode,
     selected,
     onSelect,
-    selectionAnchorKey: selectionKey
+    selectionAnchorKey: selectionKey,
+    onDeleteSuccess
   }
 
   if (cardType === 'episode') {

--- a/src/hooks/useBookshelfUpdater.ts
+++ b/src/hooks/useBookshelfUpdater.ts
@@ -2,7 +2,17 @@
 
 import { useSocketEvent } from '@/contexts/SocketContext'
 import { getVisibleBookshelfPageRange, type VisibleBookshelfPageRangeInput } from '@/hooks/useBookshelfVirtualizer'
-import { Author, AuthorRemovedPayload, BookshelfEntity, Collection, EntityType, LibraryItem, LibraryItemRemovedPayload, Playlist } from '@/types/api'
+import {
+  Author,
+  AuthorsNumBooksUpdatedPayload,
+  AuthorRemovedPayload,
+  BookshelfEntity,
+  Collection,
+  EntityType,
+  LibraryItem,
+  LibraryItemRemovedPayload,
+  Playlist
+} from '@/types/api'
 import { type RefObject, useCallback, useLayoutEffect, useRef } from 'react'
 
 /** Like refs from `useRef` with a writable `current` (avoids deprecated `MutableRefObject` in newer `@types/react`). */
@@ -220,6 +230,12 @@ export function useBookshelfUpdater({
     reconcileUpdatedEntities(rt, [author])
   }, [])
 
+  const onAuthorsNumBooksUpdated = useCallback((payload: AuthorsNumBooksUpdatedPayload) => {
+    const rt = runtimeRef.current
+    if (payload.libraryId !== rt.libraryId || rt.entityType !== 'authors' || payload.authors.length === 0) return
+    reconcileUpdatedEntities(rt, payload.authors)
+  }, [])
+
   const onAuthorAdded = useCallback((author: Author) => {
     const rt = runtimeRef.current
     if ((author.libraryId !== undefined && author.libraryId !== rt.libraryId) || rt.entityType !== 'authors') return
@@ -275,6 +291,7 @@ export function useBookshelfUpdater({
   useSocketEvent<LibraryItemRemovedPayload>('item_removed', onLibraryItemRemoved, [onLibraryItemRemoved])
   useSocketEvent<Author>('author_added', onAuthorAdded, [onAuthorAdded])
   useSocketEvent<Author>('author_updated', onAuthorUpdated, [onAuthorUpdated])
+  useSocketEvent<AuthorsNumBooksUpdatedPayload>('authors_num_books_updated', onAuthorsNumBooksUpdated, [onAuthorsNumBooksUpdated])
   useSocketEvent<AuthorRemovedPayload>('author_removed', onAuthorRemoved, [onAuthorRemoved])
   useSocketEvent<Collection>('collection_added', onCollectionAdded, [onCollectionAdded])
   useSocketEvent<Collection>('collection_updated', onCollectionUpdated, [onCollectionUpdated])

--- a/src/lib/libraryItemUpdatedUtils.ts
+++ b/src/lib/libraryItemUpdatedUtils.ts
@@ -1,4 +1,18 @@
+import { prunePersonalizedShelves } from '@/lib/personalizedShelfUtils'
 import type { LibraryItem, PersonalizedShelf, PlaylistItem, Series } from '@/types/api'
+import { isPodcastMedia } from '@/types/api'
+
+function resolveRecentEpisodeAfterUpdate(existing: LibraryItem, updated: LibraryItem) {
+  const recentEpisode = existing.recentEpisode
+  if (!recentEpisode) return undefined
+
+  if (!isPodcastMedia(updated.media)) return recentEpisode
+
+  const episodes = updated.media.episodes
+  if (!episodes?.some((episode) => episode.id === recentEpisode.id)) return undefined
+
+  return recentEpisode
+}
 
 /** Preserve client-only fields when merging a socket `item_updated` payload. */
 export function mergeLibraryItemUpdate(existing: LibraryItem, updated: LibraryItem): LibraryItem {
@@ -6,7 +20,7 @@ export function mergeLibraryItemUpdate(existing: LibraryItem, updated: LibraryIt
     ...updated,
     rssFeed: existing.rssFeed,
     mediaItemShare: existing.mediaItemShare,
-    recentEpisode: existing.recentEpisode
+    recentEpisode: resolveRecentEpisodeAfterUpdate(existing, updated)
   }
 }
 
@@ -38,10 +52,12 @@ export function applyLibraryItemUpdateToShelves(shelves: PersonalizedShelf[], up
   const nextShelves = shelves.map((shelf) => {
     if (shelf.type === 'book' || shelf.type === 'podcast' || shelf.type === 'episode') {
       let entityChanged = false
-      const nextEntities = (shelf.entities as LibraryItem[]).map((entity) => {
-        if (entity.id !== updatedItem.id) return entity
+      const nextEntities = (shelf.entities as LibraryItem[]).flatMap((entity) => {
+        if (entity.id !== updatedItem.id) return [entity]
         entityChanged = true
-        return mergeLibraryItemUpdate(entity, updatedItem)
+        const merged = mergeLibraryItemUpdate(entity, updatedItem)
+        if (shelf.type === 'episode' && !merged.recentEpisode) return []
+        return [merged]
       })
       if (!entityChanged) return shelf
       changed = true
@@ -72,5 +88,5 @@ export function applyLibraryItemUpdateToShelves(shelves: PersonalizedShelf[], up
     return shelf
   })
 
-  return changed ? nextShelves : shelves
+  return changed ? prunePersonalizedShelves(nextShelves) : shelves
 }

--- a/src/lib/personalizedShelfUtils.ts
+++ b/src/lib/personalizedShelfUtils.ts
@@ -1,4 +1,4 @@
-import type { Author, LibraryItem, PersonalizedShelf, Series } from '@/types/api'
+import type { Author, AuthorNumBooksUpdate, LibraryItem, PersonalizedShelf, Series } from '@/types/api'
 
 /** Drop series with no books, authors with no books, and shelves with no entities. */
 export function prunePersonalizedShelves(shelves: PersonalizedShelf[]): PersonalizedShelf[] {
@@ -84,14 +84,11 @@ export function applyAuthorAddedToNewestAuthorsShelf(shelves: PersonalizedShelf[
   return nextShelves
 }
 
-export function applyAuthorUpdateToNewestAuthorsShelf(shelves: PersonalizedShelf[], author: Author): PersonalizedShelf[] {
-  if ((author.numBooks ?? 0) <= 0) {
+export function applyAuthorUpdateToShelves(shelves: PersonalizedShelf[], author: Author | AuthorNumBooksUpdate): PersonalizedShelf[] {
+  if (author.numBooks !== undefined && author.numBooks <= 0) {
     return applyAuthorRemovalToShelves(shelves, author.id)
   }
-  return applyAuthorAddedToNewestAuthorsShelf(shelves, author)
-}
 
-export function applyAuthorUpdateToShelves(shelves: PersonalizedShelf[], author: Author): PersonalizedShelf[] {
   let changed = false
   const nextShelves = shelves.map((shelf) => {
     if (shelf.type !== 'authors') return shelf

--- a/src/lib/personalizedShelfUtils.ts
+++ b/src/lib/personalizedShelfUtils.ts
@@ -21,6 +21,19 @@ export function prunePersonalizedShelves(shelves: PersonalizedShelf[]): Personal
   return nextShelves.filter((shelf) => shelf.entities.length > 0)
 }
 
+/** Remove a recent-episode card from episode shelves after the episode was deleted. */
+export function applyEpisodeRemovalFromShelves(shelves: PersonalizedShelf[], libraryItemId: string, episodeId: string): PersonalizedShelf[] {
+  const nextShelves = shelves.map((shelf) => {
+    if (shelf.type !== 'episode') return shelf
+
+    const nextEntities = (shelf.entities as LibraryItem[]).filter((entity) => entity.id !== libraryItemId || entity.recentEpisode?.id !== episodeId)
+    if (nextEntities.length === shelf.entities.length) return shelf
+    return { ...shelf, entities: nextEntities }
+  })
+
+  return prunePersonalizedShelves(nextShelves)
+}
+
 /** Remove a library item from book/podcast/episode shelves and from nested series books. */
 export function applyLibraryItemRemovalToShelves(shelves: PersonalizedShelf[], libraryItemId: string): PersonalizedShelf[] {
   const nextShelves = shelves.map((shelf) => {

--- a/src/lib/personalizedShelfUtils.ts
+++ b/src/lib/personalizedShelfUtils.ts
@@ -1,0 +1,123 @@
+import type { Author, LibraryItem, PersonalizedShelf, Series } from '@/types/api'
+
+/** Drop series with no books, authors with no books, and shelves with no entities. */
+export function prunePersonalizedShelves(shelves: PersonalizedShelf[]): PersonalizedShelf[] {
+  const nextShelves = shelves.map((shelf) => {
+    if (shelf.type === 'series') {
+      const nextEntities = (shelf.entities as Series[]).filter((series) => (series.books?.length ?? 0) > 0)
+      if (nextEntities.length === shelf.entities.length) return shelf
+      return { ...shelf, entities: nextEntities }
+    }
+
+    if (shelf.type === 'authors') {
+      const nextEntities = (shelf.entities as Author[]).filter((author) => (author.numBooks ?? 0) > 0)
+      if (nextEntities.length === shelf.entities.length) return shelf
+      return { ...shelf, entities: nextEntities }
+    }
+
+    return shelf
+  })
+
+  return nextShelves.filter((shelf) => shelf.entities.length > 0)
+}
+
+/** Remove a library item from book/podcast/episode shelves and from nested series books. */
+export function applyLibraryItemRemovalToShelves(shelves: PersonalizedShelf[], libraryItemId: string): PersonalizedShelf[] {
+  const nextShelves = shelves.map((shelf) => {
+    if (shelf.type === 'book' || shelf.type === 'podcast' || shelf.type === 'episode') {
+      const nextEntities = (shelf.entities as LibraryItem[]).filter((entity) => entity.id !== libraryItemId)
+      if (nextEntities.length === shelf.entities.length) return shelf
+      return { ...shelf, entities: nextEntities }
+    }
+
+    if (shelf.type === 'series') {
+      let entityChanged = false
+      const nextEntities = (shelf.entities as Series[]).map((series) => {
+        const books = series.books
+        if (!books?.some((book) => book.id === libraryItemId)) return series
+        entityChanged = true
+        return { ...series, books: books.filter((book) => book.id !== libraryItemId) }
+      })
+      if (!entityChanged) return shelf
+      return { ...shelf, entities: nextEntities }
+    }
+
+    return shelf
+  })
+
+  return prunePersonalizedShelves(nextShelves)
+}
+
+/** Unshift newly added library items onto the recently-added shelf when present. */
+export function applyLibraryItemsAddedToRecentlyAddedShelf(shelves: PersonalizedShelf[], libraryItems: LibraryItem[]): PersonalizedShelf[] {
+  const recentlyAddedIndex = shelves.findIndex((shelf) => shelf.id === 'recently-added')
+  if (recentlyAddedIndex < 0) return shelves
+
+  const recentlyAddedShelf = shelves[recentlyAddedIndex]
+  const existingIds = new Set((recentlyAddedShelf.entities as LibraryItem[]).map((entity) => entity.id))
+  const itemsToAdd = libraryItems.filter((item) => !existingIds.has(item.id))
+  if (itemsToAdd.length === 0) return shelves
+
+  const nextShelves = [...shelves]
+  nextShelves[recentlyAddedIndex] = {
+    ...recentlyAddedShelf,
+    entities: [...itemsToAdd, ...(recentlyAddedShelf.entities as LibraryItem[])]
+  }
+  return nextShelves
+}
+
+export function applyAuthorAddedToNewestAuthorsShelf(shelves: PersonalizedShelf[], author: Author): PersonalizedShelf[] {
+  const newestAuthorsIndex = shelves.findIndex((shelf) => shelf.id === 'newest-authors')
+  if (newestAuthorsIndex < 0) return shelves
+
+  const newestAuthorsShelf = shelves[newestAuthorsIndex]
+  const existingAuthors = newestAuthorsShelf.entities as Author[]
+  if (existingAuthors.some((entity) => entity.id === author.id)) return shelves
+
+  const authorToAdd = author.numBooks != null ? author : { ...author, numBooks: 1 }
+
+  const nextShelves = [...shelves]
+  nextShelves[newestAuthorsIndex] = {
+    ...newestAuthorsShelf,
+    entities: [authorToAdd, ...existingAuthors]
+  }
+  return nextShelves
+}
+
+export function applyAuthorUpdateToNewestAuthorsShelf(shelves: PersonalizedShelf[], author: Author): PersonalizedShelf[] {
+  if ((author.numBooks ?? 0) <= 0) {
+    return applyAuthorRemovalToShelves(shelves, author.id)
+  }
+  return applyAuthorAddedToNewestAuthorsShelf(shelves, author)
+}
+
+export function applyAuthorUpdateToShelves(shelves: PersonalizedShelf[], author: Author): PersonalizedShelf[] {
+  let changed = false
+  const nextShelves = shelves.map((shelf) => {
+    if (shelf.type !== 'authors') return shelf
+
+    let entityChanged = false
+    const nextEntities = (shelf.entities as Author[]).map((entity) => {
+      if (entity.id !== author.id) return entity
+      entityChanged = true
+      return { ...entity, ...author }
+    })
+    if (!entityChanged) return shelf
+    changed = true
+    return { ...shelf, entities: nextEntities }
+  })
+
+  return changed ? nextShelves : shelves
+}
+
+export function applyAuthorRemovalToShelves(shelves: PersonalizedShelf[], authorId: string): PersonalizedShelf[] {
+  const nextShelves = shelves.map((shelf) => {
+    if (shelf.type !== 'authors') return shelf
+
+    const nextEntities = (shelf.entities as Author[]).filter((entity) => entity.id !== authorId)
+    if (nextEntities.length === shelf.entities.length) return shelf
+    return { ...shelf, entities: nextEntities }
+  })
+
+  return prunePersonalizedShelves(nextShelves)
+}

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -967,6 +967,7 @@
   "MessageNoEpisodes": "No Episodes",
   "MessageNoFoldersAvailable": "No Folders Available",
   "MessageNoGenres": "No Genres",
+  "MessageNoHomeShelves": "Nothing to show on your home page right now.",
   "MessageNoIssues": "No Issues",
   "MessageNoItems": "No Items",
   "MessageNoItemsFound": "No items found",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -272,6 +272,13 @@ export interface LibraryItemRemovedPayload {
   libraryId: string
 }
 
+/** Payload for the `episode_added` socket event (expanded episode with nested library item). */
+export interface EpisodeAddedPayload {
+  id: string
+  libraryItemId?: string
+  libraryItem?: LibraryItem
+}
+
 export interface AuthorQuickMatchPayload {
   asin?: string
   q?: string

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -266,6 +266,18 @@ export interface AuthorRemovedPayload {
   libraryId: string
 }
 
+/** Author book-count entry in the `authors_num_books_updated` socket event. */
+export interface AuthorNumBooksUpdate {
+  id: string
+  numBooks: number
+}
+
+/** Payload for the `authors_num_books_updated` socket event (scan-linked existing authors). */
+export interface AuthorsNumBooksUpdatedPayload {
+  libraryId: string
+  authors: AuthorNumBooksUpdate[]
+}
+
 /** Payload for the `item_removed` socket event. */
 export interface LibraryItemRemovedPayload {
   id: string


### PR DESCRIPTION
This keeps personalized home shelves live-updated via socket events and fixes empty-home UX when shelves are empty but the library still has items.

### Notable changes
- Socket listeners update personalized shelves on item/author/episode add-remove events
- Hide empty shelf rows; show scan empty state only when the library has no items
- Show browse-to-items message when the library has items but no home shelves

*Note: This depends on [server PR #5354](https://github.com/advplyr/audiobookshelf/pull/5354)*