### PR TITLE
Media card fixes

### DIFF
--- a/src/components/widgets/media-card/BookMediaCard.tsx
+++ b/src/components/widgets/media-card/BookMediaCard.tsx
@@ -13,11 +13,13 @@ export default function BookMediaCard(props: BookMediaCardProps) {
   const { libraryItem } = props
   const media = libraryItem.media as BookMedia
 
+  // Sequence badge only when the server injects a shelf `PersonalizedSeriesRef`
+  // (continue-series, series-filtered rows). Minified home shelves use `seriesName` only;
+  // expanded `Series[]` from socket updates must not drive this badge.
   const seriesSequence = useMemo(() => {
     const { series } = media.metadata
-    if (!series) return null
-    if (isPersonalizedSeriesRef(series)) return series.sequence ?? null
-    return series[0]?.sequence ?? null
+    if (!series || !isPersonalizedSeriesRef(series)) return null
+    return series.sequence ?? null
   }, [media.metadata])
 
   const ebookFormat = useMemo(() => media.ebookFormat, [media])

--- a/src/components/widgets/media-card/CollapsedSeriesCard.tsx
+++ b/src/components/widgets/media-card/CollapsedSeriesCard.tsx
@@ -183,6 +183,7 @@ export default function CollapsedSeriesCard(props: CollapsedSeriesCardProps) {
       }
       overlay={
         <MediaCardOverlay
+          cardId={cardId}
           isHovering={isHovering}
           isSelectionMode={isSelectionMode}
           selected={selected}

--- a/src/components/widgets/media-card/CollectionCard.tsx
+++ b/src/components/widgets/media-card/CollectionCard.tsx
@@ -166,7 +166,13 @@ function CollectionCard(props: CollectionCardProps) {
                       'hover:scale-125 hover:[&_.material-symbols]:!text-yellow-300'
                     )}
                   >
-                    <MediaCardMoreMenu items={moreMenuItems} processing={processing} onAction={handleMoreAction} onOpenChange={handleMoreMenuOpenChange} />
+                    <MediaCardMoreMenu
+                      items={moreMenuItems}
+                      cardId={cardId}
+                      processing={processing}
+                      onAction={handleMoreAction}
+                      onOpenChange={handleMoreMenuOpenChange}
+                    />
                   </div>
                 )}
               </MediaCardOverlayContainer>

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -588,6 +588,7 @@ function MediaCard(props: MediaCardProps) {
         }
         overlay={
           <MediaCardOverlay
+            cardId={cardId}
             isHovering={isHovering}
             isSelectionMode={isSelectionMode}
             selected={selected}

--- a/src/components/widgets/media-card/MediaCardMoreMenu.tsx
+++ b/src/components/widgets/media-card/MediaCardMoreMenu.tsx
@@ -4,8 +4,10 @@ import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/Co
 import { mergeClasses } from '@/lib/merge-classes'
 import { useCallback, useMemo } from 'react'
 
-function isOverlayAction(target: Node) {
-  return target instanceof Element && !!target.closest('[data-overlay-action]')
+/** Overlay buttons on the same card should not dismiss the menu before their click handlers run. */
+function isOverlayActionInsideCard(target: Node, cardId: string): boolean {
+  if (!(target instanceof Element)) return false
+  return !!target.closest(`#${CSS.escape(cardId)} [data-overlay-action]`)
 }
 
 export interface MediaCardMoreMenuSubitem {
@@ -34,6 +36,8 @@ export function mapMediaCardMoreMenuItemsToDropdownItems(items: MediaCardMoreMen
 
 interface MediaCardMoreMenuProps {
   items: MediaCardMoreMenuItem[]
+  /** Matches MediaCardFrame root `id` so overlay clicks are scoped to this card only. */
+  cardId: string
   processing?: boolean
   isOpen?: boolean
   onAction: (func: string, data?: Record<string, string>) => void
@@ -41,8 +45,9 @@ interface MediaCardMoreMenuProps {
   className?: string
 }
 
-export default function MediaCardMoreMenu({ items, processing = false, isOpen, onAction, onOpenChange, className }: MediaCardMoreMenuProps) {
+export default function MediaCardMoreMenu({ items, cardId, processing = false, isOpen, onAction, onOpenChange, className }: MediaCardMoreMenuProps) {
   const contextMenuItems = useMemo(() => mapMediaCardMoreMenuItemsToDropdownItems(items), [items])
+  const isAdditionalInside = useCallback((target: Node) => isOverlayActionInsideCard(target, cardId), [cardId])
 
   const handleContextMenuAction = useCallback(
     ({ action, data }: { action: string; data?: Record<string, string> }) => {
@@ -74,7 +79,7 @@ export default function MediaCardMoreMenu({ items, processing = false, isOpen, o
       isOpen={isOpen}
       onAction={handleContextMenuAction}
       onOpenChange={handleOpenChange}
-      isAdditionalInside={isOverlayAction}
+      isAdditionalInside={isAdditionalInside}
       className={mergeClasses('h-auto w-auto text-[1em] text-white', className)}
       usePortal
     />

--- a/src/components/widgets/media-card/MediaCardOverlay.tsx
+++ b/src/components/widgets/media-card/MediaCardOverlay.tsx
@@ -40,6 +40,7 @@ const SPACING = {
 } as const
 
 interface MediaCardOverlayProps {
+  cardId: string
   isHovering: boolean
   isSelectionMode: boolean
   selected: boolean
@@ -72,6 +73,7 @@ interface MediaCardOverlayProps {
 }
 
 export default function MediaCardOverlay({
+  cardId,
   isHovering,
   isSelectionMode,
   selected,
@@ -249,6 +251,7 @@ export default function MediaCardOverlay({
             >
               <MediaCardMoreMenu
                 items={moreMenuItems}
+                cardId={cardId}
                 processing={isProcessingOrPending}
                 isOpen={isMoreMenuOpen}
                 onAction={onMoreAction}

--- a/src/components/widgets/media-card/PlaylistCard.tsx
+++ b/src/components/widgets/media-card/PlaylistCard.tsx
@@ -143,7 +143,13 @@ function PlaylistCard(props: PlaylistCardProps) {
                       'hover:scale-125 hover:[&_.material-symbols]:!text-yellow-300'
                     )}
                   >
-                    <MediaCardMoreMenu items={moreMenuItems} processing={processing} onAction={handleMoreAction} onOpenChange={handleMoreMenuOpenChange} />
+                    <MediaCardMoreMenu
+                      items={moreMenuItems}
+                      cardId={cardId}
+                      processing={processing}
+                      onAction={handleMoreAction}
+                      onOpenChange={handleMoreMenuOpenChange}
+                    />
                   </div>
                 )}
               </MediaCardOverlayContainer>

--- a/src/lib/libraryItemUpdatedUtils.ts
+++ b/src/lib/libraryItemUpdatedUtils.ts
@@ -1,6 +1,6 @@
 import { prunePersonalizedShelves } from '@/lib/personalizedShelfUtils'
 import type { LibraryItem, PersonalizedShelf, PlaylistItem, Series } from '@/types/api'
-import { isPodcastMedia } from '@/types/api'
+import { isBookLibraryItem, isPersonalizedSeriesRef, isPodcastMedia } from '@/types/api'
 
 function resolveRecentEpisodeAfterUpdate(existing: LibraryItem, updated: LibraryItem) {
   const recentEpisode = existing.recentEpisode
@@ -14,14 +14,32 @@ function resolveRecentEpisodeAfterUpdate(existing: LibraryItem, updated: Library
   return recentEpisode
 }
 
+function preserveShelfSeriesRef(existing: LibraryItem, updated: LibraryItem): LibraryItem {
+  if (!isBookLibraryItem(existing) || !isBookLibraryItem(updated)) return updated
+  const existingSeries = existing.media.metadata.series
+  if (!existingSeries || !isPersonalizedSeriesRef(existingSeries)) return updated
+
+  return {
+    ...updated,
+    media: {
+      ...updated.media,
+      metadata: {
+        ...updated.media.metadata,
+        series: existingSeries
+      }
+    }
+  }
+}
+
 /** Preserve client-only fields when merging a socket `item_updated` payload. */
 export function mergeLibraryItemUpdate(existing: LibraryItem, updated: LibraryItem): LibraryItem {
-  return {
+  const merged: LibraryItem = {
     ...updated,
     rssFeed: existing.rssFeed,
     mediaItemShare: existing.mediaItemShare,
     recentEpisode: resolveRecentEpisodeAfterUpdate(existing, updated)
   }
+  return preserveShelfSeriesRef(existing, merged)
 }
 
 export function applyLibraryItemUpdateToList(items: LibraryItem[], updatedItem: LibraryItem): LibraryItem[] {


### PR DESCRIPTION
This fixes #105 (again).

The isAdditionalInside predicate was incorrect and included overlay actions on every card. Now it includes only the card itself as it should.

This also fixes #141
- Card no longer infers sequence from metadata.series[]
- For the continue-series shelf cards, item updates preserve server-provided metadata.series (which has a different shape)