### PR TITLE
Schedule automatic podcast downloads

### DIFF
--- a/src/app/(main)/components_catalog/examples/CronExpressionBuilderExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/CronExpressionBuilderExamples.tsx
@@ -117,8 +117,6 @@ export function CronExpressionBuilderExamples() {
               </Code>{' '}
               - the server language, date, and time settings
             </span>
-            <Code className="px-1">className?</Code>
-            <span>classes to merge with the default classes</span>
           </div>
         </div>
       </ComponentInfo>

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
@@ -3,6 +3,7 @@
 import AddToCollectionModal from '@/components/modals/AddToCollectionModal'
 import AddToPlaylistModal from '@/components/modals/AddToPlaylistModal'
 import MatchModal from '@/components/modals/MatchModal'
+import PodcastDownloadScheduleModal from '@/components/modals/PodcastDownloadScheduleModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
 import ShareModal from '@/components/modals/ShareModal'
 import Btn from '@/components/ui/Btn'
@@ -81,12 +82,14 @@ export default function LibraryItemActionButtons({
     processing,
     confirmState,
     rssFeedModalOpen,
+    scheduleModalOpen,
     shareModalOpen,
     collectionsModalOpen,
     playlistsModalOpen,
     mediaItemShare,
     closeConfirm,
     closeRssFeedModal,
+    closeScheduleModal,
     closeShareModal,
     closeCollectionsModal,
     closePlaylistsModal,
@@ -312,6 +315,7 @@ export default function LibraryItemActionButtons({
           hasEpisodesWithoutPubDate: isPodcast && podcastEpisodes.some((ep) => !ep.pubDate)
         }}
       />
+      {isPodcast && <PodcastDownloadScheduleModal isOpen={scheduleModalOpen} onClose={closeScheduleModal} libraryItem={libraryItem as PodcastLibraryItem} />}
       <ShareModal
         isOpen={shareModalOpen}
         onClose={closeShareModal}

--- a/src/app/(main)/settings/backups/BackupScheduleModal.tsx
+++ b/src/app/(main)/settings/backups/BackupScheduleModal.tsx
@@ -39,7 +39,7 @@ export default function BackupScheduleModal({ isOpen, onClose, isPending, cronEx
   return (
     <Modal isOpen={isOpen} onClose={onClose} outerContent={outerContentTitle} className="w-full md:max-w-[700px] lg:max-w-[700px]">
       <div className="flex max-h-[90vh] flex-col">
-        <div className="overflow-y-auto px-4 py-6 sm:px-6">
+        <div className="flex flex-col gap-2 overflow-y-auto px-4 py-6 sm:px-6">
           <CronExpressionBuilder value={cronExpressionValue} onChange={setCronExpressionValue} />
           <CronExpressionPreview cronExpression={cronExpressionValue} />
         </div>

--- a/src/app/(main)/settings/libraries/LibraryScheduleTab.tsx
+++ b/src/app/(main)/settings/libraries/LibraryScheduleTab.tsx
@@ -55,10 +55,10 @@ export default function LibraryScheduleTab({ settings, onSettingsChange }: Libra
       </div>
 
       {enableAutoScan ? (
-        <>
+        <div className="flex flex-col gap-2">
           <CronExpressionBuilder value={cronExpression} onChange={handleCronChange} />
           <CronExpressionPreview cronExpression={cronExpression} isValid={isValid} />
-        </>
+        </div>
       ) : (
         <p className="text-base text-yellow-400">{t('MessageScheduleLibraryScanNote')}</p>
       )}

--- a/src/components/modals/AddToCollectionModal.tsx
+++ b/src/components/modals/AddToCollectionModal.tsx
@@ -54,10 +54,12 @@ export default function AddToCollectionModal({ isOpen, onClose, libraryId, libra
 
   const sortedCollections = useMemo((): CollectionRow[] => {
     return [...collections]
-      .map((collection): CollectionRow => ({
-        ...collection,
-        allBooksIncluded: collectionIncludesAllBooks(collection, libraryItemIds)
-      }))
+      .map(
+        (collection): CollectionRow => ({
+          ...collection,
+          allBooksIncluded: collectionIncludesAllBooks(collection, libraryItemIds)
+        })
+      )
       .sort((a, b) => {
         if (a.allBooksIncluded !== b.allBooksIncluded) {
           return a.allBooksIncluded ? -1 : 1

--- a/src/components/modals/AddToPlaylistModal.tsx
+++ b/src/components/modals/AddToPlaylistModal.tsx
@@ -56,10 +56,12 @@ export default function AddToPlaylistModal({ isOpen, onClose, libraryId, items, 
 
   const sortedPlaylists = useMemo((): PlaylistRow[] => {
     return [...playlists]
-      .map((playlist): PlaylistRow => ({
-        ...playlist,
-        allItemsIncluded: playlistIncludesAllItems(playlist, items)
-      }))
+      .map(
+        (playlist): PlaylistRow => ({
+          ...playlist,
+          allItemsIncluded: playlistIncludesAllItems(playlist, items)
+        })
+      )
       .sort((a, b) => {
         if (a.allItemsIncluded !== b.allItemsIncluded) {
           return a.allItemsIncluded ? -1 : 1

--- a/src/components/modals/PodcastDownloadScheduleModal.tsx
+++ b/src/components/modals/PodcastDownloadScheduleModal.tsx
@@ -230,7 +230,7 @@ export default function PodcastDownloadScheduleModal({ isOpen, onClose, libraryI
               )}
               {showScheduleForm && (
                 <Btn disabled={!isUpdated || !cronIsValid || isProcessing} loading={isSaving} onClick={handleSave}>
-                  {t('ButtonSave')}
+                  {savedAutoDownloadEpisodes ? t('ButtonSave') : t('ButtonEnable')}
                 </Btn>
               )}
             </div>

--- a/src/components/modals/PodcastDownloadScheduleModal.tsx
+++ b/src/components/modals/PodcastDownloadScheduleModal.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { updateLibraryItemMediaAction } from '@/app/actions/mediaActions'
+import Modal from '@/components/modals/Modal'
+import Btn from '@/components/ui/Btn'
+import HelpTooltipIcon from '@/components/ui/HelpTooltipIcon'
+import TextInput from '@/components/ui/TextInput'
+import Alert from '@/components/widgets/Alert'
+import CronExpressionBuilder from '@/components/widgets/CronExpressionBuilder'
+import CronExpressionPreview from '@/components/widgets/CronExpressionPreview'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { isPodcastLibraryItem, type PodcastLibraryItem } from '@/types/api'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+interface PodcastDownloadScheduleModalProps {
+  isOpen: boolean
+  onClose: () => void
+  libraryItem: PodcastLibraryItem
+}
+
+function clampNonNegativeInt(value: string) {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) return 0
+  return parsed
+}
+
+const DEFAULT_DAILY_CRON = '0 0 * * *'
+
+function getScheduleCronExpression(libraryItem: PodcastLibraryItem) {
+  const savedSchedule = libraryItem.media.autoDownloadSchedule
+  const isEnabled = libraryItem.media.autoDownloadEpisodes ?? false
+  if (isEnabled && savedSchedule) return savedSchedule
+  return DEFAULT_DAILY_CRON
+}
+
+interface ScheduleLimitFieldProps {
+  value: string
+  onChange: (value: string) => void
+  label: string
+  helpText: string
+  disabled: boolean
+}
+
+function ScheduleLimitField({ value, onChange, label, helpText, disabled }: ScheduleLimitFieldProps) {
+  return (
+    <div className="flex items-center gap-x-4 py-1">
+      <TextInput
+        value={value}
+        onChange={onChange}
+        type="number"
+        min={0}
+        disabled={disabled}
+        size="small"
+        customInputClass="no-spinner text-center"
+        className="w-12 shrink-0"
+      />
+      <p className="min-w-0 flex-1 text-base leading-snug">
+        {label}
+        {'\u00A0'}
+        <HelpTooltipIcon text={helpText} />
+      </p>
+    </div>
+  )
+}
+
+export default function PodcastDownloadScheduleModal({ isOpen, onClose, libraryItem }: PodcastDownloadScheduleModalProps) {
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+
+  const [cronExpression, setCronExpression] = useState(() => getScheduleCronExpression(libraryItem))
+  const [cronIsValid, setCronIsValid] = useState(true)
+  const [maxEpisodesToKeep, setMaxEpisodesToKeep] = useState('')
+  const [maxNewEpisodesToDownload, setMaxNewEpisodesToDownload] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+  const [isDisabling, setIsDisabling] = useState(false)
+
+  const feedUrl = libraryItem.media.metadata.feedUrl ?? ''
+  const savedAutoDownloadEpisodes = libraryItem.media.autoDownloadEpisodes ?? false
+  const savedAutoDownloadSchedule = libraryItem.media.autoDownloadSchedule ?? ''
+  const savedMaxEpisodesToKeep = libraryItem.media.maxEpisodesToKeep ?? 0
+  const savedMaxNewEpisodesToDownload = libraryItem.media.maxNewEpisodesToDownload ?? 0
+
+  const showScheduleForm = !!feedUrl
+  const showDisableOnly = !feedUrl && savedAutoDownloadEpisodes
+
+  const initForm = useCallback(() => {
+    setCronExpression(getScheduleCronExpression(libraryItem))
+    setCronIsValid(true)
+    setMaxEpisodesToKeep(String(savedMaxEpisodesToKeep))
+    setMaxNewEpisodesToDownload(String(savedMaxNewEpisodesToDownload))
+  }, [libraryItem, savedMaxEpisodesToKeep, savedMaxNewEpisodesToDownload])
+
+  useEffect(() => {
+    if (!isOpen) return
+    initForm()
+  }, [initForm, isOpen])
+
+  const handleCronChange = useCallback((value: string, isValid: boolean) => {
+    setCronExpression(value)
+    setCronIsValid(isValid)
+  }, [])
+
+  const parsedMaxEpisodesToKeep = useMemo(() => clampNonNegativeInt(maxEpisodesToKeep), [maxEpisodesToKeep])
+  const parsedMaxNewEpisodesToDownload = useMemo(() => clampNonNegativeInt(maxNewEpisodesToDownload), [maxNewEpisodesToDownload])
+
+  const resolvedSavedSchedule = savedAutoDownloadSchedule || DEFAULT_DAILY_CRON
+
+  const isUpdated = useMemo(() => {
+    if (!showScheduleForm) return false
+
+    return (
+      !savedAutoDownloadEpisodes ||
+      resolvedSavedSchedule !== cronExpression ||
+      savedMaxEpisodesToKeep !== parsedMaxEpisodesToKeep ||
+      savedMaxNewEpisodesToDownload !== parsedMaxNewEpisodesToDownload
+    )
+  }, [
+    cronExpression,
+    parsedMaxEpisodesToKeep,
+    parsedMaxNewEpisodesToDownload,
+    resolvedSavedSchedule,
+    savedAutoDownloadEpisodes,
+    savedMaxEpisodesToKeep,
+    savedMaxNewEpisodesToDownload,
+    showScheduleForm
+  ])
+
+  const handleSave = useCallback(async () => {
+    if (!isPodcastLibraryItem(libraryItem) || !showScheduleForm || isSaving || isDisabling || !isUpdated || !cronIsValid) return
+
+    setIsSaving(true)
+    try {
+      await updateLibraryItemMediaAction(libraryItem.id, {
+        autoDownloadEpisodes: true,
+        autoDownloadSchedule: cronExpression,
+        maxEpisodesToKeep: parsedMaxEpisodesToKeep,
+        maxNewEpisodesToDownload: parsedMaxNewEpisodesToDownload
+      })
+      showToast(t('ToastItemDetailsUpdateSuccess'), { type: 'success' })
+      onClose()
+    } catch (error) {
+      console.error('Failed to update podcast download schedule', error)
+      showToast(t('ToastFailedToUpdate'), { type: 'error' })
+    } finally {
+      setIsSaving(false)
+    }
+  }, [
+    cronExpression,
+    cronIsValid,
+    isDisabling,
+    isSaving,
+    isUpdated,
+    libraryItem,
+    onClose,
+    parsedMaxEpisodesToKeep,
+    parsedMaxNewEpisodesToDownload,
+    showScheduleForm,
+    showToast,
+    t
+  ])
+
+  const handleDisable = useCallback(async () => {
+    if (!isPodcastLibraryItem(libraryItem) || !savedAutoDownloadEpisodes || isSaving || isDisabling) return
+
+    setIsDisabling(true)
+    try {
+      await updateLibraryItemMediaAction(libraryItem.id, {
+        autoDownloadEpisodes: false
+      })
+      showToast(t('ToastItemDetailsUpdateSuccess'), { type: 'success' })
+      onClose()
+    } catch (error) {
+      console.error('Failed to disable podcast download schedule', error)
+      showToast(t('ToastFailedToUpdate'), { type: 'error' })
+    } finally {
+      setIsDisabling(false)
+    }
+  }, [isDisabling, isSaving, libraryItem, onClose, savedAutoDownloadEpisodes, showToast, t])
+
+  const isProcessing = isSaving || isDisabling
+
+  const outerContentTitle = (
+    <div className="absolute start-0 top-0 p-4">
+      <h2 className="text-xl text-white">{t('HeaderScheduleEpisodeDownloads')}</h2>
+    </div>
+  )
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} processing={isProcessing} outerContent={outerContentTitle} className="w-full md:max-w-[700px] lg:max-w-[700px]">
+      <div className="flex max-h-[90vh] flex-col">
+        <div className="overflow-y-auto px-4 py-6 sm:px-6">
+          {!feedUrl && (
+            <Alert type="warning" className="mb-4">
+              {t('ToastPodcastNoRssFeed')}
+            </Alert>
+          )}
+
+          {showScheduleForm && (
+            <div className="flex flex-col gap-3">
+              <ScheduleLimitField
+                value={maxEpisodesToKeep}
+                onChange={setMaxEpisodesToKeep}
+                label={t('LabelMaxEpisodesToKeep')}
+                helpText={t('LabelMaxEpisodesToKeepHelp')}
+                disabled={isProcessing}
+              />
+
+              <ScheduleLimitField
+                value={maxNewEpisodesToDownload}
+                onChange={setMaxNewEpisodesToDownload}
+                label={t('LabelMaxEpisodesToDownloadPerCheck')}
+                helpText={t('LabelUseZeroForUnlimited')}
+                disabled={isProcessing}
+              />
+
+              <CronExpressionBuilder key={`${libraryItem.id}-${isOpen}`} value={cronExpression} onChange={handleCronChange} />
+              <CronExpressionPreview cronExpression={cronExpression} isValid={cronIsValid} />
+            </div>
+          )}
+        </div>
+
+        {(showScheduleForm || showDisableOnly) && (
+          <div className="border-border border-t px-4 py-3">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-end">
+              {savedAutoDownloadEpisodes && (
+                <Btn color="bg-error" disabled={isProcessing} loading={isDisabling} onClick={handleDisable} className="sm:me-auto">
+                  {t('ButtonDisableAutoDownloadEpisodes')}
+                </Btn>
+              )}
+              {showScheduleForm && (
+                <Btn disabled={!isUpdated || !cronIsValid || isProcessing} loading={isSaving} onClick={handleSave}>
+                  {t('ButtonSave')}
+                </Btn>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/widgets/Alert.tsx
+++ b/src/components/widgets/Alert.tsx
@@ -41,7 +41,7 @@ export default function Alert({ type = 'error', autoFocus = true, children, clas
             ? 'bg-info/5 border-info/60 text-info'
             : 'bg-primary/5 border-primary/60 text-primary'
 
-  const wrapperClass = mergeClasses('w-full border rounded-lg flex items-center relative py-4 ps-16', typeClasses, className)
+  const wrapperClass = mergeClasses('w-full border rounded-lg flex items-center relative py-4 ps-16 pe-4', typeClasses, className)
 
   useEffect(() => {
     if (isAlert && alertRef.current && autoFocus) {

--- a/src/components/widgets/CoverEdit.tsx
+++ b/src/components/widgets/CoverEdit.tsx
@@ -79,10 +79,12 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
     const libraryFiles = (libraryItem.libraryFiles || []) as LibraryFile[]
     return libraryFiles
       .filter((f) => f.fileType === 'image')
-      .map((file): LocalCover => ({
-        ...file,
-        localPath: getLibraryFileUrl(libraryItem.id, file.ino, libraryItem.updatedAt)
-      }))
+      .map(
+        (file): LocalCover => ({
+          ...file,
+          localPath: getLibraryFileUrl(libraryItem.id, file.ino, libraryItem.updatedAt)
+        })
+      )
   }, [libraryItem.libraryFiles, libraryItem.id, libraryItem.updatedAt])
 
   const userCanUpload = user.permissions?.upload || false

--- a/src/components/widgets/CronExpressionBuilder.tsx
+++ b/src/components/widgets/CronExpressionBuilder.tsx
@@ -163,7 +163,7 @@ export default function CronExpressionBuilder({ value, onChange, options: { lang
   }, [clientTimeZone, timeZone, language])
 
   return (
-    <div className="w-full py-2" cy-id="cron-expression-builder">
+    <div className="w-full" cy-id="cron-expression-builder">
       <div style={{ minHeight: '172px' }}>
         <Dropdown
           value={selectedInterval}

--- a/src/components/widgets/CronExpressionBuilder.tsx
+++ b/src/components/widgets/CronExpressionBuilder.tsx
@@ -4,8 +4,9 @@ import Dropdown from '@/components/ui/Dropdown'
 import type { MultiSelectItem } from '@/components/ui/MultiSelect'
 import { MultiSelect } from '@/components/ui/MultiSelect'
 import TextInput from '@/components/ui/TextInput'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { getLocalizedServerTimeZone, validateCron, type FormatDateOptions, type ValidationResult } from '@/lib/cron'
+import { getCronExpressionOptions, getLocalizedServerTimeZone, validateCron, type FormatDateOptions, type ValidationResult } from '@/lib/cron'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 interface CronExpressionBuilderProps {
@@ -14,8 +15,10 @@ interface CronExpressionBuilderProps {
   options?: FormatDateOptions
 }
 
-export default function CronExpressionBuilder({ value, onChange, options: { language, timeZone } = {} }: CronExpressionBuilderProps) {
+export default function CronExpressionBuilder({ value, onChange, options }: CronExpressionBuilderProps) {
   const t = useTypeSafeTranslations()
+  const { serverSettings } = useUser()
+  const { language, timeZone } = useMemo(() => options ?? getCronExpressionOptions(serverSettings), [options, serverSettings])
   const [selectedInterval, setSelectedInterval] = useState<string>('daily')
   const [customCronError, setCustomCronError] = useState<string>('')
 

--- a/src/components/widgets/CronExpressionPreview.tsx
+++ b/src/components/widgets/CronExpressionPreview.tsx
@@ -2,13 +2,11 @@
 
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { calculateNextRunDate, getHumanReadableCronExpression, validateCron } from '@/lib/cron'
-import { mergeClasses } from '@/lib/merge-classes'
 import { capitalizeFirstLetter } from '@/lib/string'
 import { useEffect, useMemo, useState } from 'react'
 
 interface CronExpressionPreviewProps {
   cronExpression: string
-  className?: string
   isValid?: boolean
   options?: {
     language?: string
@@ -18,7 +16,7 @@ interface CronExpressionPreviewProps {
   }
 }
 
-export default function CronExpressionPreview({ cronExpression, className, isValid: isValidProp, options }: CronExpressionPreviewProps) {
+export default function CronExpressionPreview({ cronExpression, isValid: isValidProp, options }: CronExpressionPreviewProps) {
   const t = useTypeSafeTranslations()
   const [clientTimeZone, setClientTimeZone] = useState<string | null>(null)
 
@@ -39,22 +37,20 @@ export default function CronExpressionPreview({ cronExpression, className, isVal
   }
 
   return (
-    <div className={mergeClasses('p-1', className)}>
-      <div className="grid grid-cols-1 gap-x-2 gap-y-1 sm:grid-cols-[auto_1fr] sm:gap-y-2">
-        <div className="flex items-center">
-          <span className="material-symbols text-foreground mr-2">schedule</span>
-          <p className="text-foreground font-medium">{t('LabelSchedule')}:</p>
-        </div>
-        <p className="text-foreground" cy-id="cron-description">
-          {verbalDescription}
-        </p>
-
-        <div className="mt-2 flex items-center sm:mt-0">
-          <span className="material-symbols text-foreground mr-2">event</span>
-          <p className="text-foreground font-medium">{t('LabelNextRun')}:</p>
-        </div>
-        <p className="text-foreground">{nextRunDate || t('LabelNotAvailable')}</p>
+    <div className="grid grid-cols-1 gap-x-2 gap-y-1 sm:grid-cols-[auto_1fr] sm:gap-y-2">
+      <div className="flex items-center">
+        <span className="material-symbols text-foreground mr-2">schedule</span>
+        <p className="text-foreground font-medium">{t('LabelSchedule')}:</p>
       </div>
+      <p className="text-foreground" cy-id="cron-description">
+        {verbalDescription}
+      </p>
+
+      <div className="mt-2 flex items-center sm:mt-0">
+        <span className="material-symbols text-foreground mr-2">event</span>
+        <p className="text-foreground font-medium">{t('LabelNextRun')}:</p>
+      </div>
+      <p className="text-foreground">{nextRunDate || t('LabelNotAvailable')}</p>
     </div>
   )
 }

--- a/src/components/widgets/CronExpressionPreview.tsx
+++ b/src/components/widgets/CronExpressionPreview.tsx
@@ -17,7 +17,7 @@ export default function CronExpressionPreview({ cronExpression, isValid: isValid
   const { serverSettings } = useUser()
   const resolvedOptions = useMemo(() => options ?? getCronExpressionOptions(serverSettings), [options, serverSettings])
   const [clientTimeZone, setClientTimeZone] = useState<string | null>(null)
-  console.log('resolvedOptions', resolvedOptions)
+
   useEffect(() => {
     setClientTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
   }, [])

--- a/src/components/widgets/CronExpressionPreview.tsx
+++ b/src/components/widgets/CronExpressionPreview.tsx
@@ -1,36 +1,34 @@
 'use client'
 
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { calculateNextRunDate, getHumanReadableCronExpression, validateCron } from '@/lib/cron'
+import { calculateNextRunDate, getCronExpressionOptions, getHumanReadableCronExpression, validateCron, type FormatDateOptions } from '@/lib/cron'
 import { capitalizeFirstLetter } from '@/lib/string'
 import { useEffect, useMemo, useState } from 'react'
 
 interface CronExpressionPreviewProps {
   cronExpression: string
   isValid?: boolean
-  options?: {
-    language?: string
-    dateFormat?: string
-    timeFormat?: string
-    timeZone?: string
-  }
+  options?: FormatDateOptions
 }
 
 export default function CronExpressionPreview({ cronExpression, isValid: isValidProp, options }: CronExpressionPreviewProps) {
   const t = useTypeSafeTranslations()
+  const { serverSettings } = useUser()
+  const resolvedOptions = useMemo(() => options ?? getCronExpressionOptions(serverSettings), [options, serverSettings])
   const [clientTimeZone, setClientTimeZone] = useState<string | null>(null)
-
+  console.log('resolvedOptions', resolvedOptions)
   useEffect(() => {
     setClientTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone)
   }, [])
 
   const { isValid, verbalDescription, nextRunDate } = useMemo(() => {
     const isValid = isValidProp !== undefined ? isValidProp : validateCron(cronExpression).isValid
-    const verbalDescription = isValid ? getHumanReadableCronExpression(cronExpression, options?.language || 'en') : ''
-    const nextRunDate = isValid ? capitalizeFirstLetter(calculateNextRunDate(cronExpression, options, clientTimeZone)) : ''
+    const verbalDescription = isValid ? getHumanReadableCronExpression(cronExpression, resolvedOptions.language || 'en') : ''
+    const nextRunDate = isValid ? capitalizeFirstLetter(calculateNextRunDate(cronExpression, resolvedOptions, clientTimeZone)) : ''
 
     return { isValid, verbalDescription, nextRunDate }
-  }, [cronExpression, isValidProp, options, clientTimeZone])
+  }, [cronExpression, isValidProp, resolvedOptions, clientTimeZone])
 
   if (!isValid || !cronExpression) {
     return null

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -8,6 +8,7 @@ import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
 import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
 import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
 import MatchModal from '@/components/modals/MatchModal'
+import PodcastDownloadScheduleModal from '@/components/modals/PodcastDownloadScheduleModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
 import ShareModal from '@/components/modals/ShareModal'
 import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
@@ -367,12 +368,14 @@ function MediaCard(props: MediaCardProps) {
     isPending,
     confirmState,
     rssFeedModalOpen,
+    scheduleModalOpen,
     shareModalOpen,
     collectionsModalOpen,
     playlistsModalOpen,
     mediaItemShare,
     closeConfirm,
     closeRssFeedModal,
+    closeScheduleModal,
     closeShareModal,
     closeCollectionsModal,
     closePlaylistsModal,
@@ -647,6 +650,7 @@ function MediaCard(props: MediaCardProps) {
           }}
         />
       )}
+      {isPodcast && scheduleModalOpen && <PodcastDownloadScheduleModal isOpen={scheduleModalOpen} onClose={closeScheduleModal} libraryItem={libraryItem} />}
       {shareModalOpen && (
         <ShareModal
           isOpen={shareModalOpen}

--- a/src/components/widgets/media-card/useMediaCardActions.ts
+++ b/src/components/widgets/media-card/useMediaCardActions.ts
@@ -104,6 +104,7 @@ export function useMediaCardActions({
   const [isPending, startTransition] = useTransition()
   const [confirmState, setConfirmState] = useState<ConfirmState | null>(null)
   const [rssFeedModalOpen, setRssFeedModalOpen] = useState(false)
+  const [scheduleModalOpen, setScheduleModalOpen] = useState(false)
   const [shareModalOpen, setShareModalOpen] = useState(false)
   const [collectionsModalOpen, setCollectionsModalOpen] = useState(false)
   const [playlistsModalOpen, setPlaylistsModalOpen] = useState(false)
@@ -247,6 +248,8 @@ export function useMediaCardActions({
         setShareModalOpen(true)
       } else if (action === 'openRssFeed') {
         setRssFeedModalOpen(true)
+      } else if (action === 'openSchedule') {
+        setScheduleModalOpen(true)
       } else if (action === 'showMatchModal') {
         onOpenMatch?.()
       } else if (action === 'downloadEpisode') {
@@ -622,6 +625,13 @@ export function useMediaCardActions({
       })
     }
 
+    if (userIsAdminOrUp && isPodcast && !episodeForQueue) {
+      items.push({
+        text: t('HeaderSchedule'),
+        func: 'openSchedule'
+      })
+    }
+
     if (userCanDownload) {
       items.push({
         text: t('LabelDownload'),
@@ -686,6 +696,10 @@ export function useMediaCardActions({
     setRssFeedModalOpen(false)
   }, [])
 
+  const closeScheduleModal = useCallback(() => {
+    setScheduleModalOpen(false)
+  }, [])
+
   const closeShareModal = useCallback(() => {
     setShareModalOpen(false)
   }, [])
@@ -711,12 +725,14 @@ export function useMediaCardActions({
     isPending,
     confirmState,
     rssFeedModalOpen,
+    scheduleModalOpen,
     shareModalOpen,
     collectionsModalOpen,
     playlistsModalOpen,
     mediaItemShare,
     closeConfirm,
     closeRssFeedModal,
+    closeScheduleModal,
     closeShareModal,
     closeCollectionsModal,
     closePlaylistsModal,

--- a/src/hooks/useAppBarBatchActions.ts
+++ b/src/hooks/useAppBarBatchActions.ts
@@ -22,7 +22,16 @@ import { usePathname, useRouter } from 'next/navigation'
 import { createElement, useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
 export type AppBarBatchActionId =
-  'play' | 'toggle-finished' | 'add-to-collection' | 'add-to-playlist' | 'batch-edit' | 'delete' | 'quick-match' | 'quick-embed' | 'rescan' | 'download'
+  | 'play'
+  | 'toggle-finished'
+  | 'add-to-collection'
+  | 'add-to-playlist'
+  | 'batch-edit'
+  | 'delete'
+  | 'quick-match'
+  | 'quick-embed'
+  | 'rescan'
+  | 'download'
 
 interface UseAppBarBatchActionsParams {
   selectedItems: readonly SelectedMediaItem[]

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -1,3 +1,4 @@
+import type { ServerSettings } from '@/types/api'
 import cronstrue from 'cronstrue/i18n'
 
 export interface ValidationResult {
@@ -10,6 +11,15 @@ export interface FormatDateOptions {
   dateFormat?: string
   timeFormat?: string
   timeZone?: string
+}
+
+export function getCronExpressionOptions(serverSettings: Pick<ServerSettings, 'language' | 'dateFormat' | 'timeFormat' | 'timeZone'>): FormatDateOptions {
+  return {
+    language: serverSettings.language,
+    dateFormat: serverSettings.dateFormat,
+    timeFormat: serverSettings.timeFormat,
+    timeZone: serverSettings.timeZone
+  }
 }
 
 // Helper function to validate individual cron fields

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -37,6 +37,7 @@
   "ButtonCreateBackup": "Create Backup",
   "ButtonDelete": "Delete",
   "ButtonDeselect": "Deselect",
+  "ButtonDisableAutoDownloadEpisodes": "Disable automatic downloads",
   "ButtonDownloadQueue": "Queue",
   "ButtonEdit": "Edit",
   "ButtonEditChapters": "Edit Chapters",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1415,6 +1415,10 @@ export interface UpdateLibraryItemMediaPayload {
   }
   tags?: string[]
   url?: string
+  autoDownloadEpisodes?: boolean
+  autoDownloadSchedule?: string
+  maxEpisodesToKeep?: number
+  maxNewEpisodesToDownload?: number
 }
 
 export interface UpdateLibraryItemMediaResponse {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -117,6 +117,8 @@ export interface ServerSettings {
   dateFormat: string
   timeFormat: string
   language: string
+  /** IANA timezone of the Audiobookshelf server host (runtime value, not user-configurable) */
+  timeZone?: string
   allowedOrigins: string[]
 
   // System info


### PR DESCRIPTION
This migrates what used to be the **Schedule** tab for podcasts. In React this is added as a separate modal, wired as a podcast context menu item.

### Notable changes from Vue
- Enable flow: Vue uses an **Enable** checkbox that gates form fields; React treats **Save** as enable and adds a separate **Disable automatic downloads** button when already enabled
- Save payload: always sends `autoDownloadEpisodes: true`, `autoDownloadSchedule`, and both limit fields via `updateLibraryItemMediaAction`
- Disable payload: `{ autoDownloadEpisodes: false }` only
- Default cron: `0 0 * * *` when not enabled or no saved schedule
- Cron UI: `CronExpressionBuilder` + separate `CronExpressionPreview` (Vue embeds preview in the builder)
- No RSS feed: 
  - show warning alert when `feedUrl` doesn't exist
  - disable on footer when enabled but feed is missing