### PR TITLE
Mobile library side rail & AppBar polish

### DIFF
--- a/cypress/tests/components/app/AppBarNav.cy.tsx
+++ b/cypress/tests/components/app/AppBarNav.cy.tsx
@@ -1,0 +1,85 @@
+import AppBarNav from '@/app/(main)/AppBarNav'
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import * as navigation from 'next/navigation'
+import { ReactNode } from 'react'
+
+function mountAppBarNav(props: { userCanUpload?: boolean; isAdmin?: boolean; username?: string } = {}, options?: { alignEnd?: boolean }) {
+  const router = {
+    back: cy.stub(),
+    forward: cy.stub(),
+    refresh: cy.stub(),
+    push: cy.stub(),
+    replace: cy.stub(),
+    prefetch: cy.stub()
+  } as AppRouterInstance
+
+  cy.stub(navigation, 'useRouter').callsFake(() => router)
+
+  const appBarNav = <AppBarNav username={props.username ?? 'testuser'} isAdmin={props.isAdmin ?? false} userCanUpload={props.userCanUpload ?? false} />
+
+  const ui: ReactNode = (
+    <AppRouterContext.Provider value={router}>{options?.alignEnd ? <div className="absolute end-0">{appBarNav}</div> : appBarNav}</AppRouterContext.Provider>
+  )
+
+  cy.mount(ui)
+
+  return router
+}
+
+describe('<AppBarNav /> desktop keyboard navigation', () => {
+  beforeEach(() => {
+    cy.viewport(1024, 768)
+  })
+
+  it('opens the menu with Enter on the desktop username button', () => {
+    mountAppBarNav()
+    cy.get('button[aria-haspopup="menu"]').focus()
+    cy.get('button[aria-haspopup="menu"]').type('{enter}')
+    cy.get('[role="menu"]').should('be.visible')
+  })
+
+  it('moves focus between menu items with arrow keys', () => {
+    mountAppBarNav()
+    cy.get('button[aria-haspopup="menu"]').focus().type('{enter}')
+    cy.get('[role="menuitem"]').eq(0).should('have.focus')
+    cy.focused().type('{downarrow}')
+    cy.get('[role="menuitem"]').eq(1).should('have.focus')
+    cy.focused().type('{uparrow}')
+    cy.get('[role="menuitem"]').eq(0).should('have.focus')
+  })
+
+  it('closes the menu with Escape and returns focus to the trigger', () => {
+    mountAppBarNav()
+    cy.get('button[aria-haspopup="menu"]').focus().type('{enter}')
+    cy.get('[role="menu"]').should('be.visible')
+    cy.focused().type('{esc}')
+    cy.get('[role="menu"]').should('not.exist')
+    cy.get('button[aria-haspopup="menu"]').should('have.focus')
+  })
+
+  it('jumps to the first and last items with Home and End', () => {
+    mountAppBarNav()
+    cy.get('button[aria-haspopup="menu"]').focus().type('{enter}')
+    cy.focused().type('{end}')
+    cy.get('[role="menuitem"]').last().should('have.focus')
+    cy.focused().type('{home}')
+    cy.get('[role="menuitem"]').first().should('have.focus')
+  })
+
+  it('excludes mobile-only items from the desktop menu', () => {
+    mountAppBarNav({ isAdmin: true, userCanUpload: true })
+    cy.get('button[aria-haspopup="menu"]').click()
+    cy.get('[role="menuitem"]').should('have.length', 4)
+    cy.get('[role="menu"]').should('not.contain.text', 'Settings')
+    cy.get('[role="menu"]').should('not.contain.text', 'Upload')
+  })
+
+  it('closes the menu when clicking outside', () => {
+    mountAppBarNav({}, { alignEnd: true })
+    cy.get('button[aria-haspopup="menu"]').click()
+    cy.get('[role="menu"]').should('be.visible')
+    cy.get('html').click({ force: true })
+    cy.get('[role="menu"]').should('not.exist')
+  })
+})

--- a/cypress/tests/components/app/AppBarNav.cy.tsx
+++ b/cypress/tests/components/app/AppBarNav.cy.tsx
@@ -32,44 +32,49 @@ describe('<AppBarNav /> desktop keyboard navigation', () => {
     cy.viewport(1024, 768)
   })
 
+  const desktopMenuTrigger = () => cy.get('button[aria-haspopup="menu"]')
+
   it('opens the menu with Enter on the desktop username button', () => {
     mountAppBarNav()
-    cy.get('button[aria-haspopup="menu"]').focus()
-    cy.get('button[aria-haspopup="menu"]').type('{enter}')
+    desktopMenuTrigger().focus()
+    desktopMenuTrigger().type('{enter}')
     cy.get('[role="menu"]').should('be.visible')
   })
 
-  it('moves focus between menu items with arrow keys', () => {
+  it('highlights menu items with arrow keys while focus stays on the trigger', () => {
     mountAppBarNav()
-    cy.get('button[aria-haspopup="menu"]').focus().type('{enter}')
-    cy.get('[role="menuitem"]').eq(0).should('have.focus')
-    cy.focused().type('{downarrow}')
-    cy.get('[role="menuitem"]').eq(1).should('have.focus')
-    cy.focused().type('{uparrow}')
-    cy.get('[role="menuitem"]').eq(0).should('have.focus')
+    desktopMenuTrigger().focus().type('{enter}')
+    desktopMenuTrigger().should('have.focus')
+    cy.get('[role="menuitem"]').eq(0).should('have.class', 'bg-dropdown-item-selected')
+    desktopMenuTrigger().type('{downarrow}')
+    cy.get('[role="menuitem"]').eq(1).should('have.class', 'bg-dropdown-item-selected')
+    desktopMenuTrigger().should('have.focus')
+    desktopMenuTrigger().type('{uparrow}')
+    cy.get('[role="menuitem"]').eq(0).should('have.class', 'bg-dropdown-item-selected')
   })
 
   it('closes the menu with Escape and returns focus to the trigger', () => {
     mountAppBarNav()
-    cy.get('button[aria-haspopup="menu"]').focus().type('{enter}')
+    desktopMenuTrigger().focus().type('{enter}')
     cy.get('[role="menu"]').should('be.visible')
-    cy.focused().type('{esc}')
+    desktopMenuTrigger().type('{esc}')
     cy.get('[role="menu"]').should('not.exist')
-    cy.get('button[aria-haspopup="menu"]').should('have.focus')
+    desktopMenuTrigger().should('have.focus')
   })
 
   it('jumps to the first and last items with Home and End', () => {
     mountAppBarNav()
-    cy.get('button[aria-haspopup="menu"]').focus().type('{enter}')
-    cy.focused().type('{end}')
-    cy.get('[role="menuitem"]').last().should('have.focus')
-    cy.focused().type('{home}')
-    cy.get('[role="menuitem"]').first().should('have.focus')
+    desktopMenuTrigger().focus().type('{enter}')
+    desktopMenuTrigger().type('{end}')
+    cy.get('[role="menuitem"]').last().should('have.class', 'bg-dropdown-item-selected')
+    desktopMenuTrigger().type('{home}')
+    cy.get('[role="menuitem"]').first().should('have.class', 'bg-dropdown-item-selected')
+    desktopMenuTrigger().should('have.focus')
   })
 
   it('excludes mobile-only items from the desktop menu', () => {
     mountAppBarNav({ isAdmin: true, userCanUpload: true })
-    cy.get('button[aria-haspopup="menu"]').click()
+    desktopMenuTrigger().click()
     cy.get('[role="menuitem"]').should('have.length', 4)
     cy.get('[role="menu"]').should('not.contain.text', 'Settings')
     cy.get('[role="menu"]').should('not.contain.text', 'Upload')
@@ -77,9 +82,26 @@ describe('<AppBarNav /> desktop keyboard navigation', () => {
 
   it('closes the menu when clicking outside', () => {
     mountAppBarNav({}, { alignEnd: true })
-    cy.get('button[aria-haspopup="menu"]').click()
+    desktopMenuTrigger().click()
     cy.get('[role="menu"]').should('be.visible')
     cy.get('html').click({ force: true })
     cy.get('[role="menu"]').should('not.exist')
+  })
+
+  it('closes the menu on Tab without moving focus to the document start', () => {
+    mountAppBarNav()
+    cy.document().then((doc) => {
+      const sentinel = doc.createElement('button')
+      sentinel.textContent = 'after menu'
+      sentinel.id = 'tab-sentinel-after'
+      doc.body.appendChild(sentinel)
+    })
+    desktopMenuTrigger().focus().type('{enter}')
+    cy.realPress('Tab')
+    cy.get('[role="menu"]').should('not.exist')
+    cy.get('#tab-sentinel-after').should('have.focus')
+    cy.document().then((doc) => {
+      doc.getElementById('tab-sentinel-after')?.remove()
+    })
   })
 })

--- a/cypress/tests/components/app/LibrariesDropdown.cy.tsx
+++ b/cypress/tests/components/app/LibrariesDropdown.cy.tsx
@@ -52,13 +52,13 @@ describe('<LibrariesDropdown />', () => {
     cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
   })
 
-  it('renders library icons in the menu list', () => {
+  it('renders other libraries in the menu list but not the selected library', () => {
     mountLibrariesDropdown(<LibrariesDropdown libraries={mockLibraries} currentLibraryId="lib-books" />)
     cy.get('button').click()
-    cy.get('[role="listbox"] > li').eq(0).find('[cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
-    cy.get('[role="listbox"] > li').eq(0).should('contain.text', 'Audiobooks')
-    cy.get('[role="listbox"] > li').eq(1).find('[cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
-    cy.get('[role="listbox"] > li').eq(1).should('contain.text', 'Podcasts')
+    cy.get('[role="listbox"] > li').should('have.length', 1)
+    cy.get('[role="listbox"] > li').eq(0).find('[cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
+    cy.get('[role="listbox"] > li').eq(0).should('contain.text', 'Podcasts')
+    cy.get('[role="listbox"]').should('not.contain.text', 'Audiobooks')
   })
 
   it('shows the selected podcast library icon when that library is active', () => {

--- a/cypress/tests/components/app/LibrariesDropdown.cy.tsx
+++ b/cypress/tests/components/app/LibrariesDropdown.cy.tsx
@@ -66,4 +66,37 @@ describe('<LibrariesDropdown />', () => {
     cy.get('button').should('contain.text', 'Podcasts')
     cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
   })
+
+  it('sizes the button to the longest library name when a shorter library is selected', () => {
+    const libraries: Library[] = [
+      {
+        id: 'lib-short',
+        name: 'Test',
+        displayOrder: 1,
+        icon: 'database',
+        mediaType: 'book',
+        createdAt: 0,
+        updatedAt: 0
+      },
+      {
+        id: 'lib-long',
+        name: 'Audiobookshelf Collection',
+        displayOrder: 2,
+        icon: 'books-1',
+        mediaType: 'book',
+        createdAt: 0,
+        updatedAt: 0
+      }
+    ]
+
+    mountLibrariesDropdown(<LibrariesDropdown libraries={libraries} currentLibraryId="lib-short" />)
+    cy.get('button').click()
+    cy.get('[role="listbox"] > li')
+      .eq(0)
+      .invoke('outerWidth')
+      .then((menuItemWidth) => {
+        cy.get('button').invoke('outerWidth').should('be.gte', menuItemWidth)
+      })
+    cy.get('[role="listbox"] > li').eq(0).should('contain.text', 'Audiobookshelf Collection')
+  })
 })

--- a/cypress/tests/components/app/LibrariesDropdown.cy.tsx
+++ b/cypress/tests/components/app/LibrariesDropdown.cy.tsx
@@ -1,0 +1,69 @@
+import LibrariesDropdown from '@/app/(main)/LibrariesDropdown'
+import { Library } from '@/types/api'
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import * as navigation from 'next/navigation'
+import { ReactNode } from 'react'
+
+const mockLibraries: Library[] = [
+  {
+    id: 'lib-books',
+    name: 'Audiobooks',
+    displayOrder: 1,
+    icon: 'books-1',
+    mediaType: 'book',
+    createdAt: 0,
+    updatedAt: 0
+  },
+  {
+    id: 'lib-podcasts',
+    name: 'Podcasts',
+    displayOrder: 2,
+    icon: 'podcast',
+    mediaType: 'podcast',
+    createdAt: 0,
+    updatedAt: 0
+  }
+]
+
+function mountLibrariesDropdown(ui: ReactNode) {
+  const router = {
+    back: cy.stub(),
+    forward: cy.stub(),
+    refresh: cy.stub(),
+    push: cy.stub().as('routerPush'),
+    replace: cy.stub(),
+    prefetch: cy.stub()
+  } as AppRouterInstance
+
+  const searchParams = new URLSearchParams()
+
+  cy.stub(navigation, 'useRouter').callsFake(() => router)
+  cy.stub(navigation, 'usePathname').callsFake(() => '/library/lib-books/items')
+  cy.stub(navigation, 'useSearchParams').callsFake(() => searchParams)
+
+  cy.mount(<AppRouterContext.Provider value={router}>{ui}</AppRouterContext.Provider>)
+}
+
+describe('<LibrariesDropdown />', () => {
+  it('renders selected library icon and name in the button', () => {
+    mountLibrariesDropdown(<LibrariesDropdown libraries={mockLibraries} currentLibraryId="lib-books" />)
+    cy.get('button').should('contain.text', 'Audiobooks')
+    cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
+  })
+
+  it('renders library icons in the menu list', () => {
+    mountLibrariesDropdown(<LibrariesDropdown libraries={mockLibraries} currentLibraryId="lib-books" />)
+    cy.get('button').click()
+    cy.get('[role="listbox"] > li').eq(0).find('[cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
+    cy.get('[role="listbox"] > li').eq(0).should('contain.text', 'Audiobooks')
+    cy.get('[role="listbox"] > li').eq(1).find('[cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
+    cy.get('[role="listbox"] > li').eq(1).should('contain.text', 'Podcasts')
+  })
+
+  it('shows the selected podcast library icon when that library is active', () => {
+    mountLibrariesDropdown(<LibrariesDropdown libraries={mockLibraries} currentLibraryId="lib-podcasts" />)
+    cy.get('button').should('contain.text', 'Podcasts')
+    cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
+  })
+})

--- a/cypress/tests/components/app/LibrariesDropdown.cy.tsx
+++ b/cypress/tests/components/app/LibrariesDropdown.cy.tsx
@@ -68,6 +68,8 @@ describe('<LibrariesDropdown />', () => {
   })
 
   it('sizes the button to the longest library name when a shorter library is selected', () => {
+    cy.viewport(1024, 768)
+
     const libraries: Library[] = [
       {
         id: 'lib-short',
@@ -95,7 +97,7 @@ describe('<LibrariesDropdown />', () => {
       .eq(0)
       .invoke('outerWidth')
       .then((menuItemWidth) => {
-        cy.get('button').invoke('outerWidth').should('be.gte', menuItemWidth)
+        cy.get('[cy-id="control-wrapper"]').invoke('outerWidth').should('be.gte', menuItemWidth)
       })
     cy.get('[role="listbox"] > li').eq(0).should('contain.text', 'Audiobookshelf Collection')
   })

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -702,6 +702,16 @@ describe('<Dropdown />', () => {
     })
   })
 
+  describe('hideSelectedInMenu Prop', () => {
+    it('hides the selected item from the menu but keeps it in the button', () => {
+      cy.mount(<Dropdown items={mockItems} value="option2" hideSelectedInMenu />)
+      cy.get('button').should('contain.text', 'Option 2')
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').should('have.length', 3)
+      cy.get('[role="listbox"]').should('not.contain.text', 'Option 2')
+    })
+  })
+
   describe('highlightSelected Prop', () => {
     it('highlights selected item when highlightSelected is true', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" highlightSelected={true} />)

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -1,4 +1,6 @@
 import Dropdown from '@/components/ui/Dropdown'
+import LibraryIcon from '@/components/ui/LibraryIcon'
+import React from 'react'
 
 // Define types for the dropdown items based on the component's interface
 interface DropdownSubitem {
@@ -10,6 +12,7 @@ interface DropdownItem {
   text: string
   value: string | number
   subtext?: string
+  leftIcon?: React.ReactNode
   subitems?: DropdownSubitem[]
 }
 
@@ -663,6 +666,39 @@ describe('<Dropdown />', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" displayText="Override Text" />)
       cy.get('button').should('contain.text', 'Override Text')
       cy.get('button').should('not.contain.text', 'Description')
+    })
+  })
+
+  describe('leftIcon Prop', () => {
+    const itemsWithIcons: DropdownItem[] = [
+      { text: 'Books', value: 'books', leftIcon: <LibraryIcon icon="books-1" decorative /> },
+      { text: 'Podcasts', value: 'podcasts', leftIcon: <LibraryIcon icon="podcast" decorative /> }
+    ]
+
+    it('displays leftIcon in the selected button value', () => {
+      cy.mount(<Dropdown items={itemsWithIcons} value="books" />)
+      cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
+      cy.get('button').should('contain.text', 'Books')
+    })
+
+    it('displays leftIcon in menu items', () => {
+      cy.mount(<Dropdown items={itemsWithIcons} value="books" />)
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').eq(0).find('[cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
+      cy.get('[role="listbox"] > li').eq(1).find('[cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
+    })
+
+    it('updates selected leftIcon when value changes', () => {
+      const TestComponent = () => {
+        const [value, setValue] = React.useState<string | number>('books')
+        return <Dropdown items={itemsWithIcons} value={value} onChange={setValue} />
+      }
+      cy.mount(<TestComponent />)
+      cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').eq(1).click()
+      cy.get('button [cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
+      cy.get('button').should('contain.text', 'Podcasts')
     })
   })
 

--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -1,4 +1,5 @@
 import DropdownMenu from '@/components/ui/DropdownMenu'
+import LibraryIcon from '@/components/ui/LibraryIcon'
 import React from 'react'
 
 // Define types for the dropdown menu items based on the component's interface
@@ -6,6 +7,7 @@ interface DropdownMenuItem {
   text: string
   value: string | number
   subtext?: string
+  leftIcon?: React.ReactNode
 }
 
 describe('<DropdownMenu />', () => {
@@ -286,6 +288,19 @@ describe('<DropdownMenu />', () => {
     it('applies primary background color', () => {
       cy.mount(<DropdownMenu {...defaultProps} />)
       cy.get('[role="listbox"]').should('have.class', 'bg-primary')
+    })
+  })
+
+  describe('leftIcon', () => {
+    it('renders leftIcon before item text', () => {
+      const itemsWithIcons: DropdownMenuItem[] = [
+        { text: 'Books', value: 'books', leftIcon: <LibraryIcon icon="books-1" decorative /> },
+        { text: 'Podcasts', value: 'podcasts', leftIcon: <LibraryIcon icon="podcast" decorative /> }
+      ]
+      cy.mount(<DropdownMenu {...defaultProps} items={itemsWithIcons} />)
+      cy.get('[role="listbox"] > li').eq(0).find('[cy-id="library-icon-span"]').should('have.class', 'icon-books-1')
+      cy.get('[role="listbox"] > li').eq(0).should('contain.text', 'Books')
+      cy.get('[role="listbox"] > li').eq(1).find('[cy-id="library-icon-span"]').should('have.class', 'icon-podcast')
     })
   })
 

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -1,18 +1,17 @@
 'use client'
 
-import IconBtn from '@/components/ui/IconBtn'
 import ButtonBase from '@/components/ui/ButtonBase'
+import IconBtn from '@/components/ui/IconBtn'
 import Tooltip from '@/components/ui/Tooltip'
 import ChromecastLauncher from '@/components/widgets/ChromecastLauncher'
 import NotificationWidget from '@/components/widgets/NotificationWidget'
 import { useMediaNavigation } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
-import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import Image from 'next/image'
-import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 import AppBarNav from './AppBarNav'
 import AppBarSelectionOverlay from './AppBarSelectionOverlay'
@@ -75,6 +74,8 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
     </>
   )
 
+  const LOGO_BUTTON_CLASSES = 'text-foreground hover:text-foreground/80 flex shrink-0 items-center justify-start gap-2 p-1 text-sm md:gap-4'
+
   return (
     <div className="bg-primary relative h-16 w-full">
       <header
@@ -87,22 +88,21 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
             size="custom"
             ariaLabel={isSideRailOpen ? t('ButtonClose') : t('ButtonMenu')}
             aria-expanded={isSideRailOpen}
-            className="text-foreground hover:text-foreground/80 flex shrink-0 items-center justify-start gap-2 text-sm md:hidden md:gap-4"
+            className={mergeClasses(LOGO_BUTTON_CLASSES, 'md:hidden')}
             onClick={toggleSideRail}
           >
             {logoContent}
           </ButtonBase>
         )}
-        <Link
-          href={redirectUrl}
-          aria-label={`audiobookshelf - ${t('ButtonHome')}`}
-          className={mergeClasses(
-            'text-foreground hover:text-foreground/80 shrink-0 items-center justify-start gap-2 text-sm md:gap-4',
-            showMobileSideRailToggle ? 'hidden md:flex' : 'flex'
-          )}
+        <ButtonBase
+          to={redirectUrl}
+          borderless
+          size="custom"
+          ariaLabel={`audiobookshelf - ${t('ButtonHome')}`}
+          className={mergeClasses(LOGO_BUTTON_CLASSES, showMobileSideRailToggle && 'hidden md:flex')}
         >
           {logoContent}
-        </Link>
+        </ButtonBase>
 
         {libraries && effectiveLibraryId && currentLibrary && (
           <>

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -1,21 +1,26 @@
 'use client'
 
 import IconBtn from '@/components/ui/IconBtn'
+import ButtonBase from '@/components/ui/ButtonBase'
 import Tooltip from '@/components/ui/Tooltip'
 import ChromecastLauncher from '@/components/widgets/ChromecastLauncher'
 import NotificationWidget from '@/components/widgets/NotificationWidget'
 import { useMediaNavigation } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import Image from 'next/image'
 import Link from 'next/link'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import AppBarNav from './AppBarNav'
 import AppBarSelectionOverlay from './AppBarSelectionOverlay'
 import GlobalSearchInput from './GlobalSearchInput'
 import LibrariesDropdown from './LibrariesDropdown'
+import SideRailMobileDrawer from './SideRailMobileDrawer'
+
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)'
 
 interface AppBarProps {
   libraries?: Library[]
@@ -24,6 +29,8 @@ interface AppBarProps {
 
 export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
   const t = useTypeSafeTranslations()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  const [isSideRailOpen, setIsSideRailOpen] = useState(false)
   const { user, userDefaultLibraryId } = useUser()
   const userCanUpload = user.permissions.upload
   const [isSearchMode, setIsSearchMode] = useState(false)
@@ -38,6 +45,20 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
     setIsSearchMode(false)
   }, [])
 
+  const toggleSideRail = useCallback(() => {
+    setIsSideRailOpen((prev) => !prev)
+  }, [])
+
+  const closeSideRail = useCallback(() => {
+    setIsSideRailOpen(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isMobile && isSideRailOpen) {
+      setIsSideRailOpen(false)
+    }
+  }, [isMobile, isSideRailOpen])
+
   const isAdmin = ['admin', 'root'].includes(user.type)
 
   const effectiveLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
@@ -45,6 +66,14 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
   const redirectLibraryId = effectiveLibraryId
   // New installs have no libraries, so redirect to settings
   const redirectUrl = redirectLibraryId ? `/library/${redirectLibraryId}` : '/settings'
+  const showMobileSideRailToggle = Boolean(effectiveLibraryId && currentLibrary)
+
+  const logoContent = (
+    <>
+      <Image src="/images/icon.svg" alt="" width={40} height={40} priority className="h-8 w-8 min-w-8 sm:h-10 sm:w-10 sm:min-w-10" />
+      <span className="hidden text-xl hover:underline md:block">audiobookshelf</span>
+    </>
+  )
 
   return (
     <div className="bg-primary relative h-16 w-full">
@@ -52,13 +81,27 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
         cy-id="appbar"
         className="box-shadow-appbar absolute start-0 top-0 bottom-0 z-60 flex h-full w-full min-w-0 items-center justify-start gap-1 px-2 py-1 max-md:overflow-x-hidden md:gap-4 md:px-6"
       >
+        {showMobileSideRailToggle && (
+          <ButtonBase
+            borderless
+            size="custom"
+            ariaLabel={isSideRailOpen ? t('ButtonClose') : t('ButtonMenu')}
+            aria-expanded={isSideRailOpen}
+            className="text-foreground hover:text-foreground/80 flex shrink-0 items-center justify-start gap-2 text-sm md:hidden md:gap-4"
+            onClick={toggleSideRail}
+          >
+            {logoContent}
+          </ButtonBase>
+        )}
         <Link
           href={redirectUrl}
           aria-label={`audiobookshelf - ${t('ButtonHome')}`}
-          className="text-foreground hover:text-foreground/80 flex shrink-0 items-center justify-start gap-2 text-sm md:gap-4"
+          className={mergeClasses(
+            'text-foreground hover:text-foreground/80 shrink-0 items-center justify-start gap-2 text-sm md:gap-4',
+            showMobileSideRailToggle ? 'hidden md:flex' : 'flex'
+          )}
         >
-          <Image src="/images/icon.svg" alt="" width={40} height={40} priority className="h-8 w-8 min-w-8 sm:h-10 sm:w-10 sm:min-w-10" />
-          <span className="hidden text-xl hover:underline md:block">audiobookshelf</span>
+          {logoContent}
         </Link>
 
         {libraries && effectiveLibraryId && currentLibrary && (
@@ -120,6 +163,9 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
         </div>
       </header>
       <AppBarSelectionOverlay libraryId={effectiveLibraryId} />
+      {showMobileSideRailToggle && isMobile && (
+        <SideRailMobileDrawer isOpen={isSideRailOpen} onClose={closeSideRail} libraries={libraries} currentLibraryId={currentLibraryId} />
+      )}
     </div>
   )
 }

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -106,7 +106,7 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
 
         {libraries && effectiveLibraryId && currentLibrary && (
           <>
-            <div className={mergeClasses('min-w-0 flex-1 overflow-hidden md:w-fit md:flex-none md:shrink-0', isSearchMode && 'hidden md:block')}>
+            <div className={mergeClasses('min-w-0 flex-1 md:w-fit md:flex-none md:shrink-0', isSearchMode && 'hidden md:block')}>
               <LibrariesDropdown currentLibraryId={effectiveLibraryId} libraries={libraries} />
             </div>
 

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -9,10 +9,11 @@ import { useMediaNavigation } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { resolveEffectiveLibrary } from '@/lib/libraries'
 import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import Image from 'next/image'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import AppBarNav from './AppBarNav'
 import AppBarSelectionOverlay from './AppBarSelectionOverlay'
 import GlobalSearchInput from './GlobalSearchInput'
@@ -34,7 +35,7 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
   const userCanUpload = user.permissions.upload
   const [isSearchMode, setIsSearchMode] = useState(false)
   // When not on a library page, use the last current library id when navigating home
-  const { lastCurrentLibraryId } = useMediaNavigation()
+  const { lastCurrentLibraryId, setLastCurrentLibraryId } = useMediaNavigation()
 
   const handleSearchModeToggle = useCallback(() => {
     setIsSearchMode((prev) => !prev)
@@ -60,12 +61,20 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
 
   const isAdmin = ['admin', 'root'].includes(user.type)
 
-  const effectiveLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
-  const currentLibrary = libraries?.find((lib) => lib.id === effectiveLibraryId)
+  const preferredLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
+  const currentLibrary = useMemo(() => resolveEffectiveLibrary(libraries, preferredLibraryId), [libraries, preferredLibraryId])
+  const effectiveLibraryId = currentLibrary?.id
   const redirectLibraryId = effectiveLibraryId
   // New installs have no libraries, so redirect to settings
   const redirectUrl = redirectLibraryId ? `/library/${redirectLibraryId}` : '/settings'
   const showMobileSideRailToggle = Boolean(effectiveLibraryId && currentLibrary)
+
+  useEffect(() => {
+    if (!effectiveLibraryId || currentLibraryId) return
+    if (lastCurrentLibraryId !== effectiveLibraryId) {
+      setLastCurrentLibraryId(effectiveLibraryId)
+    }
+  }, [currentLibraryId, effectiveLibraryId, lastCurrentLibraryId, setLastCurrentLibraryId])
 
   const logoContent = (
     <>

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -13,7 +13,8 @@ import { resolveEffectiveLibrary } from '@/lib/libraries'
 import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import Image from 'next/image'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { flushSync } from 'react-dom'
 import AppBarNav from './AppBarNav'
 import AppBarSelectionOverlay from './AppBarSelectionOverlay'
 import GlobalSearchInput from './GlobalSearchInput'
@@ -34,12 +35,21 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
   const { user, userDefaultLibraryId } = useUser()
   const userCanUpload = user.permissions.upload
   const [isSearchMode, setIsSearchMode] = useState(false)
+  const mobileSearchInputRef = useRef<HTMLInputElement>(null)
   // When not on a library page, use the last current library id when navigating home
   const { lastCurrentLibraryId, setLastCurrentLibraryId } = useMediaNavigation()
 
   const handleSearchModeToggle = useCallback(() => {
-    setIsSearchMode((prev) => !prev)
-  }, [])
+    if (isSearchMode) {
+      setIsSearchMode(false)
+      return
+    }
+    // Render the search input before focus() so the ref exists and mobile browsers treat focus as part of this tap (keyboard opens).
+    flushSync(() => {
+      setIsSearchMode(true)
+    })
+    mobileSearchInputRef.current?.focus({ preventScroll: true })
+  }, [isSearchMode])
 
   const handleSearchSubmit = useCallback(() => {
     setIsSearchMode(false)
@@ -135,11 +145,11 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
         {currentLibrary &&
           (isSearchMode ? (
             <div className="min-w-0 flex-1">
-              <GlobalSearchInput autoFocus onSubmit={handleSearchSubmit} libraryId={effectiveLibraryId} />
+              <GlobalSearchInput ref={mobileSearchInputRef} usePortal onSubmit={handleSearchSubmit} libraryId={effectiveLibraryId} />
             </div>
           ) : (
             <div className="hidden min-w-0 flex-1 md:block md:min-w-24">
-              <GlobalSearchInput onSubmit={handleSearchSubmit} libraryId={effectiveLibraryId} />
+              <GlobalSearchInput usePortal onSubmit={handleSearchSubmit} libraryId={effectiveLibraryId} />
             </div>
           ))}
 

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -148,10 +148,12 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
               <GlobalSearchInput ref={mobileSearchInputRef} usePortal onSubmit={handleSearchSubmit} libraryId={effectiveLibraryId} />
             </div>
           ) : (
-            <div className="hidden min-w-0 flex-1 md:block md:min-w-24">
+            <div className="hidden min-w-0 md:block md:w-80 md:shrink-0">
               <GlobalSearchInput usePortal onSubmit={handleSearchSubmit} libraryId={effectiveLibraryId} />
             </div>
           ))}
+
+        <div className="min-w-0 flex-1 max-md:hidden" aria-hidden="true" />
 
         {!isSearchMode && currentLibrary && (
           <IconBtn borderless ariaLabel={t('ButtonSearch')} onClick={handleSearchModeToggle} className="shrink-0 md:hidden">

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -102,16 +102,15 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
         className="box-shadow-appbar absolute start-0 top-0 bottom-0 z-60 flex h-full w-full min-w-0 items-center justify-start gap-1 px-2 py-1 max-md:overflow-x-hidden md:gap-4 md:px-6"
       >
         {showMobileSideRailToggle && (
-          <ButtonBase
+          <IconBtn
             borderless
-            size="custom"
             ariaLabel={isSideRailOpen ? t('ButtonClose') : t('ButtonMenu')}
             aria-expanded={isSideRailOpen}
-            className={mergeClasses(LOGO_BUTTON_CLASSES, 'md:hidden')}
+            className="shrink-0 md:hidden"
             onClick={toggleSideRail}
           >
-            {logoContent}
-          </ButtonBase>
+            menu
+          </IconBtn>
         )}
         <ButtonBase
           to={redirectUrl}

--- a/src/app/(main)/AppBarNav.tsx
+++ b/src/app/(main)/AppBarNav.tsx
@@ -1,13 +1,19 @@
 'use client'
 
-import Btn from '@/components/ui/Btn'
+import ButtonBase from '@/components/ui/ButtonBase'
 import IconBtn from '@/components/ui/IconBtn'
+import { useClickOutside } from '@/hooks/useClickOutside'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { autoUpdate, offset, useFloating } from '@floating-ui/react-dom'
-import Link from 'next/link'
+import { mergeClasses } from '@/lib/merge-classes'
+import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react-dom'
 import { useRouter } from 'next/navigation'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import { type AppBarNavMenuItemConfig, buildAppBarNavMenuItems } from './appBarNavMenuItems'
+import AppBarNavMenuItem from './AppBarNavMenuItem'
+
+const DESKTOP_MEDIA_QUERY = '(min-width: 768px)'
 
 interface AppBarNavProps {
   userCanUpload: boolean
@@ -18,18 +24,67 @@ interface AppBarNavProps {
 export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNavProps) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY, true)
+  const menuId = useId()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [focusedIndex, setFocusedIndex] = useState(-1)
   const [mounted, setMounted] = useState(false)
   const triggerRef = useRef<HTMLDivElement>(null)
+  const desktopTriggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<(HTMLAnchorElement | HTMLButtonElement | null)[]>([])
+
+  const allMenuItems = useMemo(() => buildAppBarNavMenuItems({ username, isAdmin, userCanUpload, t }), [isAdmin, t, userCanUpload, username])
+
+  const visibleMenuItems = useMemo(() => (isDesktop ? allMenuItems.filter((item) => !item.mobileOnly) : allMenuItems), [allMenuItems, isDesktop])
+
+  const closeMenu = useCallback(
+    (restoreDesktopFocus = false) => {
+      setMenuOpen(false)
+      setFocusedIndex(-1)
+      if (restoreDesktopFocus && isDesktop) {
+        desktopTriggerRef.current?.focus()
+      }
+    },
+    [isDesktop]
+  )
+
+  const focusMenuItem = useCallback((index: number) => {
+    setFocusedIndex(index)
+    itemRefs.current[index]?.focus()
+  }, [])
+
+  const openMenu = useCallback(
+    (startIndex = 0) => {
+      setMenuOpen(true)
+      const clampedIndex = Math.max(0, Math.min(startIndex, visibleMenuItems.length - 1))
+      setFocusedIndex(clampedIndex)
+    },
+    [visibleMenuItems.length]
+  )
 
   const toggleMenu = useCallback(() => {
-    setMobileMenuOpen((prev) => !prev)
-  }, [])
+    if (menuOpen) {
+      closeMenu(isDesktop)
+    } else {
+      openMenu()
+    }
+  }, [closeMenu, isDesktop, menuOpen, openMenu])
 
-  const closeMenu = useCallback(() => {
-    setMobileMenuOpen(false)
-  }, [])
+  const handleClickOutside = useCallback(() => {
+    closeMenu(false)
+  }, [closeMenu])
+
+  useClickOutside(menuRef, triggerRef, handleClickOutside, true)
+
+  const handleTriggerClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      toggleMenu()
+    },
+    [toggleMenu]
+  )
 
   const handleLogout = useCallback(async () => {
     try {
@@ -53,10 +108,15 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
     setMounted(true)
   }, [])
 
-  const middleware = useMemo(() => [offset(8)], [])
+  useEffect(() => {
+    if (!menuOpen || focusedIndex < 0) return
+    itemRefs.current[focusedIndex]?.focus()
+  }, [menuOpen, focusedIndex])
+
+  const middleware = useMemo(() => [offset(8), shift({ padding: 8 }), flip({ fallbackAxisSideDirection: 'start' })], [])
 
   const { refs, floatingStyles, update } = useFloating({
-    open: mobileMenuOpen,
+    open: menuOpen,
     placement: 'bottom-end',
     strategy: 'fixed',
     middleware
@@ -69,121 +129,159 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
   }, [refs])
 
   useEffect(() => {
-    if (menuRef.current && mobileMenuOpen) {
+    if (menuRef.current && menuOpen) {
       refs.setFloating(menuRef.current)
       update()
     }
-  }, [refs, mobileMenuOpen, update])
+  }, [refs, menuOpen, update])
 
   useEffect(() => {
-    if (!mobileMenuOpen || !refs.reference.current || !refs.floating.current) {
+    if (!menuOpen || !refs.reference.current || !refs.floating.current) {
       return
     }
 
     return autoUpdate(refs.reference.current, refs.floating.current, update)
-  }, [mobileMenuOpen, refs, update])
+  }, [menuOpen, refs, update])
+
+  const handleDesktopTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        if (!menuOpen) {
+          openMenu(0)
+        } else if (focusedIndex < 0) {
+          focusMenuItem(0)
+        }
+        break
+      case 'Escape':
+        if (menuOpen) {
+          e.preventDefault()
+          closeMenu(true)
+        }
+        break
+      default:
+        break
+    }
+  }
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    if (!visibleMenuItems.length) return
+
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault()
+        const nextIndex = focusedIndex < visibleMenuItems.length - 1 ? focusedIndex + 1 : 0
+        focusMenuItem(nextIndex)
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const prevIndex = focusedIndex > 0 ? focusedIndex - 1 : visibleMenuItems.length - 1
+        focusMenuItem(prevIndex)
+        break
+      }
+      case 'Home':
+        e.preventDefault()
+        focusMenuItem(0)
+        break
+      case 'End':
+        e.preventDefault()
+        focusMenuItem(visibleMenuItems.length - 1)
+        break
+      case 'Escape':
+        e.preventDefault()
+        closeMenu(isDesktop)
+        break
+      case 'Tab':
+        closeMenu(false)
+        break
+      default:
+        break
+    }
+  }
+
+  const getItemClassName = (item: AppBarNavMenuItemConfig, index: number) =>
+    mergeClasses(
+      'hover:bg-dropdown-item-hover text-foreground flex w-full items-center justify-start px-4 py-3 transition-colors outline-none',
+      item.className,
+      item.mobileOnly && 'md:hidden',
+      focusedIndex === index && 'bg-dropdown-item-selected'
+    )
 
   const menuContent = (
-    <nav className="flex flex-col py-1">
-      <Link
-        href="/account"
-        className="hover:bg-primary-hover text-foreground border-border flex items-center justify-start border-b px-4 py-3 transition-colors"
-        aria-label={t('HeaderAccount')}
-        onClick={closeMenu}
-      >
-        <span className="material-symbols mr-3 text-xl">person</span>
-        <span className="text-sm font-semibold">{username}</span>
-      </Link>
-
-      {/* Mobile only - Settings Button */}
-      {isAdmin && (
-        <Link
-          href="/settings"
-          className="hover:bg-primary-hover text-foreground flex items-center justify-start px-4 py-3 transition-colors md:hidden"
-          aria-label={t('HeaderSettings')}
-          onClick={closeMenu}
-        >
-          <span className="material-symbols mr-3 text-xl">settings</span>
-          <span className="text-sm">{t('HeaderSettings')}</span>
-        </Link>
-      )}
-
-      {userCanUpload && (
-        <Link
-          href="/upload"
-          className="hover:bg-primary-hover text-foreground flex items-center justify-start px-4 py-3 transition-colors md:hidden"
-          aria-label={t('ButtonUpload')}
-          onClick={closeMenu}
-        >
-          <span className="material-symbols mr-3 text-xl">upload</span>
-          <span className="text-sm">{t('ButtonUpload')}</span>
-        </Link>
-      )}
-
-      <Link
-        href="/account/stats"
-        className="hover:bg-primary-hover text-foreground flex items-center justify-start px-4 py-3 transition-colors"
-        aria-label={t('ButtonStats')}
-        onClick={closeMenu}
-      >
-        <span className="material-symbols mr-3 text-xl">equalizer</span>
-        <span className="text-sm">{t('ButtonStats')}</span>
-      </Link>
-
-      <Link
-        href="/components_catalog"
-        className="hover:bg-primary-hover text-foreground flex items-center justify-start px-4 py-3 transition-colors"
-        aria-label={t('ButtonComponentsCatalog')}
-        onClick={closeMenu}
-      >
-        <span className="material-symbols mr-3 text-xl">widgets</span>
-        <span className="text-sm">{t('ButtonComponentsCatalog')}</span>
-      </Link>
-
-      <button
-        onClick={handleLogout}
-        className="hover:bg-primary-hover text-foreground flex w-full items-center justify-start px-4 py-3 text-left transition-colors"
-        aria-label={t('ButtonLogout')}
-      >
-        <span className="material-symbols mr-3 text-xl">logout</span>
-        <span className="text-sm">{t('ButtonLogout')}</span>
-      </button>
+    <nav id={menuId} role="menu" className="flex flex-col py-1" onClick={(e) => e.stopPropagation()} onKeyDown={isDesktop ? handleMenuKeyDown : undefined}>
+      {visibleMenuItems.map((item, index) => (
+        <AppBarNavMenuItem
+          key={item.id}
+          ref={(el) => {
+            itemRefs.current[index] = el
+          }}
+          id={`${menuId}-item-${item.id}`}
+          tabIndex={isDesktop ? (focusedIndex === index ? 0 : -1) : undefined}
+          className={getItemClassName(item, index)}
+          ariaLabel={item.ariaLabel}
+          icon={item.icon}
+          label={item.label}
+          href={item.type === 'link' ? item.href : undefined}
+          onClick={item.type === 'logout' ? handleLogout : () => closeMenu(false)}
+        />
+      ))}
     </nav>
   )
+
+  const activeDescendantId =
+    menuOpen && focusedIndex >= 0 && focusedIndex < visibleMenuItems.length ? `${menuId}-item-${visibleMenuItems[focusedIndex].id}` : undefined
 
   return (
     <>
       <div ref={triggerRef} className="relative shrink-0">
         {/* Desktop - Username Dropdown */}
-        <Btn
+        <ButtonBase
+          ref={desktopTriggerRef}
           size="small"
           ariaLabel={`${username}, ${t('ButtonMenu')}`}
-          ariaExpanded={mobileMenuOpen}
-          className="hidden min-w-24 justify-between ps-3 pe-2 md:flex"
-          onClick={toggleMenu}
+          aria-expanded={menuOpen}
+          aria-controls={menuId}
+          aria-haspopup="menu"
+          aria-activedescendant={activeDescendantId}
+          className="text-button-foreground hidden min-w-24 justify-between px-4 py-1 ps-3 pe-2 text-sm md:inline-flex"
+          onClick={handleTriggerClick}
+          onKeyDown={handleDesktopTriggerKeyDown}
+          onMouseDown={(e) => e.preventDefault()}
         >
           <span className="block truncate text-sm">{username}</span>
           <span className="material-symbols text-xl" aria-hidden="true">
             person
           </span>
-        </Btn>
+        </ButtonBase>
 
         {/* Mobile - Hamburger Menu Button */}
-        <IconBtn borderless ariaLabel={t('ButtonMenu')} aria-expanded={mobileMenuOpen} className="md:hidden" onClick={toggleMenu}>
+        <IconBtn
+          borderless
+          ariaLabel={t('ButtonMenu')}
+          aria-expanded={menuOpen}
+          className="md:hidden"
+          onClick={handleTriggerClick}
+          onMouseDown={(e) => e.preventDefault()}
+        >
           menu
         </IconBtn>
       </div>
 
-      {mobileMenuOpen &&
+      {menuOpen &&
         mounted &&
         typeof document !== 'undefined' &&
         createPortal(
-          <>
-            <div className="fixed inset-0 z-[9998]" onClick={closeMenu} aria-hidden="true" />
-            <div ref={menuRef} className="bg-primary border-border z-[9999] min-w-[200px] rounded-md border shadow-lg" style={floatingStyles}>
-              {menuContent}
-            </div>
-          </>,
+          <div
+            ref={menuRef}
+            className="bg-primary border-border z-[9999] min-w-[200px] rounded-md border shadow-lg"
+            style={floatingStyles}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {menuContent}
+          </div>,
           document.body
         )}
     </>

--- a/src/app/(main)/AppBarNav.tsx
+++ b/src/app/(main)/AppBarNav.tsx
@@ -32,7 +32,6 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
   const triggerRef = useRef<HTMLDivElement>(null)
   const desktopTriggerRef = useRef<HTMLButtonElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
-  const itemRefs = useRef<(HTMLAnchorElement | HTMLButtonElement | null)[]>([])
 
   const allMenuItems = useMemo(() => buildAppBarNavMenuItems({ username, isAdmin, userCanUpload, t }), [isAdmin, t, userCanUpload, username])
 
@@ -48,11 +47,6 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
     },
     [isDesktop]
   )
-
-  const focusMenuItem = useCallback((index: number) => {
-    setFocusedIndex(index)
-    itemRefs.current[index]?.focus()
-  }, [])
 
   const openMenu = useCallback(
     (startIndex = 0) => {
@@ -104,14 +98,27 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
     }
   }, [router, closeMenu])
 
+  const activateMenuItem = useCallback(
+    (index: number) => {
+      const item = visibleMenuItems[index]
+      if (!item) return
+
+      if (item.type === 'logout') {
+        void handleLogout()
+        return
+      }
+
+      closeMenu(false)
+      if (item.href) {
+        router.push(item.href)
+      }
+    },
+    [closeMenu, handleLogout, router, visibleMenuItems]
+  )
+
   useEffect(() => {
     setMounted(true)
   }, [])
-
-  useEffect(() => {
-    if (!menuOpen || focusedIndex < 0) return
-    itemRefs.current[focusedIndex]?.focus()
-  }, [menuOpen, focusedIndex])
 
   const middleware = useMemo(() => [offset(8), shift({ padding: 8 }), flip({ fallbackAxisSideDirection: 'start' })], [])
 
@@ -143,16 +150,56 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
     return autoUpdate(refs.reference.current, refs.floating.current, update)
   }, [menuOpen, refs, update])
 
+  const handleVerticalNavigation = useCallback(
+    (direction: 'up' | 'down') => {
+      if (!visibleMenuItems.length) return
+
+      if (direction === 'down') {
+        if (!menuOpen) {
+          openMenu(0)
+        } else {
+          setFocusedIndex((prev) => (prev < visibleMenuItems.length - 1 ? prev + 1 : prev))
+        }
+      } else if (!menuOpen) {
+        openMenu(visibleMenuItems.length - 1)
+      } else {
+        setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev))
+      }
+    },
+    [menuOpen, openMenu, visibleMenuItems.length]
+  )
+
+  const handleHomeEnd = useCallback(
+    (key: 'home' | 'end') => {
+      if (!menuOpen || !visibleMenuItems.length) return
+      setFocusedIndex(key === 'home' ? 0 : visibleMenuItems.length - 1)
+    },
+    [menuOpen, visibleMenuItems.length]
+  )
+
+  const handleTab = useCallback(() => {
+    if (menuOpen) {
+      closeMenu(false)
+    }
+  }, [closeMenu, menuOpen])
+
   const handleDesktopTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>) => {
     switch (e.key) {
       case 'ArrowDown':
+        e.preventDefault()
+        handleVerticalNavigation('down')
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        handleVerticalNavigation('up')
+        break
       case 'Enter':
       case ' ':
         e.preventDefault()
         if (!menuOpen) {
           openMenu(0)
-        } else if (focusedIndex < 0) {
-          focusMenuItem(0)
+        } else if (focusedIndex >= 0) {
+          activateMenuItem(focusedIndex)
         }
         break
       case 'Escape':
@@ -161,41 +208,16 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
           closeMenu(true)
         }
         break
-      default:
-        break
-    }
-  }
-
-  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
-    if (!visibleMenuItems.length) return
-
-    switch (e.key) {
-      case 'ArrowDown': {
-        e.preventDefault()
-        const nextIndex = focusedIndex < visibleMenuItems.length - 1 ? focusedIndex + 1 : 0
-        focusMenuItem(nextIndex)
-        break
-      }
-      case 'ArrowUp': {
-        e.preventDefault()
-        const prevIndex = focusedIndex > 0 ? focusedIndex - 1 : visibleMenuItems.length - 1
-        focusMenuItem(prevIndex)
-        break
-      }
       case 'Home':
         e.preventDefault()
-        focusMenuItem(0)
+        handleHomeEnd('home')
         break
       case 'End':
         e.preventDefault()
-        focusMenuItem(visibleMenuItems.length - 1)
-        break
-      case 'Escape':
-        e.preventDefault()
-        closeMenu(isDesktop)
+        handleHomeEnd('end')
         break
       case 'Tab':
-        closeMenu(false)
+        handleTab()
         break
       default:
         break
@@ -211,21 +233,18 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
     )
 
   const menuContent = (
-    <nav id={menuId} role="menu" className="flex flex-col py-1" onClick={(e) => e.stopPropagation()} onKeyDown={isDesktop ? handleMenuKeyDown : undefined}>
+    <nav id={menuId} role="menu" className="flex flex-col py-1" onClick={(e) => e.stopPropagation()}>
       {visibleMenuItems.map((item, index) => (
         <AppBarNavMenuItem
           key={item.id}
-          ref={(el) => {
-            itemRefs.current[index] = el
-          }}
           id={`${menuId}-item-${item.id}`}
-          tabIndex={isDesktop ? (focusedIndex === index ? 0 : -1) : undefined}
+          tabIndex={isDesktop ? -1 : undefined}
           className={getItemClassName(item, index)}
           ariaLabel={item.ariaLabel}
           icon={item.icon}
           label={item.label}
           href={item.type === 'link' ? item.href : undefined}
-          onClick={item.type === 'logout' ? handleLogout : () => closeMenu(false)}
+          onClick={() => activateMenuItem(index)}
         />
       ))}
     </nav>
@@ -279,6 +298,7 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
             className="bg-primary border-border z-[9999] min-w-[200px] rounded-md border shadow-lg"
             style={floatingStyles}
             onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.preventDefault()}
           >
             {menuContent}
           </div>,

--- a/src/app/(main)/AppBarNav.tsx
+++ b/src/app/(main)/AppBarNav.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import ButtonBase from '@/components/ui/ButtonBase'
-import IconBtn from '@/components/ui/IconBtn'
 import { useClickOutside } from '@/hooks/useClickOutside'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
@@ -10,8 +9,8 @@ import { autoUpdate, flip, offset, shift, useFloating } from '@floating-ui/react
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { type AppBarNavMenuItemConfig, buildAppBarNavMenuItems } from './appBarNavMenuItems'
 import AppBarNavMenuItem from './AppBarNavMenuItem'
+import { type AppBarNavMenuItemConfig, buildAppBarNavMenuItems } from './appBarNavMenuItems'
 
 const DESKTOP_MEDIA_QUERY = '(min-width: 768px)'
 
@@ -276,17 +275,23 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
           </span>
         </ButtonBase>
 
-        {/* Mobile - Hamburger Menu Button */}
-        <IconBtn
-          borderless
-          ariaLabel={t('ButtonMenu')}
+        {/* Mobile - Account icon button */}
+        <ButtonBase
+          size="small"
+          ariaLabel={`${username}, ${t('ButtonMenu')}`}
           aria-expanded={menuOpen}
-          className="md:hidden"
+          aria-controls={menuId}
+          aria-haspopup="menu"
+          aria-activedescendant={activeDescendantId}
+          className="text-button-foreground inline-flex w-9 px-0 md:hidden"
           onClick={handleTriggerClick}
+          onKeyDown={handleDesktopTriggerKeyDown}
           onMouseDown={(e) => e.preventDefault()}
         >
-          menu
-        </IconBtn>
+          <span className="material-symbols text-xl" aria-hidden="true">
+            person
+          </span>
+        </ButtonBase>
       </div>
 
       {menuOpen &&

--- a/src/app/(main)/AppBarNavMenuItem.tsx
+++ b/src/app/(main)/AppBarNavMenuItem.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+
+interface AppBarNavMenuItemProps {
+  id: string
+  className: string
+  ariaLabel: string
+  tabIndex?: number
+  icon: string
+  label: string
+  href?: string
+  onClick?: () => void
+  ref: (el: HTMLAnchorElement | HTMLButtonElement | null) => void
+}
+
+export default function AppBarNavMenuItem({ id, className, ariaLabel, tabIndex, icon, label, href, onClick, ref }: AppBarNavMenuItemProps) {
+  const content = (
+    <>
+      <span className="material-symbols mr-3 text-xl">{icon}</span>
+      <span className="text-sm">{label}</span>
+    </>
+  )
+
+  const sharedProps = {
+    id,
+    role: 'menuitem' as const,
+    tabIndex,
+    className,
+    'aria-label': ariaLabel,
+    onMouseDown: (e: React.MouseEvent) => e.preventDefault()
+  }
+
+  if (href) {
+    return (
+      <Link ref={ref} href={href} {...sharedProps} onClick={onClick}>
+        {content}
+      </Link>
+    )
+  }
+
+  return (
+    <button ref={ref} type="button" {...sharedProps} onClick={onClick}>
+      {content}
+    </button>
+  )
+}

--- a/src/app/(main)/AppBarNavMenuItem.tsx
+++ b/src/app/(main)/AppBarNavMenuItem.tsx
@@ -10,11 +10,10 @@ interface AppBarNavMenuItemProps {
   icon: string
   label: string
   href?: string
-  onClick?: () => void
-  ref: (el: HTMLAnchorElement | HTMLButtonElement | null) => void
+  onClick: () => void
 }
 
-export default function AppBarNavMenuItem({ id, className, ariaLabel, tabIndex, icon, label, href, onClick, ref }: AppBarNavMenuItemProps) {
+export default function AppBarNavMenuItem({ id, className, ariaLabel, tabIndex, icon, label, href, onClick }: AppBarNavMenuItemProps) {
   const content = (
     <>
       <span className="material-symbols mr-3 text-xl">{icon}</span>
@@ -22,25 +21,31 @@ export default function AppBarNavMenuItem({ id, className, ariaLabel, tabIndex, 
     </>
   )
 
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    onClick()
+  }
+
   const sharedProps = {
     id,
     role: 'menuitem' as const,
     tabIndex,
     className,
     'aria-label': ariaLabel,
-    onMouseDown: (e: React.MouseEvent) => e.preventDefault()
+    onMouseDown: (e: React.MouseEvent) => e.preventDefault(),
+    onClick: handleClick
   }
 
   if (href) {
     return (
-      <Link ref={ref} href={href} {...sharedProps} onClick={onClick}>
+      <Link href={href} {...sharedProps}>
         {content}
       </Link>
     )
   }
 
   return (
-    <button ref={ref} type="button" {...sharedProps} onClick={onClick}>
+    <button type="button" {...sharedProps}>
       {content}
     </button>
   )

--- a/src/app/(main)/GlobalSearchInput.tsx
+++ b/src/app/(main)/GlobalSearchInput.tsx
@@ -8,12 +8,11 @@ import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 
 import { FlatResultItem, useGlobalSearchTransformer } from '@/hooks/useGlobalSearchTransformer'
 import { useRouter } from 'next/navigation'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type Ref } from 'react'
 import GlobalSearchMenu from './GlobalSearchMenu'
 
 interface GlobalSearchInputProps {
   libraryId?: string
-  autoFocus?: boolean
   onSubmit?: () => void
   /** Optional callback for when an item is selected. If provided, items become selectable instead of navigating. */
   onItemSelect?: (item: FlatResultItem) => void
@@ -21,9 +20,10 @@ interface GlobalSearchInputProps {
   onClear?: () => void
   /** Use portal to render the dropdown menu. Useful for avoiding clipping issues. */
   usePortal?: boolean
+  ref?: Ref<HTMLInputElement>
 }
 
-export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit, onItemSelect, onClear, usePortal = false }: GlobalSearchInputProps = {}) {
+export default function GlobalSearchInput({ libraryId, onSubmit, onItemSelect, onClear, usePortal = false, ref }: GlobalSearchInputProps) {
   const searchOptions = useMemo(() => ({ autoSelectFirst: false, libraryId }), [libraryId])
   const { searchQuery, setSearchQuery, isSearching, searchResults, selectedLibraryId, handleSearch, searchError, clearSelection } =
     useLibrarySearch(searchOptions)
@@ -54,6 +54,18 @@ export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit, onIt
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+
+  const setInputRef = useCallback(
+    (node: HTMLInputElement | null) => {
+      inputRef.current = node
+      if (typeof ref === 'function') {
+        ref(node)
+      } else if (ref) {
+        ref.current = node
+      }
+    },
+    [ref]
+  )
 
   // Close menu when clicking outside
   useClickOutside(
@@ -157,7 +169,7 @@ export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit, onIt
     <div className="relative w-full" ref={containerRef}>
       <InputWrapper size="small" className="w-full" inputRef={inputRef}>
         <input
-          ref={inputRef}
+          ref={setInputRef}
           type="text"
           className="h-full w-full bg-transparent text-sm outline-none placeholder:text-gray-400"
           placeholder={t('PlaceholderSearch')}
@@ -176,7 +188,6 @@ export default function GlobalSearchInput({ libraryId, autoFocus, onSubmit, onIt
           autoCorrect="off"
           autoCapitalize="off"
           spellCheck="false"
-          autoFocus={autoFocus}
         />
       </InputWrapper>
 

--- a/src/app/(main)/LibrariesDropdown.tsx
+++ b/src/app/(main)/LibrariesDropdown.tsx
@@ -73,6 +73,7 @@ export default function LibrariesDropdown({ libraries, currentLibraryId }: Libra
     <div className="relative min-w-0">
       <Dropdown
         items={libraryItems}
+        hideSelectedInMenu
         menuMaxHeight="80vh"
         size="small"
         disabled={isPending}

--- a/src/app/(main)/LibrariesDropdown.tsx
+++ b/src/app/(main)/LibrariesDropdown.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import Dropdown from '@/components/ui/Dropdown'
+import LibraryIcon from '@/components/ui/LibraryIcon'
 import { attemptGuardedNavigation } from '@/hooks/useUnsavedNavigationGuard'
 import { Library } from '@/types/api'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useTransition } from 'react'
+import { useMemo, useTransition } from 'react'
 
 interface LibrariesDropdownProps {
   libraries: Library[]
@@ -56,12 +57,17 @@ export default function LibrariesDropdown({ libraries, currentLibraryId }: Libra
   const searchParams = useSearchParams()
   const [isPending, startTransition] = useTransition()
 
-  const search = searchParams.size > 0 ? `?${searchParams.toString()}` : ''
+  const search = searchParams?.size ? `?${searchParams.toString()}` : ''
 
-  const libraryItems = libraries.map((library) => ({
-    text: library.name,
-    value: library.id
-  }))
+  const libraryItems = useMemo(
+    () =>
+      libraries.map((library) => ({
+        text: library.name,
+        value: library.id,
+        leftIcon: <LibraryIcon icon={library.icon} decorative />
+      })),
+    [libraries]
+  )
 
   return (
     <div className="relative min-w-0">

--- a/src/app/(main)/LibrariesDropdown.tsx
+++ b/src/app/(main)/LibrariesDropdown.tsx
@@ -3,9 +3,13 @@
 import Dropdown from '@/components/ui/Dropdown'
 import LibraryIcon from '@/components/ui/LibraryIcon'
 import { attemptGuardedNavigation } from '@/hooks/useUnsavedNavigationGuard'
+import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useMemo, useTransition } from 'react'
+
+// Match Vue LibrariesDropdown max width (max-w-52 = 13rem)
+const LIBRARIES_DROPDOWN_MAX_WIDTH_CLASS = 'md:max-w-52'
 
 interface LibrariesDropdownProps {
   libraries: Library[]
@@ -69,28 +73,48 @@ export default function LibrariesDropdown({ libraries, currentLibraryId }: Libra
     [libraries]
   )
 
+  const widestLibrary = useMemo(() => {
+    if (!libraries.length) return null
+
+    return libraries.reduce((longest, library) => (library.name.length > longest.name.length ? library : longest))
+  }, [libraries])
+
   return (
-    <div className="relative min-w-0">
-      <Dropdown
-        items={libraryItems}
-        hideSelectedInMenu
-        menuMaxHeight="80vh"
-        size="small"
-        disabled={isPending}
-        value={currentLibraryId}
-        usePortal
-        onChange={(value) => {
-          const lib = libraries.find((l) => l.id === value)
-          if (!lib || lib.id === currentLibraryId) return
+    <div className={mergeClasses('relative min-w-0 md:grid md:w-fit', LIBRARIES_DROPDOWN_MAX_WIDTH_CLASS)}>
+      {widestLibrary && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none invisible col-start-1 row-start-1 hidden h-0 overflow-hidden whitespace-nowrap md:flex md:h-9 md:items-center md:overflow-visible md:rounded-md md:px-2 md:text-sm"
+        >
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 ps-1">
+            <LibraryIcon icon={widestLibrary.icon} decorative />
+            <span className="font-sans">{widestLibrary.name}</span>
+          </span>
+          <span className="material-symbols pointer-events-none ms-3 shrink-0 text-2xl">expand_more</span>
+        </span>
+      )}
+      <div className="col-start-1 row-start-1 min-w-0">
+        <Dropdown
+          items={libraryItems}
+          hideSelectedInMenu
+          menuMaxHeight="80vh"
+          size="small"
+          disabled={isPending}
+          value={currentLibraryId}
+          usePortal
+          onChange={(value) => {
+            const lib = libraries.find((l) => l.id === value)
+            if (!lib || lib.id === currentLibraryId) return
 
-          const path = getLibrarySwitchPath(pathname, search, currentLibraryId, lib.id, lib.mediaType)
-          if (!attemptGuardedNavigation(path)) return
+            const path = getLibrarySwitchPath(pathname, search, currentLibraryId, lib.id, lib.mediaType)
+            if (!attemptGuardedNavigation(path)) return
 
-          startTransition(() => {
-            router.push(path)
-          })
-        }}
-      />
+            startTransition(() => {
+              router.push(path)
+            })
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/src/app/(main)/SideRail.tsx
+++ b/src/app/(main)/SideRail.tsx
@@ -1,156 +1,18 @@
 'use client'
 
-import VersionFooter from '@/components/app/VersionFooter'
 import { useLibrary } from '@/contexts/LibraryContext'
-import { useUser } from '@/contexts/UserContext'
-import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { mergeClasses } from '@/lib/merge-classes'
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
+import SideRailContent from './SideRailContent'
 
 export default function SideRail({ serverVersion, installSource }: { serverVersion: string; installSource: string }) {
-  const pathname = usePathname()
-  const t = useTypeSafeTranslations()
   const { library } = useLibrary()
-  const { userIsAdminOrUp } = useUser()
 
-  const currentLibraryId = library?.id ?? ''
-  const currentLibraryMediaType = library?.mediaType ?? 'book'
-
-  const buttons = [
-    {
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
-          />
-        </svg>
-      ),
-      label: t('ButtonHome'),
-      href: `/library/${currentLibraryId}`
-    },
-    {
-      icon: <span className="material-symbols text-2xl">&#xe241;</span>,
-      label: t('ButtonLatest'),
-      href: `/library/${currentLibraryId}/latest`,
-      mediaType: 'podcast'
-    },
-    {
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-          />
-        </svg>
-      ),
-      label: t('ButtonLibrary'),
-      href: `/library/${currentLibraryId}/items`
-    },
-    {
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth="2"
-            d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"
-          />
-        </svg>
-      ),
-      label: t('ButtonSeries'),
-      href: `/library/${currentLibraryId}/series`,
-      mediaType: 'book'
-    },
-    {
-      icon: <span className="material-symbols text-2xl">&#xe431;</span>,
-      label: t('ButtonCollections'),
-      href: `/library/${currentLibraryId}/collections`,
-      mediaType: 'book'
-    },
-    {
-      icon: <span className="material-symbols text-2.5xl">&#xe03d;</span>,
-      label: t('ButtonPlaylists'),
-      href: `/library/${currentLibraryId}/playlists`
-    },
-    {
-      icon: (
-        <svg className="h-6 w-6" viewBox="0 0 24 24">
-          <path
-            fill="currentColor"
-            d="M12,5.5A3.5,3.5 0 0,1 15.5,9A3.5,3.5 0 0,1 12,12.5A3.5,3.5 0 0,1 8.5,9A3.5,3.5 0 0,1 12,5.5M5,8C5.56,8 6.08,8.15 6.53,8.42C6.38,9.85 6.8,11.27 7.66,12.38C7.16,13.34 6.16,14 5,14A3,3 0 0,1 2,11A3,3 0 0,1 5,8M19,8A3,3 0 0,1 22,11A3,3 0 0,1 19,14C17.84,14 16.84,13.34 16.34,12.38C17.2,11.27 17.62,9.85 17.47,8.42C17.92,8.15 18.44,8 19,8M5.5,18.25C5.5,16.18 8.41,14.5 12,14.5C15.59,14.5 18.5,16.18 18.5,18.25V20H5.5V18.25M0,20V18.5C0,17.11 1.89,15.94 4.45,15.6C3.86,16.28 3.5,17.22 3.5,18.25V20H0M24,20H20.5V18.25C20.5,17.22 20.14,16.28 19.55,15.6C22.11,15.94 24,17.11 24,18.5V20Z"
-          />
-        </svg>
-      ),
-      label: t('ButtonAuthors'),
-      href: `/library/${currentLibraryId}/authors`,
-      mediaType: 'book'
-    },
-    {
-      icon: <span className="material-symbols text-2xl">&#xe91f;</span>,
-      label: t('LabelNarrators'),
-      href: `/library/${currentLibraryId}/narrators`,
-      mediaType: 'book'
-    },
-    {
-      icon: <span className="material-symbols text-2xl">&#xf190;</span>,
-      label: t('ButtonStats'),
-      href: `/library/${currentLibraryId}/stats`,
-      mediaType: 'book'
-    },
-    {
-      icon: <span className="abs-icons icon-podcast text-xl"></span>,
-      label: t('ButtonAdd'),
-      href: `/library/${currentLibraryId}/add-podcast`,
-      mediaType: 'podcast',
-      adminOnly: true
-    },
-    {
-      icon: <span className="material-symbols text-2xl">&#xf090;</span>,
-      label: t('ButtonDownloadQueue'),
-      href: `/library/${currentLibraryId}/download-queue`,
-      mediaType: 'podcast',
-      adminOnly: true
-    },
-    {
-      icon: <span className="material-symbols text-2xl">warning</span>,
-      label: t('ButtonIssues'),
-      href: `/library/${currentLibraryId}/issues`,
-      hidden: true
-    }
-  ]
-
-  const filteredButtons = buttons.filter(
-    (button) => (!button.mediaType || button.mediaType === currentLibraryMediaType) && !button.hidden && (!button.adminOnly || userIsAdminOrUp)
-  )
+  if (!library) {
+    return null
+  }
 
   return (
     <div className="bg-bg box-shadow-side z-10 hidden h-full max-h-[calc(100vh-4rem)] w-20 min-w-20 md:block">
-      <div className="h-full max-h-[calc(100%-3rem)] w-full overflow-y-auto">
-        {filteredButtons.map((button) => (
-          <Link
-            key={button.label}
-            href={button.href}
-            className={mergeClasses(
-              'text-foreground border-primary/30 hover:bg-nav-item-hover relative flex h-20 w-full cursor-pointer flex-col items-center justify-center border-b',
-              pathname === button.href && 'bg-nav-item-selected'
-            )}
-          >
-            {button.icon}
-            <p className="text-sm">{button.label}</p>
-
-            {pathname === button.href && <div className="absolute start-0 top-0 h-full w-0.5 bg-yellow-400"></div>}
-          </Link>
-        ))}
-      </div>
-      <div className="border-primary/30 h-12 w-full border-t px-1 py-2">
-        <VersionFooter serverVersion={serverVersion} installSource={installSource} />
-      </div>
+      <SideRailContent libraryId={library.id} mediaType={library.mediaType} serverVersion={serverVersion} installSource={installSource} />
     </div>
   )
 }

--- a/src/app/(main)/SideRailContent.tsx
+++ b/src/app/(main)/SideRailContent.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+import VersionFooter from '@/components/app/VersionFooter'
+import { useUser } from '@/contexts/UserContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { mergeClasses } from '@/lib/merge-classes'
+import { Library } from '@/types/api'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+interface SideRailContentProps {
+  libraryId: string
+  mediaType: Library['mediaType']
+  serverVersion: string
+  installSource: string
+  onItemClick?: () => void
+  showFooter?: boolean
+  variant?: 'rail' | 'drawer'
+}
+
+export default function SideRailContent({
+  libraryId,
+  mediaType,
+  serverVersion,
+  installSource,
+  onItemClick,
+  showFooter = true,
+  variant = 'rail'
+}: SideRailContentProps) {
+  const pathname = usePathname()
+  const t = useTypeSafeTranslations()
+  const { userIsAdminOrUp } = useUser()
+
+  const buttons = [
+    {
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          />
+        </svg>
+      ),
+      label: t('ButtonHome'),
+      href: `/library/${libraryId}`
+    },
+    {
+      icon: <span className="material-symbols text-2xl">&#xe241;</span>,
+      label: t('ButtonLatest'),
+      href: `/library/${libraryId}/latest`,
+      mediaType: 'podcast' as const
+    },
+    {
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+          />
+        </svg>
+      ),
+      label: t('ButtonLibrary'),
+      href: `/library/${libraryId}/items`
+    },
+    {
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2"
+          />
+        </svg>
+      ),
+      label: t('ButtonSeries'),
+      href: `/library/${libraryId}/series`,
+      mediaType: 'book' as const
+    },
+    {
+      icon: <span className="material-symbols text-2xl">&#xe431;</span>,
+      label: t('ButtonCollections'),
+      href: `/library/${libraryId}/collections`,
+      mediaType: 'book' as const
+    },
+    {
+      icon: <span className="material-symbols text-2.5xl">&#xe03d;</span>,
+      label: t('ButtonPlaylists'),
+      href: `/library/${libraryId}/playlists`
+    },
+    {
+      icon: (
+        <svg className="h-6 w-6" viewBox="0 0 24 24">
+          <path
+            fill="currentColor"
+            d="M12,5.5A3.5,3.5 0 0,1 15.5,9A3.5,3.5 0 0,1 12,12.5A3.5,3.5 0 0,1 8.5,9A3.5,3.5 0 0,1 12,5.5M5,8C5.56,8 6.08,8.15 6.53,8.42C6.38,9.85 6.8,11.27 7.66,12.38C7.16,13.34 6.16,14 5,14A3,3 0 0,1 2,11A3,3 0 0,1 5,8M19,8A3,3 0 0,1 22,11A3,3 0 0,1 19,14C17.84,14 16.84,13.34 16.34,12.38C17.2,11.27 17.62,9.85 17.47,8.42C17.92,8.15 18.44,8 19,8M5.5,18.25C5.5,16.18 8.41,14.5 12,14.5C15.59,14.5 18.5,16.18 18.5,18.25V20H5.5V18.25M0,20V18.5C0,17.11 1.89,15.94 4.45,15.6C3.86,16.28 3.5,17.22 3.5,18.25V20H0M24,20H20.5V18.25C20.5,17.22 20.14,16.28 19.55,15.6C22.11,15.94 24,17.11 24,18.5V20Z"
+          />
+        </svg>
+      ),
+      label: t('ButtonAuthors'),
+      href: `/library/${libraryId}/authors`,
+      mediaType: 'book' as const
+    },
+    {
+      icon: <span className="material-symbols text-2xl">&#xe91f;</span>,
+      label: t('LabelNarrators'),
+      href: `/library/${libraryId}/narrators`,
+      mediaType: 'book' as const
+    },
+    {
+      icon: <span className="material-symbols text-2xl">&#xf190;</span>,
+      label: t('ButtonStats'),
+      href: `/library/${libraryId}/stats`,
+      mediaType: 'book' as const
+    },
+    {
+      icon: <span className="abs-icons icon-podcast text-xl"></span>,
+      label: t('ButtonAdd'),
+      href: `/library/${libraryId}/add-podcast`,
+      mediaType: 'podcast' as const,
+      adminOnly: true
+    },
+    {
+      icon: <span className="material-symbols text-2xl">&#xf090;</span>,
+      label: t('ButtonDownloadQueue'),
+      href: `/library/${libraryId}/download-queue`,
+      mediaType: 'podcast' as const,
+      adminOnly: true
+    },
+    {
+      icon: <span className="material-symbols text-2xl">warning</span>,
+      label: t('ButtonIssues'),
+      href: `/library/${libraryId}/issues`,
+      hidden: true
+    }
+  ]
+
+  const filteredButtons = buttons.filter(
+    (button) => (!button.mediaType || button.mediaType === mediaType) && !button.hidden && (!button.adminOnly || userIsAdminOrUp)
+  )
+
+  const isDrawer = variant === 'drawer'
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <nav className={mergeClasses('min-h-0 w-full flex-1 overflow-y-auto', isDrawer ? 'flex flex-col py-1' : '')}>
+        {filteredButtons.map((button) => (
+          <Link
+            key={button.label}
+            href={button.href}
+            onClick={onItemClick ?? undefined}
+            className={mergeClasses(
+              'text-foreground hover:bg-nav-item-hover relative w-full cursor-pointer border-b transition-colors',
+              isDrawer ? 'border-border flex items-center justify-start px-4 py-3' : 'border-primary/30 flex h-20 flex-col items-center justify-center',
+              pathname === button.href && (isDrawer ? 'bg-nav-item-hover' : 'bg-nav-item-selected')
+            )}
+          >
+            <span
+              className={mergeClasses(
+                'shrink-0',
+                isDrawer ? 'me-3 flex items-center [&_.abs-icons]:text-xl [&_.material-symbols]:text-xl [&_svg]:h-5 [&_svg]:w-5' : ''
+              )}
+            >
+              {button.icon}
+            </span>
+            <span className={mergeClasses(isDrawer ? 'text-sm font-semibold' : 'text-sm')}>{button.label}</span>
+
+            {!isDrawer && pathname === button.href && <div className="absolute start-0 top-0 h-full w-0.5 bg-yellow-400"></div>}
+          </Link>
+        ))}
+      </nav>
+      {showFooter && (
+        <div className={mergeClasses('w-full shrink-0 border-t', isDrawer ? 'border-primary/30 px-4 py-2' : 'border-primary/30 h-12 px-1 py-2')}>
+          <VersionFooter serverVersion={serverVersion} installSource={installSource} variant={isDrawer ? 'row' : undefined} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/(main)/SideRailMobileDrawer.tsx
+++ b/src/app/(main)/SideRailMobileDrawer.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import IconBtn from '@/components/ui/IconBtn'
+import LibraryIcon from '@/components/ui/LibraryIcon'
+import { useMediaNavigation } from '@/contexts/MediaContext'
+import { useUser } from '@/contexts/UserContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { Library } from '@/types/api'
+import { usePathname } from 'next/navigation'
+import { useEffect, useRef } from 'react'
+import SideRailContent from './SideRailContent'
+
+interface SideRailMobileDrawerProps {
+  isOpen: boolean
+  onClose: () => void
+  libraries?: Library[]
+  currentLibraryId?: string
+}
+
+export default function SideRailMobileDrawer({ isOpen, onClose, libraries, currentLibraryId }: SideRailMobileDrawerProps) {
+  const t = useTypeSafeTranslations()
+  const pathname = usePathname()
+  const { lastCurrentLibraryId } = useMediaNavigation()
+  const { userDefaultLibraryId, serverSettings, Source } = useUser()
+
+  const serverVersion = serverSettings?.version || 'Error'
+  const installSource = Source || 'Unknown'
+
+  const effectiveLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
+  const library = libraries?.find((lib) => lib.id === effectiveLibraryId)
+  const previousPathnameRef = useRef(pathname)
+
+  useEffect(() => {
+    if (previousPathnameRef.current === pathname) {
+      return
+    }
+    previousPathnameRef.current = pathname
+    onClose()
+  }, [pathname, onClose])
+
+  if (!library) {
+    return null
+  }
+
+  const handleBackdropClick = () => {
+    onClose()
+  }
+
+  const handleItemClick = () => {
+    onClose()
+  }
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-100 ease-in-out ${isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+        onClick={handleBackdropClick}
+        aria-hidden="true"
+      />
+
+      {/* Drawer */}
+      <div
+        className={`bg-bg box-shadow-side border-border fixed top-0 left-0 z-70 flex h-full w-64 min-w-64 transform flex-col border-e shadow-2xl transition-transform duration-100 ease-in-out ${
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        <div className="border-primary/30 shrink-0 border-b px-4 py-3">
+          <p className="text-foreground-subdued text-xs font-semibold tracking-wide uppercase">{t('LabelLibrary')}</p>
+          <div className="mt-1 flex items-center gap-2">
+            <LibraryIcon icon={library.icon} size={6} decorative className="text-foreground-muted" />
+            <h2 className="text-foreground-muted min-w-0 flex-1 truncate text-base font-medium">{library.name}</h2>
+            <IconBtn className="shrink-0" ariaLabel="Menu" size="large" borderless onClick={onClose}>
+              arrow_back
+            </IconBtn>
+          </div>
+        </div>
+        <div className="min-h-0 w-full flex-1">
+          <SideRailContent
+            libraryId={library.id}
+            mediaType={library.mediaType}
+            serverVersion={serverVersion}
+            installSource={installSource}
+            onItemClick={handleItemClick}
+            variant="drawer"
+          />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/app/(main)/SideRailMobileDrawer.tsx
+++ b/src/app/(main)/SideRailMobileDrawer.tsx
@@ -5,6 +5,7 @@ import LibraryIcon from '@/components/ui/LibraryIcon'
 import { useMediaNavigation } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { resolveEffectiveLibrary } from '@/lib/libraries'
 import { Library } from '@/types/api'
 import { usePathname } from 'next/navigation'
 import { useEffect, useRef } from 'react'
@@ -26,8 +27,8 @@ export default function SideRailMobileDrawer({ isOpen, onClose, libraries, curre
   const serverVersion = serverSettings?.version || 'Error'
   const installSource = Source || 'Unknown'
 
-  const effectiveLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
-  const library = libraries?.find((lib) => lib.id === effectiveLibraryId)
+  const preferredLibraryId = currentLibraryId || lastCurrentLibraryId || userDefaultLibraryId
+  const library = resolveEffectiveLibrary(libraries, preferredLibraryId)
   const previousPathnameRef = useRef(pathname)
 
   useEffect(() => {

--- a/src/app/(main)/SideRailMobileDrawer.tsx
+++ b/src/app/(main)/SideRailMobileDrawer.tsx
@@ -55,7 +55,7 @@ export default function SideRailMobileDrawer({ isOpen, onClose, libraries, curre
     <>
       {/* Backdrop */}
       <div
-        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-100 ease-in-out ${isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
+        className={`fixed inset-0 z-[65] bg-black/50 transition-opacity duration-100 ease-in-out ${isOpen ? 'pointer-events-auto opacity-100' : 'pointer-events-none opacity-0'}`}
         onClick={handleBackdropClick}
         aria-hidden="true"
       />

--- a/src/app/(main)/appBarNavMenuItems.ts
+++ b/src/app/(main)/appBarNavMenuItems.ts
@@ -1,0 +1,87 @@
+import type { TypeSafeTranslations } from '@/types/translations'
+
+export type AppBarNavMenuItemType = 'link' | 'logout'
+
+export interface AppBarNavMenuItemConfig {
+  id: string
+  type: AppBarNavMenuItemType
+  href?: string
+  label: string
+  ariaLabel: string
+  icon: string
+  mobileOnly?: boolean
+  className?: string
+}
+
+export interface BuildAppBarNavMenuItemsParams {
+  username: string
+  isAdmin: boolean
+  userCanUpload: boolean
+  t: TypeSafeTranslations
+}
+
+export function buildAppBarNavMenuItems({ username, isAdmin, userCanUpload, t }: BuildAppBarNavMenuItemsParams): AppBarNavMenuItemConfig[] {
+  const items: AppBarNavMenuItemConfig[] = [
+    {
+      id: 'account',
+      type: 'link',
+      href: '/account',
+      label: username,
+      ariaLabel: t('HeaderAccount'),
+      icon: 'person',
+      className: 'border-border border-b'
+    }
+  ]
+
+  if (isAdmin) {
+    items.push({
+      id: 'settings',
+      type: 'link',
+      href: '/settings',
+      label: t('HeaderSettings'),
+      ariaLabel: t('HeaderSettings'),
+      icon: 'settings',
+      mobileOnly: true
+    })
+  }
+
+  if (userCanUpload) {
+    items.push({
+      id: 'upload',
+      type: 'link',
+      href: '/upload',
+      label: t('ButtonUpload'),
+      ariaLabel: t('ButtonUpload'),
+      icon: 'upload',
+      mobileOnly: true
+    })
+  }
+
+  items.push(
+    {
+      id: 'stats',
+      type: 'link',
+      href: '/account/stats',
+      label: t('ButtonStats'),
+      ariaLabel: t('ButtonStats'),
+      icon: 'equalizer'
+    },
+    {
+      id: 'components-catalog',
+      type: 'link',
+      href: '/components_catalog',
+      label: t('ButtonComponentsCatalog'),
+      ariaLabel: t('ButtonComponentsCatalog'),
+      icon: 'widgets'
+    },
+    {
+      id: 'logout',
+      type: 'logout',
+      label: t('ButtonLogout'),
+      ariaLabel: t('ButtonLogout'),
+      icon: 'logout'
+    }
+  )
+
+  return items
+}

--- a/src/app/(main)/settings/libraries/LibrariesClient.tsx
+++ b/src/app/(main)/settings/libraries/LibrariesClient.tsx
@@ -75,7 +75,7 @@ export default function LibrariesClient({ libraries }: LibraryClientProps) {
         }}
         moreInfoUrl="https://www.audiobookshelf.org/guides/library_creation"
       >
-        <LibrariesList libraries={libraries} saveLibraryOrderAction={saveLibraryOrder} onEditLibrary={handleEditLibrary} />
+        <LibrariesList libraries={libraries} saveLibraryOrderAction={saveLibraryOrder} onEditLibrary={handleEditLibrary} onAddLibrary={handleAddLibrary} />
       </SettingsContent>
 
       <LibraryEditModal isOpen={isModalOpen} library={editingLibrary} processing={isProcessing} onClose={handleCloseModal} onSubmit={handleSubmit} />

--- a/src/app/(main)/settings/libraries/LibrariesList.tsx
+++ b/src/app/(main)/settings/libraries/LibrariesList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Btn from '@/components/ui/Btn'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import SortableList from '@/components/widgets/SortableList'
 import { useGlobalToast } from '@/contexts/ToastContext'
@@ -13,16 +14,19 @@ interface LibrariesListProps {
   libraries: Library[]
   saveLibraryOrderAction: (reorderObjects: { id: string; newOrder: number }[]) => void
   onEditLibrary?: (library: Library) => void
+  onAddLibrary?: () => void
 }
 
 export default function LibrariesList(props: LibrariesListProps) {
-  const { libraries: librariesData, saveLibraryOrderAction, onEditLibrary } = props
+  const { libraries: librariesData, saveLibraryOrderAction, onEditLibrary, onAddLibrary } = props
   const t = useTypeSafeTranslations()
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
   const { showToast } = useGlobalToast()
   const [isPending, startTransition] = useTransition()
   const [libraries, setLibraries] = useState(librariesData || ([] as Library[]))
   const delRef = useRef<Library>(null)
+
+  const hasBookLibrary = libraries.some((library) => library.mediaType === 'book')
 
   useEffect(() => {
     setLibraries(librariesData)
@@ -68,15 +72,31 @@ export default function LibrariesList(props: LibrariesListProps) {
 
   return (
     <div className="min-w-0 overflow-x-hidden overscroll-x-contain">
-      <SortableList
-        items={libraries}
-        itemClassName="first:rounded-t-md last:rounded-b-md border border-border"
-        disabled={isPending}
-        onSortEnd={handleSortChange}
-        renderItem={(item: Library, _index, dragHandle) => (
-          <LibrariesListRow item={item} handleDeleteLibrary={handleDeleteLibrary} handleEditLibrary={handleEditLibrary} sortableDragHandleProps={dragHandle} />
-        )}
-      />
+      {libraries.length > 0 ? (
+        <SortableList
+          items={libraries}
+          itemClassName="first:rounded-t-md last:rounded-b-md border border-border"
+          disabled={isPending}
+          onSortEnd={handleSortChange}
+          renderItem={(item: Library, _index, dragHandle) => (
+            <LibrariesListRow
+              item={item}
+              handleDeleteLibrary={handleDeleteLibrary}
+              handleEditLibrary={handleEditLibrary}
+              sortableDragHandleProps={dragHandle}
+            />
+          )}
+        />
+      ) : (
+        <div className="pb-4">
+          <Btn onClick={onAddLibrary}>{t('ButtonAddYourFirstLibrary')}</Btn>
+        </div>
+      )}
+      {hasBookLibrary && (
+        <p className="text-foreground-subdued mt-4 text-xs">
+          **<strong>{t('ButtonMatchBooks')}</strong> {t('MessageMatchBooksDescription')}
+        </p>
+      )}
       <ConfirmDialog
         isOpen={showConfirmDialog}
         message={t('MessageConfirmDeleteLibrary', { 0: delRef.current?.name || '' })}

--- a/src/app/(main)/settings/libraries/actions.ts
+++ b/src/app/(main)/settings/libraries/actions.ts
@@ -19,6 +19,7 @@ export async function editLibrary(libraryId: string, updatedLibrary: Library): P
 export async function deleteLibrary(libraryId: string): Promise<Library> {
   const result = await api.deleteLibrary(libraryId)
   revalidatePath('/settings/libraries')
+  revalidatePath('/settings', 'layout')
   return result
 }
 

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -17,6 +17,7 @@ export interface DropdownItem {
   value: string | number
   subtext?: string
   keepOpen?: boolean
+  leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
   disabled?: boolean
   /** Subitems for two-level menu support */
@@ -373,6 +374,7 @@ export default function Dropdown({
     value: item.value,
     subtext: item.subtext,
     keepOpen: item.keepOpen,
+    leftIcon: item.leftIcon,
     rightIcon: item.rightIcon,
     subitems: item.subitems?.map((sub) => ({
       text: sub.text,
@@ -417,8 +419,11 @@ export default function Dropdown({
           onClick={handleButtonClick}
           onKeyDown={handleKeyDown}
         >
-          <span className="flex-1 overflow-hidden text-start" title={longLabel.trim() || undefined}>
-            <DropdownItemLabel text={selectedText} subtext={selectedSubtext || undefined} />
+          <span className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden text-start" title={longLabel.trim() || undefined}>
+            {selectedItem?.leftIcon && <span className="shrink-0">{selectedItem.leftIcon}</span>}
+            <span className="min-w-0 flex-1">
+              <DropdownItemLabel text={selectedText} subtext={selectedSubtext || undefined} />
+            </span>
           </span>
           <span className="pointer-events-none ms-3 flex flex-shrink-0 items-center">
             {rightIcon || <span className="material-symbols text-2xl">expand_more</span>}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -37,6 +37,8 @@ interface DropdownProps {
   highlightSelected?: boolean
   /** Override the display text shown in the dropdown button */
   displayText?: string
+  /** Hide the selected value from the menu while still showing it in the button */
+  hideSelectedInMenu?: boolean
   /** Use portal to render the dropdown menu. Useful for avoiding clipping issues. */
   usePortal?: boolean
 }
@@ -58,6 +60,7 @@ export default function Dropdown({
   rightIcon,
   highlightSelected = false,
   displayText,
+  hideSelectedInMenu = false,
   usePortal = false
 }: DropdownProps) {
   const [showMenu, setShowMenu] = useState(false)
@@ -102,8 +105,8 @@ export default function Dropdown({
     }
   }
 
-  const openSubMenu = (index: number) => {
-    const currentItem = items[index]
+  const openSubMenu = (index: number, menuItems: DropdownItem[]) => {
+    const currentItem = menuItems[index]
     setOpenSubmenuIndex(index)
     // Only set focusedSubIndex to 0 if there are actual subitems
     if (currentItem?.subitems && currentItem.subitems.length > 0) {
@@ -150,6 +153,11 @@ export default function Dropdown({
     [items]
   )
 
+  const menuItemsToShow = useMemo(() => {
+    if (!hideSelectedInMenu || value === undefined) return itemsToShow
+    return itemsToShow.filter((item) => item.value !== value)
+  }, [itemsToShow, hideSelectedInMenu, value])
+
   const selectedItem = itemsToShow.find((item) => item.value === value)
   // Use displayText if provided, otherwise fall back to selected item text
   const selectedText = displayText || selectedItem?.text || ''
@@ -169,11 +177,11 @@ export default function Dropdown({
   // Helper to get filtered subitems for the currently open submenu
   const getFilteredSubitems = useCallback(() => {
     if (openSubmenuIndex === null) return []
-    const currentItem = items[openSubmenuIndex]
+    const currentItem = menuItemsToShow[openSubmenuIndex]
     if (!currentItem?.subitems) return []
     if (!submenuFilterText) return currentItem.subitems
     return currentItem.subitems.filter((subitem) => subitem.text.toLowerCase().startsWith(submenuFilterText.toLowerCase()))
-  }, [items, openSubmenuIndex, submenuFilterText])
+  }, [menuItemsToShow, openSubmenuIndex, submenuFilterText])
 
   // Keyboard navigation handlers
   const handleVerticalNavigation = (direction: 'up' | 'down') => {
@@ -188,11 +196,11 @@ export default function Dropdown({
         }
       } else {
         closeSubMenu()
-        setFocusedIndex((prev) => (prev < itemsToShow.length - 1 ? prev + 1 : prev))
+        setFocusedIndex((prev) => (prev < menuItemsToShow.length - 1 ? prev + 1 : prev))
       }
     } else {
       if (!showMenu) {
-        openMenu(itemsToShow.length - 1)
+        openMenu(menuItemsToShow.length - 1)
       } else if (focusedSubIndex !== -1 && openSubmenuIndex !== null) {
         // Navigating within submenu - use filtered list
         const filteredSubitems = getFilteredSubitems()
@@ -210,9 +218,9 @@ export default function Dropdown({
     if (direction === 'right') {
       // Open submenu if current item has subitems
       if (showMenu && focusedSubIndex === -1 && focusedIndex >= 0) {
-        const currentItem = items[focusedIndex]
+        const currentItem = menuItemsToShow[focusedIndex]
         if (currentItem?.subitems) {
-          openSubMenu(focusedIndex)
+          openSubMenu(focusedIndex, menuItemsToShow)
         }
       }
     } else {
@@ -235,17 +243,17 @@ export default function Dropdown({
           handleSubitemClick(subitem.value)
         }
       }
-    } else if (focusedIndex >= 0 && focusedIndex < itemsToShow.length) {
-      const currentItem = items[focusedIndex]
+    } else if (focusedIndex >= 0 && focusedIndex < menuItemsToShow.length) {
+      const currentItem = menuItemsToShow[focusedIndex]
       if (currentItem?.subitems) {
         // Toggle submenu
         if (openSubmenuIndex === focusedIndex) {
           closeSubMenu()
         } else {
-          openSubMenu(focusedIndex)
+          openSubMenu(focusedIndex, menuItemsToShow)
         }
       } else {
-        handleOptionClick(itemsToShow[focusedIndex].value)
+        handleOptionClick(menuItemsToShow[focusedIndex].value)
       }
     }
   }
@@ -276,7 +284,7 @@ export default function Dropdown({
           }
         } else {
           closeSubMenu()
-          setFocusedIndex(itemsToShow.length - 1)
+          setFocusedIndex(menuItemsToShow.length - 1)
         }
       }
     }
@@ -370,7 +378,7 @@ export default function Dropdown({
     }
   }
 
-  const dropdownMenuItems: DropdownMenuItem[] = itemsToShow.map((item) => ({
+  const dropdownMenuItems: DropdownMenuItem[] = menuItemsToShow.map((item) => ({
     text: item.text,
     value: item.value,
     subtext: item.subtext,
@@ -447,7 +455,7 @@ export default function Dropdown({
               if (openSubmenuIndex === idx) {
                 closeSubMenu()
               } else {
-                openSubMenu(idx)
+                openSubMenu(idx, menuItemsToShow)
               }
             }
           } else {

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -67,6 +67,7 @@ export default function Dropdown({
   // Type-to-filter for submenus
   const [submenuFilterText, setSubmenuFilterText] = useState('')
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const controlWrapperRef = useRef<HTMLDivElement>(null)
   const menuRef = useRef<HTMLUListElement>(null)
 
   // Generate unique ID for this dropdown instance
@@ -392,7 +393,7 @@ export default function Dropdown({
         </Label>
       )}
 
-      <InputWrapper disabled={disabled} size={size} inputRef={buttonRef}>
+      <InputWrapper disabled={disabled} size={size} inputRef={buttonRef} wrapperRef={controlWrapperRef}>
         <button
           ref={buttonRef}
           id={dropdownButtonId}
@@ -471,7 +472,7 @@ export default function Dropdown({
         highlightSelected={highlightSelected}
         isItemSelected={(item) => item.value === value}
         usePortal={usePortal}
-        triggerRef={buttonRef as React.RefObject<HTMLElement>}
+        triggerRef={controlWrapperRef as React.RefObject<HTMLElement>}
       />
     </div>
   )

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -19,6 +19,7 @@ export interface DropdownMenuItem {
   value: string | number
   subtext?: string
   keepOpen?: boolean
+  leftIcon?: React.ReactNode
   rightIcon?: React.ReactNode
   subitems?: DropdownMenuSubitem[]
 }
@@ -444,7 +445,12 @@ export default function DropdownMenu({
             onMouseLeave={hasSubitems ? handleMouseleaveParent : undefined}
           >
             <div className="flex min-w-0 items-center overflow-hidden">
-              <DropdownItemLabel text={item.text} subtext={item.subtext} className="ms-3 min-w-0 flex-1 text-sm" />
+              {item.leftIcon && <span className="ms-3 shrink-0">{item.leftIcon}</span>}
+              <DropdownItemLabel
+                text={item.text}
+                subtext={item.subtext}
+                className={mergeClasses(item.leftIcon ? 'ms-1.5' : 'ms-3', 'min-w-0 flex-1 text-sm')}
+              />
             </div>
             {hasSubitems && (
               <div className="pointer-events-none absolute inset-y-0 right-2 flex h-full items-center">

--- a/src/components/ui/InputWrapper.tsx
+++ b/src/components/ui/InputWrapper.tsx
@@ -11,6 +11,7 @@ export interface InputWrapperProps {
   size?: 'small' | 'medium' | 'large' | 'auto'
   className?: string
   inputRef?: React.RefObject<HTMLElement | null>
+  wrapperRef?: React.RefObject<HTMLDivElement | null>
 }
 
 const InputWrapper = ({
@@ -21,7 +22,8 @@ const InputWrapper = ({
   borderless = false,
   size = 'medium',
   className,
-  inputRef
+  inputRef,
+  wrapperRef
 }: InputWrapperProps) => {
   const wrapperClass = mergeClasses(
     // Base styles
@@ -53,7 +55,7 @@ const InputWrapper = ({
 
   return (
     <>
-      <div className={wrapperClass} cy-id="control-wrapper" onClick={handleClick}>
+      <div ref={wrapperRef} className={wrapperClass} cy-id="control-wrapper" onClick={handleClick}>
         {children}
       </div>
       {typeof error === 'string' && error && <div className="text-error mt-1 text-sm">{error}</div>}

--- a/src/lib/libraries.ts
+++ b/src/lib/libraries.ts
@@ -1,0 +1,20 @@
+import { Library } from '@/types/api'
+
+function sortLibrariesByDisplayOrder(libraries: Library[]) {
+  return [...libraries].sort((a, b) => a.displayOrder - b.displayOrder)
+}
+
+/**
+ * Resolve the active library from a list, matching Vue getNextAccessibleLibrary behavior.
+ * Falls back to the first library (by display order) when the preferred id is missing.
+ */
+export function resolveEffectiveLibrary(libraries: Library[] | undefined, preferredLibraryId?: string | null): Library | undefined {
+  if (!libraries?.length) return undefined
+
+  if (preferredLibraryId) {
+    const preferredLibrary = libraries.find((library) => library.id === preferredLibraryId)
+    if (preferredLibrary) return preferredLibrary
+  }
+
+  return sortLibrariesByDisplayOrder(libraries)[0]
+}


### PR DESCRIPTION
This adds a mobile slide-in drawer for library navigation, toggled from the **AppBar logo** when a library is selected. In Vue the side rail is desktop-only (`hidden md:block`) with no mobile alternative.

This fixes #110 

### Notable changes from Vue

- **Mobile navigation**: New **`SideRailMobileDrawer`** with backdrop dismiss, library header (icon + name), and horizontal nav links
- **Entry point**: AppBar logo toggles the drawer on `< md`; desktop logo remains a home link
- **Shared nav**: Extracted **`SideRailContent`** from **`SideRail`** for desktop rail and mobile drawer (`variant: 'rail' | 'drawer'`)
- **Library scope**: Uses the effective library from the dropdown, so nav is available wherever Appbar is visible.
- **Close behavior**: Drawer closes on backdrop tap, back arrow, nav link, route change, and resize to desktop

### Additional AppBar polish fixes:
- **Library icons**: Show each library’s icon in the dropdown button and menu
- **Hide selected library in menu**: Keep the active library in the button, but omit it from the open menu (Vue parity).
- **Portaled menu alignment**: Anchor the menu to the full control wrapper so the portaled list lines up with the selected value.
- **Focus outline**: Stop clipping the libraries dropdown focus ring in the AppBar.
- **AppBar logo buttons**: Use `ButtonBase` for the mobile drawer toggle and desktop home link so focus styles render correctly.
- **Stable desktop width**: Size the dropdown to the longest library name (capped at `max-w-52`) so menu items aren’t truncated when a shorter library is selected.
- Fixed bug where the libraries dropdown disappeared when the selected library was deleted.
- Added empty state (no libraries) on /settings/libraries, to match Vue
- Refactored and fixed AppBarNav keyboard navigation and click outside behavior.
- **Global search** on mobile:
  - Render search results menu in a portal so it is not clipped by the app bar’s `overflow-x-hidden`
  - When the search icon expands the field, use `flushSync` and focus the input via ref other wise the focus would be lost