### PR TITLE
Various fixes

### DIFF
--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -328,5 +328,22 @@ describe('<DropdownMenu />', () => {
       cy.get('[role="listbox"] > li').eq(1).should('contain.text', 'Short')
       cy.get('[role="listbox"] > li').eq(1).should('contain.text', 'This is a very long text')
     })
+
+    it('wraps long text when wrapText is set', () => {
+      const longText = 'This is a very long text that should wrap onto multiple lines in the dropdown menu item instead of truncating with an ellipsis'
+      const longItems: DropdownMenuItem[] = [{ text: longText, value: 'long1' }]
+      cy.mount(
+        <div className="w-48">
+          <DropdownMenu {...defaultProps} items={longItems} wrapText />
+        </div>
+      )
+      cy.get('[role="listbox"] > li')
+        .eq(0)
+        .find('span')
+        .first()
+        .should('have.class', 'line-clamp-2')
+        .and('have.class', 'break-words')
+        .and('not.have.class', 'truncate')
+    })
   })
 })

--- a/cypress/tests/components/widgets/ChaptersTable.cy.tsx
+++ b/cypress/tests/components/widgets/ChaptersTable.cy.tsx
@@ -42,7 +42,8 @@ const mockUserContextValue: UserContextType = {
   ereaderDevices: [],
   Source: 'test',
   getMediaItemProgress: () => undefined,
-  getBookmarksForLibraryItem: () => []
+  getBookmarksForLibraryItem: () => [],
+  mergeServerSettings: () => {}
 }
 
 const mockLibraryItem: BookLibraryItem = {

--- a/src/app/(main)/account/AccountActionsRow.tsx
+++ b/src/app/(main)/account/AccountActionsRow.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import Btn from '@/components/ui/Btn'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import LogoutBtn from './LogoutBtn'
+
+const MOBILE_MEDIA_QUERY = '(max-width: 767px)'
+
+export default function AccountActionsRow() {
+  const t = useTypeSafeTranslations()
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY)
+  const size = isMobile ? 'small' : 'medium'
+
+  return (
+    <div className="flex w-full flex-wrap items-center gap-x-4 gap-y-2">
+      <Btn to="/account/change-password" size={size} className="shrink-0 whitespace-nowrap">
+        {t('LabelChangePassword')}
+      </Btn>
+      <LogoutBtn size={size} />
+    </div>
+  )
+}

--- a/src/app/(main)/account/LogoutBtn.tsx
+++ b/src/app/(main)/account/LogoutBtn.tsx
@@ -5,7 +5,11 @@ import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
-export default function LogoutBtn() {
+interface LogoutBtnProps {
+  size?: 'small' | 'medium'
+}
+
+export default function LogoutBtn({ size = 'medium' }: LogoutBtnProps) {
   const t = useTranslations()
   const router = useRouter()
   const [loading, setLoading] = useState(false)
@@ -30,7 +34,12 @@ export default function LogoutBtn() {
   }
 
   return (
-    <Btn onClick={handleLogout} loading={loading} className="items-center justify-between gap-2 ps-6">
+    <Btn
+      onClick={handleLogout}
+      loading={loading}
+      size={size}
+      className={`ms-auto shrink-0 items-center justify-between gap-2 whitespace-nowrap ${size === 'small' ? 'ps-4' : 'ps-6'}`}
+    >
       <span className="material-symbols text-lg">logout</span>
       {t('LabelLogout')}
     </Btn>

--- a/src/app/(main)/account/page.tsx
+++ b/src/app/(main)/account/page.tsx
@@ -3,10 +3,9 @@ import TextInput from '@/components/ui/TextInput'
 import { getCurrentUser } from '@/lib/api'
 import { getTypeSafeTranslations } from '@/lib/getTypeSafeTranslations'
 
-import Btn from '@/components/ui/Btn'
 import { getTheme } from '@/lib/theme'
 import { cookies } from 'next/headers'
-import LogoutBtn from './LogoutBtn'
+import AccountActionsRow from './AccountActionsRow'
 import ThemeSelector from './ThemeSelector'
 import UserLanguageSelector from './UserLanguageSelector'
 
@@ -48,10 +47,7 @@ export default async function AccountPage() {
           <ThemeSelector value={currentTheme} label={t('LabelTheme')} />
         </div>
         <div className="bg-border h-px w-full" />
-        <div className="flex w-full items-center justify-between">
-          <Btn to="/account/change-password">{t('LabelChangePassword')}</Btn>
-          <LogoutBtn />
-        </div>
+        <AccountActionsRow />
       </div>
     </div>
   )

--- a/src/app/(main)/components_catalog/examples/DropdownExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/DropdownExamples.tsx
@@ -59,6 +59,7 @@ export function DropdownExamples() {
   const [dropdownValue3, setDropdownValue3] = useState('option1')
   const [dropdownValue4, setDropdownValue4] = useState('option1')
   const [dropdownValue5, setDropdownValue5] = useState('option1')
+  const [dropdownValue6, setDropdownValue6] = useState('option1')
 
   // Dropdown change handlers
   const handleDropdownChange = (value: string | number) => {
@@ -81,6 +82,10 @@ export function DropdownExamples() {
     setDropdownValue5(String(value))
   }
 
+  const handleDropdownChange6 = (value: string | number) => {
+    setDropdownValue6(String(value))
+  }
+
   return (
     <ComponentExamples title="Dropdowns">
       <ComponentInfo component="Dropdown" description="Select dropdown component with labels, subtext, and various states">
@@ -89,7 +94,7 @@ export function DropdownExamples() {
         </p>
         <p className="mb-2">
           <span className="font-bold">Props:</span> <Code>value</Code>, <Code>onChange</Code>, <Code>items</Code> (DropdownItem[]), <Code>label</Code>,{' '}
-          <Code>disabled</Code>, <Code>small</Code>, <Code>menuMaxHeight</Code>, <Code>className</Code>
+          <Code>disabled</Code>, <Code>small</Code>, <Code>menuMaxHeight</Code>, <Code>wrapText</Code>, <Code>className</Code>
         </p>
       </ComponentInfo>
 
@@ -135,6 +140,19 @@ export function DropdownExamples() {
           />
         </Example>
 
+        <Example title="Different item lengths with wrap">
+          <Dropdown
+            value={dropdownValue3}
+            onChange={handleDropdownChange3}
+            items={dropdownItemsWithDifferentLengths}
+            label="Dropdown with wrapping menu items"
+            wrapText
+          />
+        </Example>
+
+        <Example title="Dropdown with submenus">
+          <Dropdown value={dropdownValue5} onChange={handleDropdownChange5} items={dropdownItemsWithSubmenus} label="Dropdown with submenus" />
+        </Example>
         <Example title="Different item lengths and subtext">
           <Dropdown
             value={dropdownValue4}
@@ -143,8 +161,16 @@ export function DropdownExamples() {
             label="Dropdown with different item lengths and subtext"
           />
         </Example>
-        <Example title="Dropdown with submenus">
-          <Dropdown value={dropdownValue5} onChange={handleDropdownChange5} items={dropdownItemsWithSubmenus} label="Dropdown with submenus" />
+
+        <Example title="Submenu flips left near the right edge" className="md:col-span-2 lg:col-span-3">
+          <p className="text-foreground-muted mb-4 text-sm">
+            Open the menu and hover a submenu item — with the control at the right edge, the submenu flips left instead of clipping.
+          </p>
+          <div className="flex justify-end">
+            <div className="w-64">
+              <Dropdown value={dropdownValue6} onChange={handleDropdownChange6} items={dropdownItemsWithSubmenus} label="Submenu flips left" usePortal />
+            </div>
+          </div>
         </Example>
       </ExamplesBlock>
     </ComponentExamples>

--- a/src/app/(main)/library/[library]/(book)/narrators/NarratorsClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/narrators/NarratorsClient.tsx
@@ -2,16 +2,25 @@
 
 import type { EditListItem } from '@/components/ui/EditList'
 import EditList from '@/components/ui/EditList'
+import { useLibrary } from '@/contexts/LibraryContext'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { NarratorObject } from '@/types/api'
-import { useTransition } from 'react'
+import { useEffect, useTransition } from 'react'
 import { deleteNarrator, saveNarrator } from './actions'
 
 export default function NarratorsClient({ libraryId, narrators }: { libraryId: string; narrators: NarratorObject[] }) {
   const { showToast } = useGlobalToast()
+  const { setItemCount } = useLibrary()
   const t = useTypeSafeTranslations()
   const [isPending, startTransition] = useTransition()
+
+  useEffect(() => {
+    setItemCount(narrators.length)
+    return () => {
+      setItemCount(null)
+    }
+  }, [narrators.length, setItemCount])
 
   const handleSave = async (item: EditListItem, newName: string) => {
     if (isPending) return

--- a/src/app/(main)/library/[library]/LibraryFilterSelect.tsx
+++ b/src/app/(main)/library/[library]/LibraryFilterSelect.tsx
@@ -442,7 +442,7 @@ export default function LibraryFilterSelect({ entityType = 'items', user }: Libr
   if (entityType === 'authors') return null
 
   return (
-    <div className="relative h-9 w-36 sm:w-44 md:w-48">
+    <div className="relative h-9 max-w-48 min-w-0 flex-1 md:w-48 md:flex-none">
       <Dropdown
         value={currentFilter}
         items={filterItems}
@@ -452,6 +452,7 @@ export default function LibraryFilterSelect({ entityType = 'items', user }: Libr
         displayText={getSelectedText()}
         menuMaxHeight="calc(100vh - 120px)"
         usePortal
+        wrapText
       />
       {showClear && (
         <button

--- a/src/app/(main)/library/[library]/LibraryLayoutWrapper.tsx
+++ b/src/app/(main)/library/[library]/LibraryLayoutWrapper.tsx
@@ -27,6 +27,8 @@ export default function LibraryLayoutWrapper({ children }: LibraryLayoutWrapperP
   const installSource = Source || 'Unknown'
   const isLibraryItemPage = pathname.includes('/item/')
   const isBatchEditPage = pathname.endsWith('/batch')
+  const isStatsPage = pathname.endsWith('/stats')
+  const showToolbar = !isLibraryItemPage && !isBatchEditPage && !isStatsPage
   const showCoverSizeWidget =
     !isLibraryItemPage &&
     !pathname.endsWith('/latest') &&
@@ -62,14 +64,14 @@ export default function LibraryLayoutWrapper({ children }: LibraryLayoutWrapperP
     <div className={mergeClasses('page-wrapper relative flex overflow-hidden', libraryItemIdStreaming ? 'streaming' : '')}>
       <SideRail serverVersion={serverVersion} installSource={installSource} />
       <div className="page-bg-gradient min-w-0 flex-1 overflow-hidden">
-        {!isLibraryItemPage && !isBatchEditPage && <Toolbar />}
-        {/* subtract height of toolbar if not library item page */}
+        {showToolbar && <Toolbar />}
+        {/* subtract height of toolbar when it is shown */}
         <div
           className={mergeClasses(
             'w-full overflow-x-hidden',
-            isBatchEditPage && 'h-full overflow-hidden',
-            isLibraryItemPage && !isBatchEditPage && 'h-full overflow-y-auto',
-            !isLibraryItemPage && !isBatchEditPage && 'h-[calc(100%-2.5rem)] overflow-y-auto'
+            showToolbar && 'h-[calc(100%-2.5rem)] overflow-y-auto',
+            !showToolbar && isBatchEditPage && 'h-full overflow-hidden',
+            !showToolbar && !isBatchEditPage && 'h-full overflow-y-auto'
           )}
         >
           {children}

--- a/src/app/(main)/library/[library]/LibrarySortSelect.tsx
+++ b/src/app/(main)/library/[library]/LibrarySortSelect.tsx
@@ -189,7 +189,7 @@ export default function LibrarySortSelect({ entityType = 'items', libraryMediaTy
   }, [currentSortDesc, t])
 
   return (
-    <div className="h-9 w-36 sm:w-44 md:w-48">
+    <div className="h-9 max-w-48 min-w-0 flex-1 md:w-48 md:flex-none">
       <Dropdown
         value={currentSortBy}
         items={sortItems}
@@ -200,6 +200,7 @@ export default function LibrarySortSelect({ entityType = 'items', libraryMediaTy
         highlightSelected={true}
         menuMaxHeight="none"
         usePortal
+        wrapText
       />
     </div>
   )

--- a/src/app/(main)/library/[library]/Toolbar.tsx
+++ b/src/app/(main)/library/[library]/Toolbar.tsx
@@ -53,8 +53,10 @@ export default function Toolbar() {
   const showBookshelfSummary = !isSearchPage && (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage) && itemCount !== null && !isSeriesDetailPage
   const showSeriesDetailSummary = !isSearchPage && isSeriesDetailPage && itemCount !== null
   const showSearchSummary = isSearchPage && searchQuery
-  const showToolbarExtras = isBookshelfPage && !isBookshelfEmpty && !isSeriesDetailPage && !isSearchPage && !isSelectionMode
+  // Wait for itemCount so the mobile count badge is present before flex filter/sort measure their widths
+  const showToolbarExtras = isBookshelfPage && itemCount !== null && !isBookshelfEmpty && !isSeriesDetailPage && !isSearchPage && !isSelectionMode
   const showContextMenu = contextMenuItems.length > 0 && (!isBookshelfEmpty || isSeriesDetailPage) && !isSearchPage && !isSelectionMode
+  const countBadgeLabel = itemName ? `${itemCount} ${itemName}` : String(itemCount)
 
   return (
     <div className="bg-bg box-shadow-toolbar relative z-40 h-10 w-full" cy-id="library-toolbar">
@@ -70,26 +72,46 @@ export default function Toolbar() {
         )}
 
         {showBookshelfSummary && (
-          <p className="text-foreground hidden text-base md:block">
-            <span>
-              {itemCount} {itemName}
-            </span>
-            {itemCountSupplement ? <span className="text-foreground-muted">{itemCountSupplement}</span> : null}
-          </p>
+          <>
+            <p className="text-foreground hidden text-base md:block">
+              <span>
+                {itemCount} {itemName}
+              </span>
+              {itemCountSupplement ? <span className="text-foreground-muted">{itemCountSupplement}</span> : null}
+            </p>
+            <div
+              className="bg-foreground/10 flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full px-1.5 font-mono text-sm md:hidden"
+              aria-label={countBadgeLabel}
+              title={countBadgeLabel}
+            >
+              {itemCount}
+            </div>
+          </>
         )}
 
         {showSeriesDetailSummary && (
-          <div className="hidden min-w-0 flex-1 md:block">
-            <p className="text-foreground truncate text-base" title={detailToolbarTitle ?? ''}>
-              <span>{detailToolbarTitle}</span>
-              <span className="text-foreground-muted"> {itemCount ? `(${itemCount})` : ''}</span>
-            </p>
-          </div>
+          <>
+            <div className="hidden min-w-0 flex-1 md:block">
+              <p className="text-foreground truncate text-base" title={detailToolbarTitle ?? ''}>
+                <span>{detailToolbarTitle}</span>
+                <span className="text-foreground-muted"> {itemCount ? `(${itemCount})` : ''}</span>
+              </p>
+            </div>
+            <div
+              className="bg-foreground/10 flex h-6 min-w-6 shrink-0 items-center justify-center rounded-full px-1.5 font-mono text-sm md:hidden"
+              aria-label={`${detailToolbarTitle} (${itemCount})`}
+              title={`${detailToolbarTitle} (${itemCount})`}
+            >
+              {itemCount}
+            </div>
+          </>
         )}
 
-        {!showSearchSummary && <div className="flex-grow" />}
+        {!showSearchSummary && <div className={showToolbarExtras ? 'hidden flex-grow md:block' : 'flex-grow'} />}
 
-        {showToolbarExtras && <div className="mr-2 flex items-center gap-4">{toolbarExtras}</div>}
+        {showToolbarExtras && (
+          <div className="ms-1.5 flex min-w-0 flex-1 items-center justify-end gap-1.5 md:ms-0 md:me-2 md:flex-none md:gap-4">{toolbarExtras}</div>
+        )}
 
         {showContextMenu && (
           <ContextMenuDropdown items={contextMenuItems} borderless usePortal size="small" autoWidth onAction={(args) => handleAction(args.action)} />

--- a/src/app/(main)/library/[library]/Toolbar.tsx
+++ b/src/app/(main)/library/[library]/Toolbar.tsx
@@ -23,6 +23,7 @@ export default function Toolbar() {
   const isBookshelfPage = BOOKSHELF_PAGE_PATTERNS.some((pattern) => pathname.endsWith(pattern))
   const isCollectionDetailPage = pathname.includes('/collection/')
   const isPlaylistDetailPage = pathname.includes('/playlist/')
+  const isNarratorsPage = pathname.endsWith('/narrators')
 
   const isBookshelfEmpty = itemCount === 0 && filterBy === 'all'
 
@@ -38,6 +39,8 @@ export default function Toolbar() {
     itemName = t('LabelPlaylists')
   } else if (pathname.endsWith('/authors')) {
     itemName = t('LabelAuthors')
+  } else if (isNarratorsPage) {
+    itemName = t('LabelNarrators')
   } else if (pathname.endsWith('/items') || isCollectionDetailPage || isPlaylistDetailPage) {
     if (library?.mediaType === 'podcast') {
       itemName = isPlaylistDetailPage ? t('LabelEpisodes') : t('LabelPodcasts')
@@ -50,7 +53,8 @@ export default function Toolbar() {
     onContextMenuAction?.(action)
   }
 
-  const showBookshelfSummary = !isSearchPage && (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage) && itemCount !== null && !isSeriesDetailPage
+  const showBookshelfSummary =
+    !isSearchPage && (isBookshelfPage || isCollectionDetailPage || isPlaylistDetailPage || isNarratorsPage) && itemCount !== null && !isSeriesDetailPage
   const showSeriesDetailSummary = !isSearchPage && isSeriesDetailPage && itemCount !== null
   const showSearchSummary = isSearchPage && searchQuery
   // Wait for itemCount so the mobile count badge is present before flex filter/sort measure their widths

--- a/src/app/(main)/library/[library]/Toolbar.tsx
+++ b/src/app/(main)/library/[library]/Toolbar.tsx
@@ -12,7 +12,8 @@ const BOOKSHELF_PAGE_PATTERNS = ['/items', '/series', '/collections', '/playlist
 export default function Toolbar() {
   const pathname = usePathname()
   const searchParams = useSearchParams()
-  const { library, itemCount, itemCountSupplement, detailToolbarTitle, contextMenuItems, onContextMenuAction, toolbarExtras, filterBy } = useLibrary()
+  const { library, itemCount, itemCountSupplement, detailToolbarTitle, contextMenuItems, onContextMenuAction, toolbarExtras, filterBy, seriesFilterBy } =
+    useLibrary()
   const { isSelectionMode } = useBookshelfSelection()
   const t = useTypeSafeTranslations()
 
@@ -25,13 +26,15 @@ export default function Toolbar() {
   const isPlaylistDetailPage = pathname.includes('/playlist/')
   const isNarratorsPage = pathname.endsWith('/narrators')
 
-  const isBookshelfEmpty = itemCount === 0 && filterBy === 'all'
+  const isSeriesPage = pathname.endsWith('/series')
+  const activeFilter = isSeriesPage ? seriesFilterBy : filterBy
+  const isBookshelfEmpty = itemCount === 0 && activeFilter === 'all'
 
   const isSeriesDetailPage = Boolean(detailToolbarTitle)
 
   // Determine item name based on current page and library type
   let itemName = ''
-  if (pathname.endsWith('/series')) {
+  if (isSeriesPage) {
     itemName = t('LabelSeries')
   } else if (pathname.endsWith('/collections')) {
     itemName = t('LabelCollections')

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
@@ -17,10 +17,8 @@ import { useMediaCardActions } from '@/components/widgets/media-card/useMediaCar
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { formatJsDate } from '@/lib/datefns'
 import { getEbookFormat } from '@/lib/ereader/ereaderEbook'
-import { buildBookQueueItem, getPodcastItemPagePlaybackParams } from '@/lib/playerQueue'
-import { PlayerState, type BookLibraryItem, type PodcastEpisode, type PodcastLibraryItem, type RssFeed } from '@/types/api'
+import { PlayerState, type BookLibraryItem, type PodcastLibraryItem, type RssFeed } from '@/types/api'
 import { useCallback, useMemo, useState } from 'react'
 
 interface LibraryItemActionButtonsProps {
@@ -29,8 +27,9 @@ interface LibraryItemActionButtonsProps {
   onOpenCoverEdit?: () => void
   /** Current RSS feed state (from useItemPageSocket + initial server data). */
   rssFeed?: RssFeed | null
-  /** Filtered/sorted podcast episodes from EpisodeTable (item-page Play). */
-  getPodcastEpisodesInOrder?: () => PodcastEpisode[]
+  showPlayButton: boolean
+  isItemPlaying: boolean
+  onPlay: () => void
 }
 
 export default function LibraryItemActionButtons({
@@ -38,15 +37,15 @@ export default function LibraryItemActionButtons({
   onEdit,
   onOpenCoverEdit,
   rssFeed = null,
-  getPodcastEpisodesInOrder
+  showPlayButton,
+  isItemPlaying,
+  onPlay
 }: LibraryItemActionButtonsProps) {
-  const { userCanUpdate, getMediaItemProgress, ereaderDevices, user, serverSettings } = useUser()
+  const { userCanUpdate, getMediaItemProgress, ereaderDevices } = useUser()
   const {
-    playItem,
     libraryItemIdStreaming,
     streamLibraryItem,
     isStreaming: isStreamingFn,
-    isPlaying: isPlayingFn,
     isStreamingFromDifferentLibrary,
     getIsMediaQueued,
     addItemToQueue,
@@ -67,13 +66,9 @@ export default function LibraryItemActionButtons({
   const isBook = libraryItem.mediaType === 'book'
   const bookMedia = !isPodcast ? libraryItem.media : null
   const podcastMedia = isPodcast ? libraryItem.media : null
-  const tracks = useMemo(() => (isBook ? (bookMedia?.tracks ?? []) : []), [isBook, bookMedia?.tracks])
   const podcastEpisodes = useMemo(() => (isPodcast ? (podcastMedia?.episodes ?? []) : []), [isPodcast, podcastMedia?.episodes])
   const ebookFormat = bookMedia ? getEbookFormat(bookMedia) : undefined
 
-  const showPlayButton = !libraryItem.isMissing && !libraryItem.isInvalid && (isPodcast ? podcastEpisodes.length > 0 : tracks.length > 0)
-  const isStreaming = isStreamingFn(libraryItem.id, null)
-  const isItemPlaying = isPlayingFn(libraryItem.id, null)
   const showQueueBtn = isBook && !!streamLibraryItem && !isStreamingFromDifferentLibrary(libraryItem.libraryId)
   const isQueued = getIsMediaQueued(libraryItem.id, null)
   const showReadButton = !!ebookFormat
@@ -124,51 +119,6 @@ export default function LibraryItemActionButtons({
     onOpenCoverEdit,
     playerControls
   })
-
-  const handlePlay = useCallback(() => {
-    if (isStreaming) {
-      playerControls.playPause()
-      return
-    }
-
-    if (isPodcast) {
-      const dateFormat = serverSettings.dateFormat ?? 'MM/dd/yyyy'
-      const podcastEpisodesInOrder = getPodcastEpisodesInOrder?.() ?? []
-      const playback = getPodcastItemPagePlaybackParams(
-        podcastEpisodesInOrder.length > 0 ? podcastEpisodesInOrder : podcastEpisodes,
-        libraryItem as PodcastLibraryItem,
-        user.mediaProgress,
-        (episode) =>
-          episode.publishedAt ? t('LabelPublishedDate', { 0: formatJsDate(new Date(episode.publishedAt), dateFormat) }) : t('LabelUnknownPublishDate')
-      )
-      if (!playback) return
-
-      void playItem({
-        libraryItem,
-        episodeId: playback.episodeId,
-        queueItems: playback.queueItems
-      })
-      return
-    }
-
-    const queueItem = buildBookQueueItem(libraryItem)
-    void playItem({
-      libraryItem,
-      episodeId: null,
-      queueItems: queueItem ? [queueItem] : []
-    })
-  }, [
-    isPodcast,
-    isStreaming,
-    libraryItem,
-    playItem,
-    playerControls,
-    podcastEpisodes,
-    getPodcastEpisodesInOrder,
-    serverSettings.dateFormat,
-    t,
-    user.mediaProgress
-  ])
 
   const handleQueueClick = useCallback(() => {
     if (isQueued) {
@@ -221,13 +171,7 @@ export default function LibraryItemActionButtons({
     <>
       <div className="flex flex-wrap items-center justify-start gap-1 pt-4">
         {showPlayButton && (
-          <Btn
-            onClick={handlePlay}
-            loading={playerLoadState === PlayerState.LOADING}
-            color="bg-success"
-            size="small"
-            className="mr-2 flex h-9 items-center px-4"
-          >
+          <Btn onClick={onPlay} loading={playerLoadState === PlayerState.LOADING} color="bg-success" size="small" className="mr-2 flex h-9 items-center px-4">
             <span className="material-symbols fill -ml-2 pr-1 text-2xl text-white">{isItemPlaying ? 'pause' : 'play_arrow'}</span>
             {isItemPlaying ? t('ButtonPause') : t('ButtonPlay')}
           </Btn>

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -19,11 +19,13 @@ import { useItemPageSocket } from '@/hooks/useItemPageSocket'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { mergeLibraryItemUpdate } from '@/lib/libraryItemUpdatedUtils'
+import { computeProgress } from '@/lib/mediaProgress'
 import { BookLibraryItem, BookMetadata, PodcastEpisode, PodcastLibraryItem, PodcastMetadata } from '@/types/api'
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import LibraryItemActionButtons from './LibraryItemActionButtons'
 import LibraryItemCover from './LibraryItemCover'
 import LibraryItemDetails from './LibraryItemDetails'
+import LibraryItemProgressPanel from './LibraryItemProgressPanel'
 import { useLibraryItemPagePlay } from './useLibraryItemPagePlay'
 
 interface LibraryItemClientProps {
@@ -61,6 +63,10 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
   const description = 'description' in metadata ? metadata.description : undefined
 
   const userProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
+  const showProgressPanel = useMemo(() => {
+    if (isPodcast || !userProgress) return false
+    return computeProgress({ progress: userProgress, useSeriesProgress: false }).percent > 0
+  }, [isPodcast, userProgress])
 
   const handleOpenEditModal = () => {
     setIsEditModalOpen(true)
@@ -173,16 +179,6 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
 
               <LibraryItemDetails libraryItem={libraryItem} />
 
-              <LibraryItemActionButtons
-                libraryItem={libraryItem}
-                onEdit={handleOpenEditModal}
-                onOpenCoverEdit={() => setIsCoverEditModalOpen(true)}
-                rssFeed={rssFeed ?? null}
-                showPlayButton={showPlayButton}
-                isItemPlaying={isItemPlaying}
-                onPlay={handlePlay}
-              />
-
               {/* Podcast episode downloads queue */}
               {episodeDownloadsQueued.length > 0 && (
                 <div className="bg-info/40 relative mx-auto mt-4 max-w-max rounded-md px-4 py-2 text-sm font-semibold text-gray-100 md:mx-0">
@@ -213,6 +209,24 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                   ))}
                 </div>
               )}
+
+              {showProgressPanel && userProgress && (
+                <LibraryItemProgressPanel
+                  libraryItem={libraryItem as BookLibraryItem}
+                  mediaProgress={userProgress}
+                  dateFormat={serverSettings?.dateFormat ?? 'MM/dd/yyyy'}
+                />
+              )}
+
+              <LibraryItemActionButtons
+                libraryItem={libraryItem}
+                onEdit={handleOpenEditModal}
+                onOpenCoverEdit={() => setIsCoverEditModalOpen(true)}
+                rssFeed={rssFeed ?? null}
+                showPlayButton={showPlayButton}
+                isItemPlaying={isItemPlaying}
+                onPlay={handlePlay}
+              />
 
               {description && <ExpandableHtml html={description} lineClamp={4} className="mt-6" />}
 

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -20,10 +20,11 @@ import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { mergeLibraryItemUpdate } from '@/lib/libraryItemUpdatedUtils'
 import { BookLibraryItem, BookMetadata, PodcastEpisode, PodcastLibraryItem, PodcastMetadata } from '@/types/api'
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import LibraryItemActionButtons from './LibraryItemActionButtons'
 import LibraryItemCover from './LibraryItemCover'
 import LibraryItemDetails from './LibraryItemDetails'
+import { useLibraryItemPagePlay } from './useLibraryItemPagePlay'
 
 interface LibraryItemClientProps {
   libraryItem: BookLibraryItem | PodcastLibraryItem
@@ -39,11 +40,12 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isCoverEditModalOpen, setIsCoverEditModalOpen] = useState(false)
   const [isClearQueueDialogOpen, setIsClearQueueDialogOpen] = useState(false)
-  const podcastEpisodesInOrderRef = useRef<PodcastEpisode[]>([])
+  const [podcastEpisodesInOrder, setPodcastEpisodesInOrder] = useState<PodcastEpisode[]>([])
   const handlePodcastEpisodesInOrderChange = useCallback((episodes: PodcastEpisode[]) => {
-    podcastEpisodesInOrderRef.current = episodes
+    setPodcastEpisodesInOrder(episodes)
   }, [])
-  const getPodcastEpisodesInOrder = useCallback(() => podcastEpisodesInOrderRef.current, [])
+
+  const { handlePlay, showPlayButton, isItemPlaying } = useLibraryItemPagePlay({ libraryItem, podcastEpisodesInOrder })
 
   useEffect(() => {
     setLibraryItem(initialLibraryItem)
@@ -121,7 +123,15 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
         <div className="mx-auto w-full max-w-6xl">
           <div className="flex flex-col gap-6 md:flex-row md:gap-8">
             <div className="mx-auto flex w-full max-w-72 flex-shrink-0 items-start justify-center md:w-52 md:max-w-52 md:justify-start">
-              <LibraryItemCover libraryItem={libraryItem} canUpdate={userCanUpdate} mediaProgress={userProgress} onEdit={() => setIsCoverEditModalOpen(true)} />
+              <LibraryItemCover
+                libraryItem={libraryItem}
+                canUpdate={userCanUpdate}
+                mediaProgress={userProgress}
+                onEdit={() => setIsCoverEditModalOpen(true)}
+                showPlayButton={showPlayButton}
+                isItemPlaying={isItemPlaying}
+                onPlay={handlePlay}
+              />
             </div>
             <div className="flex-1">
               <div className="flex flex-col gap-1">
@@ -168,7 +178,9 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                 onEdit={handleOpenEditModal}
                 onOpenCoverEdit={() => setIsCoverEditModalOpen(true)}
                 rssFeed={rssFeed ?? null}
-                getPodcastEpisodesInOrder={getPodcastEpisodesInOrder}
+                showPlayButton={showPlayButton}
+                isItemPlaying={isItemPlaying}
+                onPlay={handlePlay}
               />
 
               {/* Podcast episode downloads queue */}

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemCover.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemCover.tsx
@@ -20,9 +20,21 @@ interface LibraryItemCoverProps {
   onEdit?: () => void
   mediaProgress?: MediaProgress | null
   className?: string
+  showPlayButton?: boolean
+  isItemPlaying?: boolean
+  onPlay?: () => void
 }
 
-export default function LibraryItemCover({ libraryItem, canUpdate = false, className, mediaProgress, onEdit }: LibraryItemCoverProps) {
+export default function LibraryItemCover({
+  libraryItem,
+  canUpdate = false,
+  className,
+  mediaProgress,
+  onEdit,
+  showPlayButton = false,
+  isItemPlaying = false,
+  onPlay
+}: LibraryItemCoverProps) {
   const coverAspectRatio = useBookCoverAspectRatio()
   const t = useTypeSafeTranslations()
   const [isHovering, setIsHovering] = useState(false)
@@ -113,20 +125,22 @@ export default function LibraryItemCover({ libraryItem, canUpdate = false, class
             )}
           >
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-              <IconBtn
-                borderless
-                outlined={false}
-                className="pointer-events-auto transform text-gray-200 duration-200 hover:scale-110 hover:text-white"
-                style={{ fontSize: '4rem' }}
-                onClick={(e) => {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  // Implementation pending
-                }}
-                ariaLabel={t('ButtonPlay')}
-              >
-                play_arrow
-              </IconBtn>
+              {showPlayButton && onPlay && (
+                <IconBtn
+                  borderless
+                  outlined={false}
+                  className="pointer-events-auto transform text-gray-200 duration-200 hover:scale-110 hover:text-white"
+                  style={{ fontSize: '4rem' }}
+                  onClick={(e) => {
+                    e.preventDefault()
+                    e.stopPropagation()
+                    onPlay()
+                  }}
+                  ariaLabel={isItemPlaying ? t('ButtonPause') : t('ButtonPlay')}
+                >
+                  {isItemPlaying ? 'pause' : 'play_arrow'}
+                </IconBtn>
+              )}
             </div>
 
             {canUpdate && onEdit && (

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemProgressPanel.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemProgressPanel.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { deleteMediaProgressAction } from '@/app/actions/mediaActions'
+import ButtonBase from '@/components/ui/ButtonBase'
+import ConfirmDialog from '@/components/widgets/ConfirmDialog'
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { formatJsDate } from '@/lib/datefns'
+import { formatDuration } from '@/lib/formatDuration'
+import { computeProgress } from '@/lib/mediaProgress'
+import type { BookLibraryItem, MediaProgress } from '@/types/api'
+import { useCallback, useMemo, useState } from 'react'
+
+interface LibraryItemProgressPanelProps {
+  libraryItem: BookLibraryItem
+  mediaProgress: MediaProgress
+  dateFormat: string
+}
+
+export default function LibraryItemProgressPanel({ libraryItem, mediaProgress, dateFormat }: LibraryItemProgressPanelProps) {
+  const t = useTypeSafeTranslations()
+  const { showToast } = useGlobalToast()
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+
+  const { percent, startedAt, finishedAt } = useMemo(() => computeProgress({ progress: mediaProgress, useSeriesProgress: false }), [mediaProgress])
+
+  const useEbookProgress = !mediaProgress.progress && mediaProgress.ebookProgress > 0
+
+  const timeRemainingLabel = useMemo(() => {
+    if (percent >= 1 || useEbookProgress) return null
+    const duration = mediaProgress.duration || libraryItem.media.duration || 0
+    const remaining = Math.max(0, duration - mediaProgress.currentTime)
+    return t('LabelTimeRemaining', { 0: formatDuration(remaining, t) })
+  }, [percent, useEbookProgress, mediaProgress.duration, mediaProgress.currentTime, libraryItem.media.duration, t])
+
+  const handleConfirmReset = useCallback(async () => {
+    setIsConfirmOpen(false)
+    try {
+      await deleteMediaProgressAction(mediaProgress.id)
+    } catch (error) {
+      console.error('Progress reset failed', error)
+      showToast(t('ToastFailedToUpdate'), { type: 'error' })
+    }
+  }, [mediaProgress.id, showToast, t])
+
+  if (percent <= 0) {
+    return null
+  }
+
+  return (
+    <>
+      <div
+        role="region"
+        aria-label={t('LabelYourProgress')}
+        className="bg-primary relative mt-4 max-w-max rounded-md px-4 py-2 text-sm font-semibold text-gray-100"
+      >
+        {percent < 1 ? (
+          <p className="leading-6">
+            {t('LabelYourProgress')}: {Math.round(percent * 100)}%
+          </p>
+        ) : (
+          <p className="text-xs">
+            {t('LabelFinished')} {finishedAt ? formatJsDate(new Date(finishedAt), dateFormat) : ''}
+          </p>
+        )}
+        {timeRemainingLabel ? <p className="text-xs text-gray-200">{timeRemainingLabel}</p> : null}
+        {startedAt ? (
+          <p className="pt-1 text-xs text-gray-400">
+            {t('LabelStarted')} {formatJsDate(new Date(startedAt), dateFormat)}
+          </p>
+        ) : null}
+
+        <ButtonBase
+          borderless
+          size="custom"
+          ariaLabel={t('ButtonResetProgress')}
+          className="group absolute top-1 right-1 z-10 size-9 shrink-0 translate-x-1/2 -translate-y-1/2"
+          onClick={() => setIsConfirmOpen(true)}
+        >
+          <span className="bg-bg border-primary group-hover:bg-error flex size-5 items-center justify-center rounded-full border p-1">
+            <span className="material-symbols text-sm" aria-hidden>
+              close
+            </span>
+          </span>
+        </ButtonBase>
+      </div>
+
+      <ConfirmDialog
+        isOpen={isConfirmOpen}
+        title={t('ButtonReset')}
+        message={t('MessageConfirmResetProgress')}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={handleConfirmReset}
+      />
+    </>
+  )
+}

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemProgressPanel.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemProgressPanel.tsx
@@ -52,7 +52,7 @@ export default function LibraryItemProgressPanel({ libraryItem, mediaProgress, d
       <div
         role="region"
         aria-label={t('LabelYourProgress')}
-        className="bg-primary relative mt-4 max-w-max rounded-md px-4 py-2 text-sm font-semibold text-gray-100"
+        className="bg-primary border-border text-foreground relative mt-4 max-w-max rounded-md border px-4 py-2 text-sm font-semibold"
       >
         {percent < 1 ? (
           <p className="leading-6">
@@ -63,9 +63,9 @@ export default function LibraryItemProgressPanel({ libraryItem, mediaProgress, d
             {t('LabelFinished')} {finishedAt ? formatJsDate(new Date(finishedAt), dateFormat) : ''}
           </p>
         )}
-        {timeRemainingLabel ? <p className="text-xs text-gray-200">{timeRemainingLabel}</p> : null}
+        {timeRemainingLabel ? <p className="text-foreground-muted text-xs">{timeRemainingLabel}</p> : null}
         {startedAt ? (
-          <p className="pt-1 text-xs text-gray-400">
+          <p className="text-foreground-subdued pt-1 text-xs">
             {t('LabelStarted')} {formatJsDate(new Date(startedAt), dateFormat)}
           </p>
         ) : null}

--- a/src/app/(main)/library/[library]/item/[item]/useLibraryItemPagePlay.ts
+++ b/src/app/(main)/library/[library]/item/[item]/useLibraryItemPagePlay.ts
@@ -1,0 +1,71 @@
+'use client'
+
+import { useGlobalToast } from '@/contexts/ToastContext'
+import { useMediaContext } from '@/contexts/MediaContext'
+import { useUser } from '@/contexts/UserContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { formatJsDate } from '@/lib/datefns'
+import { buildBookQueueItem, getPodcastItemPagePlaybackParams } from '@/lib/playerQueue'
+import type { BookLibraryItem, PodcastEpisode, PodcastLibraryItem } from '@/types/api'
+import { useCallback, useMemo } from 'react'
+
+interface UseLibraryItemPagePlayOptions {
+  libraryItem: BookLibraryItem | PodcastLibraryItem
+  /** Filtered/sorted episodes from EpisodeTable (item-page Play). */
+  podcastEpisodesInOrder?: PodcastEpisode[]
+}
+
+export function useLibraryItemPagePlay({ libraryItem, podcastEpisodesInOrder = [] }: UseLibraryItemPagePlayOptions) {
+  const { user, serverSettings } = useUser()
+  const { playItem, isStreaming: isStreamingFn, isPlaying: isPlayingFn, playerControls } = useMediaContext()
+  const { showToast } = useGlobalToast()
+  const t = useTypeSafeTranslations()
+
+  const isPodcast = libraryItem.mediaType === 'podcast'
+  const isBook = libraryItem.mediaType === 'book'
+  const bookMedia = !isPodcast ? libraryItem.media : null
+  const podcastMedia = isPodcast ? libraryItem.media : null
+  const tracks = useMemo(() => (isBook ? (bookMedia?.tracks ?? []) : []), [isBook, bookMedia?.tracks])
+  const podcastEpisodes = useMemo(() => (isPodcast ? (podcastMedia?.episodes ?? []) : []), [isPodcast, podcastMedia?.episodes])
+
+  const isStreaming = isStreamingFn(libraryItem.id, null)
+  const isItemPlaying = isPlayingFn(libraryItem.id, null)
+
+  const showPlayButton = !libraryItem.isMissing && !libraryItem.isInvalid && (isPodcast ? podcastEpisodes.length > 0 : tracks.length > 0)
+
+  const handlePlay = useCallback(() => {
+    if (isStreaming) {
+      playerControls.playPause()
+      return
+    }
+
+    if (isPodcast) {
+      if (podcastEpisodesInOrder.length === 0) {
+        showToast(t('MessageNoEpisodesToPlay'), { type: 'info' })
+        return
+      }
+
+      const dateFormat = serverSettings.dateFormat ?? 'MM/dd/yyyy'
+      const playback = getPodcastItemPagePlaybackParams(podcastEpisodesInOrder, libraryItem as PodcastLibraryItem, user.mediaProgress, (episode) =>
+        episode.publishedAt ? t('LabelPublishedDate', { 0: formatJsDate(new Date(episode.publishedAt), dateFormat) }) : t('LabelUnknownPublishDate')
+      )
+      if (!playback) return
+
+      void playItem({
+        libraryItem,
+        episodeId: playback.episodeId,
+        queueItems: playback.queueItems
+      })
+      return
+    }
+
+    const queueItem = buildBookQueueItem(libraryItem)
+    void playItem({
+      libraryItem,
+      episodeId: null,
+      queueItems: queueItem ? [queueItem] : []
+    })
+  }, [isPodcast, isStreaming, libraryItem, playItem, playerControls, podcastEpisodesInOrder, serverSettings.dateFormat, showToast, t, user.mediaProgress])
+
+  return { handlePlay, showPlayButton, isItemPlaying }
+}

--- a/src/app/(main)/library/[library]/playlist/[playlist]/PlaylistClient.tsx
+++ b/src/app/(main)/library/[library]/playlist/[playlist]/PlaylistClient.tsx
@@ -13,6 +13,7 @@ import { useBookCoverAspectRatio, useLibrary } from '@/contexts/LibraryContext'
 import { useMediaContext } from '@/contexts/MediaContext'
 import { usePrimaryInputCanHover } from '@/hooks/useMediaQuery'
 import { useUser } from '@/contexts/UserContext'
+import { useSocketEvent } from '@/contexts/SocketContext'
 import { usePlaylistDisplayMode } from '@/hooks/usePlaylistDisplayMode'
 import { usePlaylistItems } from '@/hooks/usePlaylistItems'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
@@ -36,7 +37,6 @@ export default function PlaylistClient({ playlist }: PlaylistClientProps) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const { displayMode, toggleDisplayMode } = usePlaylistDisplayMode(library.mediaType)
-  const { orderedItems, setOrderedItems, handleItemRemoved } = usePlaylistItems(playlist)
   const isListMode = displayMode === 'list'
   const alternateViewLabel = isListMode ? t('LabelCollectionBookshelfView') : t('LabelCollectionListView')
   const coverWidth = 120
@@ -52,6 +52,20 @@ export default function PlaylistClient({ playlist }: PlaylistClientProps) {
   const handlePlaylistDeleted = useCallback(() => {
     router.push(`/library/${playlist.libraryId}/playlists`)
   }, [playlist.libraryId, router])
+
+  const { orderedItems, setOrderedItems, handleItemRemoved } = usePlaylistItems(playlist)
+
+  useSocketEvent<Playlist>(
+    'playlist_removed',
+    useCallback(
+      (removed) => {
+        if (removed.id === playlist.id) {
+          handlePlaylistDeleted()
+        }
+      },
+      [handlePlaylistDeleted, playlist.id]
+    )
+  )
 
   const { processing, confirmState, closeConfirm, handleMoreAction, moreMenuItems } = usePlaylistCardActions({
     playlist,

--- a/src/app/(main)/settings/SettingsClient.tsx
+++ b/src/app/(main)/settings/SettingsClient.tsx
@@ -5,29 +5,24 @@ import Dropdown from '@/components/ui/Dropdown'
 import { MultiSelect, MultiSelectItem } from '@/components/ui/MultiSelect'
 import LanguageDropdown from '@/components/widgets/LanguageDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatJsDate } from '@/lib/datefns'
 import { BookshelfView, ServerSettings } from '@/types/api'
 import { useRouter } from 'next/navigation'
-import { useMemo, useState, useTransition } from 'react'
-import type { UpdateServerSettingsApiResponse, UpdateSortingPrefixesApiResponse } from './actions'
+import { useEffect, useMemo, useState, useTransition } from 'react'
+import { updateServerSettings, updateSortingPrefixes } from './actions'
 import { dateFormats, timeFormats } from './settingsConstants'
 import SettingsToggleSwitch from './SettingsToggleSwitch'
 
-interface SettingsClientProps {
-  serverSettings: ServerSettings
-  updateServerSettings: (settingsUpdatePayload: Partial<ServerSettings>) => Promise<UpdateServerSettingsApiResponse>
-  updateSortingPrefixes: (sortingPrefixes: string[]) => Promise<UpdateSortingPrefixesApiResponse>
-}
-
-export default function SettingsClient(props: SettingsClientProps) {
-  const { serverSettings: initialServerSettings, updateServerSettings, updateSortingPrefixes } = props
+export default function SettingsClient() {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
-  const [serverSettings, setServerSettings] = useState(initialServerSettings)
-  const [sortingPrefixes, setSortingPrefixes] = useState<string[]>(initialServerSettings.sortingPrefixes || [])
   const { showToast } = useGlobalToast()
+  const { serverSettings, mergeServerSettings } = useUser()
+
+  const [sortingPrefixes, setSortingPrefixes] = useState<string[]>(serverSettings.sortingPrefixes || [])
 
   const corsAllowedItems = useMemo(() => {
     return (
@@ -50,6 +45,11 @@ export default function SettingsClient(props: SettingsClientProps) {
     return sortingPrefixes.some((p) => !serverPrefixes.includes(p)) || serverPrefixes.some((p) => !sortingPrefixes.includes(p))
   }, [sortingPrefixes, serverSettings?.sortingPrefixes])
 
+  useEffect(() => {
+    if (hasPrefixesChanged) return
+    setSortingPrefixes(serverSettings.sortingPrefixes || [])
+  }, [serverSettings.sortingPrefixes, hasPrefixesChanged])
+
   const exampleDateFormat = useMemo(() => {
     if (!serverSettings?.dateFormat) {
       return ''
@@ -65,20 +65,18 @@ export default function SettingsClient(props: SettingsClientProps) {
   }, [serverSettings?.timeFormat])
 
   const handleSaveSettings = (updatedSettings: ServerSettings) => {
-    // Optimistically update the UI
-    setServerSettings(updatedSettings)
+    const previousSettings = serverSettings
 
-    // Send the update to the server
+    // Optimistic update: toggles and app chrome (e.g. Chromecast) react before PATCH completes
+    mergeServerSettings(updatedSettings)
+
     startTransition(async () => {
       try {
         const response = await updateServerSettings(updatedSettings)
-        if (response?.serverSettings) {
-          // Update with the actual server response
-          setServerSettings(response.serverSettings)
-        }
+        mergeServerSettings(response?.serverSettings)
       } catch (error) {
-        // Revert on error
-        setServerSettings(serverSettings)
+        // Revert optimistic update
+        mergeServerSettings(previousSettings)
         console.error('Failed to update server settings:', error)
       }
     })
@@ -97,18 +95,15 @@ export default function SettingsClient(props: SettingsClientProps) {
   }
 
   const handleLanguageChanged = async (language: string) => {
+    const previousSettings = serverSettings
     const updatedSettings = { ...serverSettings, language } as ServerSettings
 
     try {
-      // Optimistically update the UI
-      setServerSettings(updatedSettings)
+      // Optimistic update until PATCH and cookie/refresh complete
+      mergeServerSettings(updatedSettings)
 
-      // Update server settings
       const response = await updateServerSettings(updatedSettings)
-      if (response.serverSettings) {
-        // Update with the actual server response
-        setServerSettings(response.serverSettings)
-      }
+      mergeServerSettings(response?.serverSettings)
 
       // Set the language cookie
       await fetch('/internal-api/set-language', {
@@ -123,8 +118,8 @@ export default function SettingsClient(props: SettingsClientProps) {
       router.refresh()
     } catch (error) {
       console.error('Failed to update language:', error)
-      // Revert on error
-      setServerSettings(serverSettings)
+      // Revert optimistic update
+      mergeServerSettings(previousSettings)
       showToast(t('ToastFailedToUpdate'), { type: 'error' })
     }
   }
@@ -144,11 +139,11 @@ export default function SettingsClient(props: SettingsClientProps) {
     startTransition(async () => {
       try {
         const response = await updateSortingPrefixes(prefixes)
+        mergeServerSettings(response?.serverSettings)
         if (response.rowsUpdated) {
           const rowsUpdated = response.rowsUpdated.toString()
           showToast(t('ToastSortingPrefixesUpdateSuccess', { 0: rowsUpdated }), { type: 'success' })
           if (response.serverSettings) {
-            setServerSettings(response.serverSettings)
             setSortingPrefixes(response.serverSettings.sortingPrefixes || [])
           }
         }

--- a/src/app/(main)/settings/actions.ts
+++ b/src/app/(main)/settings/actions.ts
@@ -1,3 +1,5 @@
+'use server'
+
 import { apiRequest } from '@/lib/api'
 import { ServerSettings } from '@/types/api'
 import { updateTag } from 'next/cache'
@@ -11,10 +13,7 @@ export type UpdateSortingPrefixesApiResponse = {
   serverSettings: ServerSettings
 }
 
-// Server Action
 export async function updateServerSettings(settingsUpdatePayload: Partial<ServerSettings>): Promise<UpdateServerSettingsApiResponse> {
-  'use server'
-
   const response = await apiRequest<UpdateServerSettingsApiResponse>('/api/settings', {
     method: 'PATCH',
     body: JSON.stringify(settingsUpdatePayload)
@@ -28,10 +27,7 @@ export async function updateServerSettings(settingsUpdatePayload: Partial<Server
   return response
 }
 
-// Server Action for updating sorting prefixes
 export async function updateSortingPrefixes(sortingPrefixes: string[]): Promise<UpdateSortingPrefixesApiResponse> {
-  'use server'
-
   const response = await apiRequest<UpdateSortingPrefixesApiResponse>('/api/sorting-prefixes', {
     method: 'PATCH',
     body: JSON.stringify({ sortingPrefixes })
@@ -46,16 +42,12 @@ export async function updateSortingPrefixes(sortingPrefixes: string[]): Promise<
 }
 
 export async function purgeCache(): Promise<void> {
-  'use server'
-
   await apiRequest<void>('/api/cache/purge', {
     method: 'POST'
   })
 }
 
 export async function purgeItemsCache(): Promise<void> {
-  'use server'
-
   await apiRequest<void>('/api/cache/items/purge', {
     method: 'POST'
   })

--- a/src/app/(main)/settings/backups/BackupsClient.tsx
+++ b/src/app/(main)/settings/backups/BackupsClient.tsx
@@ -20,7 +20,7 @@ import { bytesPretty } from '@/lib/string'
 import { Backup, GetBackupsResponse, ServerSettings } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
-import { UpdateServerSettingsApiResponse } from '../actions'
+import { updateServerSettings } from '../actions'
 import SettingsContent from '../SettingsContent'
 import SettingsToggleSwitch from '../SettingsToggleSwitch'
 import { applyBackup, createBackup, deleteBackup } from './actions'
@@ -33,11 +33,10 @@ const LEGACY_BACKUP_UNSUPPORTED_HINT = 'This backup was created with an old vers
 
 interface BackupsClientProps {
   backupResponse: GetBackupsResponse
-  updateServerSettings: (settingsUpdatePayload: Partial<ServerSettings>) => Promise<UpdateServerSettingsApiResponse>
   appliedBackupToast?: boolean
 }
 
-export default function BackupsClient({ backupResponse, updateServerSettings, appliedBackupToast = false }: BackupsClientProps) {
+export default function BackupsClient({ backupResponse, appliedBackupToast = false }: BackupsClientProps) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -52,7 +51,7 @@ export default function BackupsClient({ backupResponse, updateServerSettings, ap
   const [deletingBackupId, setDeletingBackupId] = useState<string | null>(null)
   const backupPendingDeleteRef = useRef<Backup | null>(null)
   const { showToast } = useGlobalToast()
-  const { serverSettings } = useUser()
+  const { serverSettings, mergeServerSettings } = useUser()
 
   const backups = useMemo(() => {
     return [...backupResponse.backups].sort((a, b) => b.createdAt - a.createdAt)
@@ -64,6 +63,11 @@ export default function BackupsClient({ backupResponse, updateServerSettings, ap
   const [maxBackupSize, setMaxBackupSize] = useState(serverSettings.maxBackupSize ? String(serverSettings.maxBackupSize) : '')
 
   const backupSchedule = serverSettings.backupSchedule // cron expression or false if disabled
+
+  useEffect(() => {
+    setBackupsToKeep(serverSettings.backupsToKeep ? String(serverSettings.backupsToKeep) : '')
+    setMaxBackupSize(serverSettings.maxBackupSize ? String(serverSettings.maxBackupSize) : '')
+  }, [serverSettings.backupsToKeep, serverSettings.maxBackupSize])
 
   useEffect(() => {
     if (!appliedBackupToast) return
@@ -81,6 +85,7 @@ export default function BackupsClient({ backupResponse, updateServerSettings, ap
 
     startTransition(async () => {
       const response = await updateServerSettings(settingsUpdatePayload)
+      mergeServerSettings(response?.serverSettings)
       if (!response?.serverSettings) {
         console.error('Failed to update server settings')
         showToast(t('ToastFailedToUpdate'), { type: 'error' })

--- a/src/app/(main)/settings/backups/page.tsx
+++ b/src/app/(main)/settings/backups/page.tsx
@@ -1,5 +1,4 @@
 import { getBackups, getData } from '@/lib/api'
-import { updateServerSettings } from '../actions'
 import BackupsClient from './BackupsClient'
 
 export const dynamic = 'force-dynamic'
@@ -12,5 +11,5 @@ export default async function BackupsPage({ searchParams }: { searchParams: Prom
     return <div>Error loading backups</div>
   }
 
-  return <BackupsClient backupResponse={backupsResponse} updateServerSettings={updateServerSettings} appliedBackupToast={sp.backup === '1'} />
+  return <BackupsClient backupResponse={backupsResponse} appliedBackupToast={sp.backup === '1'} />
 }

--- a/src/app/(main)/settings/logs/LogsClient.tsx
+++ b/src/app/(main)/settings/logs/LogsClient.tsx
@@ -1,23 +1,21 @@
 'use client'
 
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { LoggerDataLog, ServerSettings } from '@/types/api'
-import type { UpdateServerSettingsApiResponse } from '../actions'
+import { LoggerDataLog } from '@/types/api'
 import SettingsContent from '../SettingsContent'
 import LogsContainer from './LogsContainer'
 
 interface LogsClientProps {
   currentDailyLogs: LoggerDataLog[]
   logLevel?: number
-  updateServerSettings: (settingsUpdatePayload: Partial<ServerSettings>) => Promise<UpdateServerSettingsApiResponse>
 }
 
-export default function LogsClient({ currentDailyLogs, logLevel, updateServerSettings }: LogsClientProps) {
+export default function LogsClient({ currentDailyLogs, logLevel }: LogsClientProps) {
   const t = useTypeSafeTranslations()
   return (
     <SettingsContent title={t('HeaderLogs')} moreInfoUrl="https://www.audiobookshelf.org/guides/server_logs">
       <div className="py-4">
-        <LogsContainer currentDailyLogs={currentDailyLogs} logLevel={logLevel} updateServerSettings={updateServerSettings} />
+        <LogsContainer currentDailyLogs={currentDailyLogs} logLevel={logLevel} />
       </div>
     </SettingsContent>
   )

--- a/src/app/(main)/settings/logs/LogsContainer.tsx
+++ b/src/app/(main)/settings/logs/LogsContainer.tsx
@@ -3,10 +3,11 @@
 import Dropdown, { DropdownItem } from '@/components/ui/Dropdown'
 import TextInput from '@/components/ui/TextInput'
 import { useSocketEmit, useSocketEvent } from '@/contexts/SocketContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { LoggerDataLog, LogLevel, ServerSettings } from '@/types/api'
+import { LoggerDataLog, LogLevel } from '@/types/api'
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
-import type { UpdateServerSettingsApiResponse } from '../actions'
+import { updateServerSettings } from '../actions'
 
 const MAX_LOGS = 5000
 const TRIM_AMOUNT = 1000 // Remove this many logs when we hit the max
@@ -21,7 +22,6 @@ const LOG_LEVEL_NAMES: Record<number, string> = {
 interface LogsContainerProps {
   currentDailyLogs: LoggerDataLog[]
   logLevel?: number
-  updateServerSettings: (settingsUpdatePayload: Partial<ServerSettings>) => Promise<UpdateServerSettingsApiResponse>
 }
 
 function getLogLevelColor(levelName: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'TRACE'): string {
@@ -39,8 +39,9 @@ function getLogLevelColor(levelName: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'TRAC
   }
 }
 
-export default function LogsContainer({ currentDailyLogs, logLevel: initialLogLevel, updateServerSettings }: LogsContainerProps) {
+export default function LogsContainer({ currentDailyLogs, logLevel: initialLogLevel }: LogsContainerProps) {
   const t = useTypeSafeTranslations()
+  const { mergeServerSettings } = useUser()
   const [logs, setLogs] = useState<LoggerDataLog[]>(currentDailyLogs)
   const [searchQuery, setSearchQuery] = useState('')
   const [logLevel, setLogLevel] = useState<number>(initialLogLevel ?? LogLevel.INFO)
@@ -94,7 +95,8 @@ export default function LogsContainer({ currentDailyLogs, logLevel: initialLogLe
 
     startTransition(async () => {
       try {
-        await updateServerSettings({ logLevel: newLevel as LogLevel })
+        const response = await updateServerSettings({ logLevel: newLevel as LogLevel })
+        mergeServerSettings(response?.serverSettings)
       } catch (error) {
         setLogLevel(logLevel)
         console.error('Failed to update log level:', error)

--- a/src/app/(main)/settings/logs/page.tsx
+++ b/src/app/(main)/settings/logs/page.tsx
@@ -1,5 +1,4 @@
 import { getCurrentUser, getData, getLoggerData } from '@/lib/api'
-import { updateServerSettings } from '../actions'
 import LogsClient from './LogsClient'
 
 export const dynamic = 'force-dynamic'
@@ -9,5 +8,5 @@ export default async function LogsPage() {
   const currentDailyLogs = loggerDataResponse?.currentDailyLogs || []
   const logLevel = currentUser?.serverSettings?.logLevel
 
-  return <LogsClient currentDailyLogs={currentDailyLogs} logLevel={logLevel} updateServerSettings={updateServerSettings} />
+  return <LogsClient currentDailyLogs={currentDailyLogs} logLevel={logLevel} />
 }

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -1,7 +1,6 @@
 import { getCurrentUser, getData } from '@/lib/api'
 import { getTypeSafeTranslations } from '@/lib/getTypeSafeTranslations'
-import { ServerSettings } from '@/types/api'
-import { purgeCache, purgeItemsCache, updateServerSettings, updateSortingPrefixes } from './actions'
+import { purgeCache, purgeItemsCache } from './actions'
 import SettingsCachePurge from './SettingsCachePurge'
 import SettingsClient from './SettingsClient'
 import SettingsContent from './SettingsContent'
@@ -23,11 +22,7 @@ export default async function SettingsPage() {
   return (
     <>
       <SettingsContent title={t('HeaderSettings')}>
-        <SettingsClient
-          serverSettings={serverSettings as ServerSettings}
-          updateServerSettings={updateServerSettings}
-          updateSortingPrefixes={updateSortingPrefixes}
-        />
+        <SettingsClient />
       </SettingsContent>
       <SettingsCachePurge purgeCache={purgeCache} purgeItemsCache={purgeItemsCache} />
       <SettingsFooter />

--- a/src/app/actions/mediaActions.ts
+++ b/src/app/actions/mediaActions.ts
@@ -12,6 +12,10 @@ export async function toggleFinishedAction(libraryItemId: string, params: { isFi
   return api.updateMediaFinished(libraryItemId, params)
 }
 
+export async function deleteMediaProgressAction(progressId: string) {
+  return api.deleteMediaProgress(progressId)
+}
+
 export async function batchUpdateMediaFinishedAction(payload: { libraryItemId: string; episodeId?: string; isFinished: boolean }[]) {
   return api.batchUpdateMediaFinished(payload)
 }

--- a/src/components/player/PlayerControls.tsx
+++ b/src/components/player/PlayerControls.tsx
@@ -15,7 +15,7 @@ interface PlayerControlsProps {
 /** Desktop layout: transport centered with secondary toolbar on the right. */
 export default function PlayerControls({ playerHandler, streamLibraryItem }: PlayerControlsProps) {
   const controlsState = usePlayerControlsState(playerHandler, streamLibraryItem)
-  console.log('controlsState', controlsState)
+
   return (
     <>
       <div className="mt-10 flex items-center">

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -41,6 +41,8 @@ interface DropdownProps {
   hideSelectedInMenu?: boolean
   /** Use portal to render the dropdown menu. Useful for avoiding clipping issues. */
   usePortal?: boolean
+  /** When true, menu item labels wrap up to two lines then truncate */
+  wrapText?: boolean
 }
 
 /**
@@ -61,7 +63,8 @@ export default function Dropdown({
   highlightSelected = false,
   displayText,
   hideSelectedInMenu = false,
-  usePortal = false
+  usePortal = false,
+  wrapText = false
 }: DropdownProps) {
   const [showMenu, setShowMenu] = useState(false)
   const [focusedIndex, setFocusedIndex] = useState(-1)
@@ -481,6 +484,7 @@ export default function Dropdown({
         isItemSelected={(item) => item.value === value}
         usePortal={usePortal}
         triggerRef={controlWrapperRef as React.RefObject<HTMLElement>}
+        wrapText={wrapText}
       />
     </div>
   )

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -24,13 +24,17 @@ export interface DropdownMenuItem {
   subitems?: DropdownMenuSubitem[]
 }
 
+const PREFERRED_SUBMENU_WIDTH = 192
+
 /**
- * Renders label + optional subtext as one truncating line
+ * Renders label + optional subtext as one truncating line, or up to two wrapping lines when `wrapText` is set
  */
-export function DropdownItemLabel({ text, subtext, className }: { text: string; subtext?: string; className?: string }) {
+export function DropdownItemLabel({ text, subtext, className, wrapText = false }: { text: string; subtext?: string; className?: string; wrapText?: boolean }) {
+  const textOverflowClass = wrapText ? 'line-clamp-2 break-words whitespace-normal' : 'truncate'
+
   if (!subtext) {
     return (
-      <span className={mergeClasses('block min-w-0 truncate font-sans', className)} title={text}>
+      <span className={mergeClasses('block min-w-0 font-sans', textOverflowClass, className)} title={text}>
         {text}
       </span>
     )
@@ -39,7 +43,7 @@ export function DropdownItemLabel({ text, subtext, className }: { text: string; 
   const fullLabel = `${text}: ${subtext}`
 
   return (
-    <span className={mergeClasses('block min-w-0 truncate font-sans', className)} title={fullLabel}>
+    <span className={mergeClasses('block min-w-0 font-sans', textOverflowClass, className)} title={fullLabel}>
       <span className="font-semibold">{text}</span>
       <span>:&nbsp;</span>
       <span className="text-foreground-subdued font-normal">{subtext}</span>
@@ -58,9 +62,9 @@ function DropdownSubmenu({
   onSubitemClick,
   onMouseOver,
   onMouseLeave,
-  openLeft,
   referenceElement,
   filterText,
+  wrapText = false,
   t
 }: {
   subitems: DropdownMenuSubitem[]
@@ -70,46 +74,51 @@ function DropdownSubmenu({
   onSubitemClick?: (subitem: DropdownMenuSubitem) => void
   onMouseOver: () => void
   onMouseLeave: () => void
-  openLeft: boolean
   referenceElement: HTMLElement | null
   filterText: string
+  wrapText?: boolean
   t: ReturnType<typeof useTypeSafeTranslations>
 }) {
   const submenuRef = useRef<HTMLUListElement>(null)
 
-  const [scrollbarOffset, setScrollbarOffset] = useState(0)
-  const [maxHeight, setMaxHeight] = useState<number | undefined>(undefined)
+  const [parentScrollbarWidth, setParentScrollbarWidth] = useState(0)
+  const [floatingSize, setFloatingSize] = useState<{ width: number; maxHeight: number } | null>(null)
 
-  // Calculate scrollbar offset to prevent overlapping
+  // Parent menu scrollbar width — applied as offset only when the submenu opens to the right
   useLayoutEffect(() => {
     if (referenceElement?.parentElement) {
       const parent = referenceElement.parentElement
-      const width = parent.offsetWidth - parent.clientWidth
-      // Only apply offset if opening to the right and scrollbar is present
-      if (width > 0 && !openLeft) {
-        setScrollbarOffset(width)
-      } else {
-        setScrollbarOffset(0)
-      }
+      setParentScrollbarWidth(parent.offsetWidth - parent.clientWidth)
+    } else {
+      setParentScrollbarWidth(0)
     }
-  }, [referenceElement, openLeft])
+  }, [referenceElement])
 
-  // Floating UI setup
+  // Floating UI setup — prefer right; flip + size keep the menu fully on-screen
   const { refs, floatingStyles, isPositioned } = useFloating({
-    placement: openLeft ? 'left-start' : 'right-start',
+    placement: 'right-start',
     strategy: 'fixed', // Use fixed positioning for portals to avoid stacking context issues
     middleware: [
-      // mainAxis: scrollbar gap, crossAxis: -4 to align first item with parent (counteract py-1)
-      offset({ mainAxis: scrollbarOffset, crossAxis: -4 }),
+      // mainAxis: scrollbar gap when opening right; crossAxis: -4 to align first item with parent (counteract py-1)
+      offset(({ placement }) => ({
+        mainAxis: placement.startsWith('right') ? parentScrollbarWidth : 0,
+        crossAxis: -4
+      })),
       // Only allow horizontal flipping (left/right), keep -start alignment so submenu always opens downward
       flip({
-        fallbackPlacements: openLeft ? ['right-start'] : ['left-start']
+        fallbackPlacements: ['left-start']
       }),
       shift({ padding: 10 }),
       size({
         padding: 10,
-        apply({ availableHeight }) {
-          setMaxHeight(availableHeight)
+        apply({ availableWidth, availableHeight }) {
+          // Shrink to fit the viewport so the right edge (and scrollbar) stay on-screen
+          const width = Math.min(PREFERRED_SUBMENU_WIDTH, Math.max(0, availableWidth))
+          const maxHeight = Math.max(0, availableHeight)
+          setFloatingSize((prev) => {
+            if (prev && prev.width === width && prev.maxHeight === maxHeight) return prev
+            return { width, maxHeight }
+          })
         }
       })
     ],
@@ -150,8 +159,8 @@ function DropdownSubmenu({
       className="bg-primary border-dropdown-menu-border absolute z-[9999] overflow-y-auto rounded-md border py-1 shadow-lg"
       style={{
         ...floatingStyles,
-        width: '192px',
-        maxHeight: maxHeight ? `${maxHeight}px` : '300px', // Dynamic height based on available viewport space
+        width: `${floatingSize?.width ?? PREFERRED_SUBMENU_WIDTH}px`,
+        maxHeight: floatingSize ? `${floatingSize.maxHeight}px` : '300px',
         // Hide until positioned to prevent flicker at 0,0
         opacity: isPositioned ? 1 : 0,
         visibility: isPositioned ? 'visible' : 'hidden'
@@ -182,11 +191,12 @@ function DropdownSubmenu({
           }}
           onMouseDown={(e) => e.preventDefault()}
         >
-          <div className="flex min-w-0 items-center overflow-hidden">
-            <span className="ms-3 block min-w-0 flex-1 truncate font-sans text-sm" title={subitem.text}>
-              {subitem.text}
-            </span>
-          </div>
+          <span
+            className={mergeClasses('ms-3 block min-w-0 font-sans text-sm', wrapText ? 'line-clamp-2 break-words whitespace-normal' : 'truncate')}
+            title={subitem.text}
+          >
+            {subitem.text}
+          </span>
         </li>
       ))}
       {filteredSubitems.length === 0 && (
@@ -228,6 +238,7 @@ interface DropdownMenuProps {
   triggerRef?: React.RefObject<HTMLElement>
   highlightSelected?: boolean
   submenuFilterText?: string
+  wrapText?: boolean
 }
 
 /**
@@ -256,7 +267,8 @@ export default function DropdownMenu({
   usePortal: usePortalProp = false,
   triggerRef,
   highlightSelected = false,
-  submenuFilterText = ''
+  submenuFilterText = '',
+  wrapText = false
 }: DropdownMenuProps) {
   const t = useTypeSafeTranslations()
   const defaultNoItemsText = noItemsText || t('LabelNoItems')
@@ -271,8 +283,6 @@ export default function DropdownMenu({
   })
   const [isMouseOver, setIsMouseOver] = useState(false)
 
-  // Track whether the submenu should open on the left
-  const [openSubmenuLeft, setOpenSubmenuLeft] = useState(false)
   // Track pending submenu closure with timeout
   const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -281,8 +291,6 @@ export default function DropdownMenu({
 
   // Store refs to menu items for submenu positioning
   const menuItemRefs = useRef<(HTMLLIElement | null)[]>([])
-
-  const submenuWidth = 192 // Fixed submenu width
 
   // Use portal if it is explicitly enabled or if the modalRef is not null
   // For the portal to work, triggerRef must be provided
@@ -306,22 +314,16 @@ export default function DropdownMenu({
     getElement: useCallback((container, index) => container.querySelector(`#${dropdownId}-item-${index}`) as HTMLElement, [dropdownId])
   })
 
-  // Update submenu position when menu opens
+  // Reset submenu hover/close state when menu closes
   useEffect(() => {
-    if (showMenu && menuRef.current) {
-      const boundingRect = menuRef.current.getBoundingClientRect()
-      if (boundingRect) {
-        setOpenSubmenuLeft(window.innerWidth - boundingRect.x < boundingRect.width + submenuWidth + 5)
-      }
-    } else if (!showMenu) {
-      // Reset internal state when menu closes
+    if (!showMenu) {
       isOverSubmenuRef.current = false
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current)
         closeTimeoutRef.current = null
       }
     }
-  }, [showMenu, menuRef])
+  }, [showMenu])
 
   // Clear timeout on unmount
   useEffect(() => {
@@ -426,7 +428,8 @@ export default function DropdownMenu({
               menuItemRefs.current[index] = el
             }}
             className={mergeClasses(
-              'text-foreground hover:bg-dropdown-item-hover relative cursor-pointer overflow-hidden py-2',
+              'text-foreground hover:bg-dropdown-item-hover relative cursor-pointer py-2',
+              wrapText ? 'overflow-x-hidden' : 'overflow-hidden',
               focusedIndex === index && focusedSubIndex === -1 ? 'bg-dropdown-item-selected' : '',
               isSubmenuOpen ? 'bg-dropdown-item-hover' : '',
               highlightSelected && isItemSelected?.(item) ? 'text-yellow-400' : ''
@@ -444,11 +447,18 @@ export default function DropdownMenu({
             onMouseOver={hasSubitems ? () => handleMouseoverParent(index) : undefined}
             onMouseLeave={hasSubitems ? handleMouseleaveParent : undefined}
           >
-            <div className="flex min-w-0 items-center overflow-hidden">
+            <div
+              className={mergeClasses(
+                'flex min-w-0',
+                wrapText ? 'items-start' : 'items-center overflow-hidden',
+                wrapText && (hasSubitems || item.rightIcon || (showSelectedIndicator && isItemSelected?.(item))) && 'pe-8'
+              )}
+            >
               {item.leftIcon && <span className="ms-3 shrink-0">{item.leftIcon}</span>}
               <DropdownItemLabel
                 text={item.text}
                 subtext={item.subtext}
+                wrapText={wrapText}
                 className={mergeClasses(item.leftIcon ? 'ms-1.5' : 'ms-3', 'min-w-0 flex-1 text-sm')}
               />
             </div>
@@ -474,9 +484,9 @@ export default function DropdownMenu({
                 onSubitemClick={onSubitemClick}
                 onMouseOver={handleMouseoverSubmenu}
                 onMouseLeave={handleMouseleaveSubmenu}
-                openLeft={openSubmenuLeft}
                 referenceElement={menuItemRefs.current[index]}
                 filterText={submenuFilterText}
+                wrapText={wrapText}
                 t={t}
               />
             )}
@@ -498,8 +508,8 @@ export default function DropdownMenu({
       handleMouseleaveParent,
       handleMouseoverSubmenu,
       handleMouseleaveSubmenu,
-      openSubmenuLeft,
       submenuFilterText,
+      wrapText,
       t
     ]
   )

--- a/src/components/widgets/ChromecastLauncher.tsx
+++ b/src/components/widgets/ChromecastLauncher.tsx
@@ -27,6 +27,7 @@ function ChromecastLauncher({ libraryId }: ChromecastLauncherProps) {
     if (!container || !chromecastEnabled || !isChromecastInitialized || !isHttps) return
 
     const launcher = document.createElement('google-cast-launcher')
+    launcher.classList.add('h-6')
     container.appendChild(launcher)
 
     return () => {
@@ -39,7 +40,7 @@ function ChromecastLauncher({ libraryId }: ChromecastLauncherProps) {
   if (!isHttps) {
     return (
       <Tooltip text={t('MessageCastingRequiresHttps')} position="bottom">
-        <span className="material-symbols text-warning/50 text-2xl" aria-hidden>
+        <span className="material-symbols text-warning/50 text-2.5xl" aria-hidden>
           cast
         </span>
       </Tooltip>

--- a/src/components/widgets/ChromecastLauncher.tsx
+++ b/src/components/widgets/ChromecastLauncher.tsx
@@ -2,6 +2,7 @@
 
 import Tooltip from '@/components/ui/Tooltip'
 import { setChromecastLibraryId, useChromecast } from '@/contexts/ChromecastContext'
+import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { memo, useEffect, useRef } from 'react'
 
@@ -11,8 +12,10 @@ interface ChromecastLauncherProps {
 
 function ChromecastLauncher({ libraryId }: ChromecastLauncherProps) {
   const t = useTypeSafeTranslations()
+  const { serverSettings } = useUser()
   const { isChromecastInitialized, isHttps } = useChromecast()
   const launcherContainerRef = useRef<HTMLDivElement>(null)
+  const chromecastEnabled = serverSettings.chromecastEnabled
 
   useEffect(() => {
     setChromecastLibraryId(libraryId ?? null)
@@ -21,7 +24,7 @@ function ChromecastLauncher({ libraryId }: ChromecastLauncherProps) {
   // Mount google-cast-launcher once; recreating it on parent re-renders causes the Cast dialog to flicker.
   useEffect(() => {
     const container = launcherContainerRef.current
-    if (!container || !isChromecastInitialized || !isHttps) return
+    if (!container || !chromecastEnabled || !isChromecastInitialized || !isHttps) return
 
     const launcher = document.createElement('google-cast-launcher')
     container.appendChild(launcher)
@@ -29,9 +32,9 @@ function ChromecastLauncher({ libraryId }: ChromecastLauncherProps) {
     return () => {
       launcher.remove()
     }
-  }, [isChromecastInitialized, isHttps])
+  }, [chromecastEnabled, isChromecastInitialized, isHttps])
 
-  if (!isChromecastInitialized) return null
+  if (!chromecastEnabled || !isChromecastInitialized) return null
 
   if (!isHttps) {
     return (

--- a/src/components/widgets/media-card/CollectionCard.tsx
+++ b/src/components/widgets/media-card/CollectionCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import CollectionEditModal from '@/components/modals/CollectionEditModal'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import CollectionGroupCover from '@/components/widgets/media-card/CollectionGroupCover'
 import MediaCardFrame from '@/components/widgets/media-card/MediaCardFrame'
@@ -31,8 +32,6 @@ export interface CollectionCardProps {
   selected?: boolean
   /** Callback when the select button is clicked */
   onSelect?: (event: React.MouseEvent) => void
-  /** Callback when the edit button is clicked */
-  onEdit?: (collection: Collection) => void
   /** Callback to open RSS feed modal */
   onOpenRssFeedModal?: (collection: Collection) => void
   /** Whether to show the selection button */
@@ -47,7 +46,6 @@ function CollectionCard(props: CollectionCardProps) {
     isSelectionMode = false,
     selected = false,
     onSelect,
-    onEdit,
     onOpenRssFeedModal,
     showSelectedButton = false
   } = props
@@ -61,6 +59,7 @@ function CollectionCard(props: CollectionCardProps) {
 
   const [isHovering, setIsHovering] = useState(false)
   const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
 
   // Use prop to override context value if provided
   const effectiveSizeMultiplier = sizeMultiplier ?? contextSizeMultiplier
@@ -87,14 +86,15 @@ function CollectionCard(props: CollectionCardProps) {
     router.push(`/library/${collection.libraryId}/collection/${collection.id}`)
   }, [collection.id, collection.libraryId, router])
 
-  const handleEditClick = useCallback(
-    (event: React.MouseEvent) => {
-      event.preventDefault()
-      event.stopPropagation()
-      onEdit?.(collection)
-    },
-    [collection, onEdit]
-  )
+  const handleEditClick = useCallback((event: React.MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setEditModalOpen(true)
+  }, [])
+
+  const handleCloseEditModal = useCallback(() => {
+    setEditModalOpen(false)
+  }, [])
 
   // Selection handler - kept for future use
   const handleSelectClick = useCallback(
@@ -226,6 +226,8 @@ function CollectionCard(props: CollectionCardProps) {
           )
         }
       />
+
+      {editModalOpen && <CollectionEditModal isOpen collection={collection} onClose={handleCloseEditModal} />}
 
       {/* Confirm dialog for delete */}
       {confirmState && (

--- a/src/components/widgets/media-card/PlaylistCard.tsx
+++ b/src/components/widgets/media-card/PlaylistCard.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import PlaylistEditModal from '@/components/modals/PlaylistEditModal'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import MediaCardFrame from '@/components/widgets/media-card/MediaCardFrame'
 import MediaCardMoreMenu from '@/components/widgets/media-card/MediaCardMoreMenu'
@@ -30,14 +31,12 @@ export interface PlaylistCardProps {
   selected?: boolean
   /** Callback when the select button is clicked */
   onSelect?: (event: React.MouseEvent) => void
-  /** Callback when the edit button is clicked */
-  onEdit?: (playlist: Playlist) => void
   /** Whether to show the selection button */
   showSelectedButton?: boolean
 }
 
 function PlaylistCard(props: PlaylistCardProps) {
-  const { playlist, bookshelfView, sizeMultiplier, isSelectionMode = false, selected = false, onSelect, onEdit, showSelectedButton = false } = props
+  const { playlist, bookshelfView, sizeMultiplier, isSelectionMode = false, selected = false, onSelect, showSelectedButton = false } = props
 
   const router = useRouter()
   const { userCanUpdate } = useUser()
@@ -47,6 +46,7 @@ function PlaylistCard(props: PlaylistCardProps) {
 
   const [isHovering, setIsHovering] = useState(false)
   const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false)
+  const [editModalOpen, setEditModalOpen] = useState(false)
 
   // Use prop to override context value if provided
   const effectiveSizeMultiplier = sizeMultiplier ?? contextSizeMultiplier
@@ -72,14 +72,15 @@ function PlaylistCard(props: PlaylistCardProps) {
     router.push(`/library/${playlist.libraryId}/playlist/${playlist.id}`)
   }, [playlist.libraryId, playlist.id, router])
 
-  const handleEditClick = useCallback(
-    (event: React.MouseEvent) => {
-      event.preventDefault()
-      event.stopPropagation()
-      onEdit?.(playlist)
-    },
-    [playlist, onEdit]
-  )
+  const handleEditClick = useCallback((event: React.MouseEvent) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setEditModalOpen(true)
+  }, [])
+
+  const handleCloseEditModal = useCallback(() => {
+    setEditModalOpen(false)
+  }, [])
 
   // Selection handler - kept for future use
   const handleSelectClick = useCallback(
@@ -190,6 +191,8 @@ function PlaylistCard(props: PlaylistCardProps) {
           )
         }
       />
+
+      {editModalOpen && <PlaylistEditModal isOpen playlist={playlist} onClose={handleCloseEditModal} />}
 
       {/* Confirm dialog for delete */}
       {confirmState && (

--- a/src/components/widgets/media-card/useCollectionCardActions.ts
+++ b/src/components/widgets/media-card/useCollectionCardActions.ts
@@ -44,7 +44,7 @@ export function useCollectionCardActions({ collection, rssFeed, onOpenRssFeedMod
             const playlist = await createPlaylistFromCollectionAction(collection.id)
             if (playlist?.id) {
               showToast(t('ToastPlaylistCreateSuccess'), { type: 'success' })
-              router.push(`/playlist/${playlist.id}`)
+              router.push(`/library/${collection.libraryId}/playlist/${playlist.id}`)
             }
           } catch (error) {
             console.error('Failed to create playlist from collection', error)
@@ -80,7 +80,7 @@ export function useCollectionCardActions({ collection, rssFeed, onOpenRssFeedMod
         })
       }
     },
-    [collection.id, collection.name, onCollectionDeleted, onOpenRssFeedModal, router, showToast, t]
+    [collection.id, collection.libraryId, collection.name, onCollectionDeleted, onOpenRssFeedModal, router, showToast, t]
   )
 
   const moreMenuItems = useMemo<MediaCardMoreMenuItem[]>(() => {

--- a/src/contexts/ChromecastContext.tsx
+++ b/src/contexts/ChromecastContext.tsx
@@ -68,7 +68,12 @@ export function ChromecastProvider({ children }: { children: React.ReactNode }) 
   libraryIdRef.current = userDefaultLibraryId
 
   useEffect(() => {
-    if (!serverSettings.chromecastEnabled) return
+    if (!serverSettings.chromecastEnabled) {
+      setIsChromecastInitialized(false)
+      setIsCasting(false)
+      notifyCastSessionActive(false)
+      return
+    }
 
     let active = true
 

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -2,7 +2,7 @@
 
 import { getUserPermissionFlags } from '@/lib/userPermissions'
 import { AudioBookmark, EReaderDevice, MediaProgress, ServerSettings, User, UserLoginResponse } from '@/types/api'
-import { createContext, ReactNode, useContext, useEffect, useState } from 'react'
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from 'react'
 import { useSocketEvent } from './SocketContext'
 
 interface UserItemProgressUpdatedPayload {
@@ -26,6 +26,7 @@ export interface UserContextType {
   /** Book media id or podcast episode id matches `MediaProgress.mediaItemId` */
   getMediaItemProgress: (mediaItemId: string) => MediaProgress | undefined
   getBookmarksForLibraryItem: (libraryItemId: string) => AudioBookmark[]
+  mergeServerSettings: (settings: ServerSettings | null | undefined) => void
 }
 
 export const UserContext = createContext<UserContextType | undefined>(undefined)
@@ -76,6 +77,16 @@ export function UserProvider({ children, initialUser }: { children: ReactNode; i
     setCurrentUserData(initialUser)
   }, [initialUser])
 
+  const mergeServerSettings = useCallback((settings: ServerSettings | null | undefined) => {
+    if (!settings) {
+      return
+    }
+    setCurrentUserData((prev) => ({
+      ...prev,
+      serverSettings: settings
+    }))
+  }, [])
+
   const contextValue: UserContextType = {
     user,
     ...permissionFlags,
@@ -85,7 +96,8 @@ export function UserProvider({ children, initialUser }: { children: ReactNode; i
     ereaderDevices: currentUserData.ereaderDevices,
     Source: currentUserData.Source,
     getMediaItemProgress: (mediaItemId: string) => user.mediaProgress.find((p) => p.mediaItemId === mediaItemId),
-    getBookmarksForLibraryItem: (libraryItemId: string) => user.bookmarks?.filter((bm) => bm.libraryItemId === libraryItemId) ?? []
+    getBookmarksForLibraryItem: (libraryItemId: string) => user.bookmarks?.filter((bm) => bm.libraryItemId === libraryItemId) ?? [],
+    mergeServerSettings
   }
 
   return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>

--- a/src/hooks/usePlaylistItems.ts
+++ b/src/hooks/usePlaylistItems.ts
@@ -21,10 +21,20 @@ export function usePlaylistItems(playlist: Playlist) {
 
   const handleItemRemoved = useCallback(
     (libraryItemId: string, episodeId?: string | null) => {
-      setOrderedItems((prev) => prev.filter((item) => !matchesPlaylistItem(item, libraryItemId, episodeId)))
-      router.refresh()
+      let removedLastItem = false
+      setOrderedItems((prev) => {
+        const next = prev.filter((item) => !matchesPlaylistItem(item, libraryItemId, episodeId))
+        removedLastItem = prev.length > 0 && next.length === 0
+        return next
+      })
+      // Backend deletes playlists with no items left — navigate away instead of refreshing a dead page.
+      if (removedLastItem) {
+        router.push(`/library/${playlist.libraryId}/playlists`)
+      } else {
+        router.refresh()
+      }
     },
-    [router]
+    [playlist.libraryId, router]
   )
 
   useEffect(() => {

--- a/src/hooks/useVersionData.ts
+++ b/src/hooks/useVersionData.ts
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 // - Fetches GitHub releases via checkForUpdate()
 // - Caches the result in localStorage so we don't hit the API on every page load
 // - Re-checks at most once every 5 minutes (based on VersionFooter being mounted)
+// - Loads cache only after mount (in useEffect) to avoid SSR/client hydration mismatches
 // - Used by VersionFooter for the changelog modal and "Update available" link
 
 const VERSION_CHECK_BUFF = 1000 * 60 * 5
@@ -38,14 +39,9 @@ function loadSavedVersionData(): VersionData | null {
 }
 
 export function useVersionData(currentVersion: string) {
-  // Hydrate from cache on first render so the changelog can open immediately
-  const [versionData, setVersionData] = useState<VersionData | null>(() => {
-    const saved = loadSavedVersionData()
-    if (saved?.currentVersion === currentVersion && saved.releasesToShow?.length) {
-      return reviveVersionData(saved)
-    }
-    return null
-  })
+  // Always start as null so SSR and the first client paint match.
+  // localStorage is only available in the browser and would cause a hydration mismatch.
+  const [versionData, setVersionData] = useState<VersionData | null>(null)
 
   useEffect(() => {
     if (!currentVersion || currentVersion === 'Error') return
@@ -62,6 +58,11 @@ export function useVersionData(currentVersion: string) {
     if (!shouldCheckForUpdate && savedVersionData) {
       setVersionData(reviveVersionData(savedVersionData))
       return
+    }
+
+    // Show cached data immediately while a fresh check runs
+    if (savedVersionData?.currentVersion === currentVersion && savedVersionData.releasesToShow?.length) {
+      setVersionData(reviveVersionData(savedVersionData))
     }
 
     let cancelled = false

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -930,6 +930,15 @@ export async function updateEbookProgress(libraryItemId: string, payload: { eboo
 }
 
 /**
+ * Remove media progress for the current user (reset progress)
+ */
+export async function deleteMediaProgress(progressId: string): Promise<void> {
+  return apiRequest<void>(`/api/me/progress/${progressId}`, {
+    method: 'DELETE'
+  })
+}
+
+/**
  * Batch update media finished state for multiple items or episodes
  */
 export async function batchUpdateMediaFinished(payload: { libraryItemId: string; episodeId?: string; isFinished: boolean }[]): Promise<void> {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -977,6 +977,7 @@
   "MessageNoDownloadsQueued": "No episodes queued",
   "MessageNoEpisodeMatchesFound": "No episode matches found",
   "MessageNoEpisodes": "No Episodes",
+  "MessageNoEpisodesToPlay": "No episodes match the current filter or search",
   "MessageNoFoldersAvailable": "No Folders Available",
   "MessageNoGenres": "No Genres",
   "MessageNoHomeShelves": "Nothing to show on your home page right now.",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -98,6 +98,7 @@
   "ButtonRemoveFromContinueReading": "Remove from Continue Reading",
   "ButtonRemoveSeriesFromContinueSeries": "Remove Series from Continue Series",
   "ButtonReset": "Reset",
+  "ButtonResetProgress": "Reset progress",
   "ButtonResetToDefault": "Reset to default",
   "ButtonRestore": "Restore",
   "ButtonRetry": "Retry",


### PR DESCRIPTION
This contains various fixes to issues in #112.

### Fixes

- Wire library item page cover play button
  - Move play logic to `useLibraryItemPagePlay`
  - On podcast page, Play shows `MessageNoEpisodesToPlay` toast if no episodes match filter or search (Vue does nothing, which can be confusing)
- Add library item progress info panel (Vue parity)
  - Item header order: details → podcast download banners → progress panel → action buttons
  - Panel is start-aligned on mobile (Vue centers with `mx-auto`)
  - Panel and reset button accessibility:
    - Reset button is tabbable
    - Reset button has larger hit/touch target (but looks the same)
    - Panel has `role="region"` and aria-title
    - Reset button has `ButtonResetProgress` localized aria-label (Vue had fixed English string)
- Fix account page actions buttons wrapping on mobile.
- Show toolbar item count on mobile as a compact badge on all library pages
  - Include narrators page (count synced from `NarratorsClient`)
  - Filter/sort grow equally into remaining toolbar space on small screens
  - Wait for item count before showing filter/sort so mobile widths don’t jitter
  - Dropdown `wrapText` option so menu items wrap (used by library filter/sort)
  - Submenus use Floating UI flip/size to stay fully on-screen (so the scrollbar isn’t clipped)
- Hide toolbar on library stats page
- Fix redirect URL after creating a playlist from a collection on the collection page
- Wire collection/playlist card edit buttons
- Fix hydration mismatch in `useVersionData`
- Keep server settings in sync app-wide after admin changes (similar to vue $store)
  - `UserContext` exposes `mergeServerSettings` to replace `serverSettings` on the login payload
  - Main settings (`SettingsClient`):
    - read `serverSettings` from context (no local state)
    - optimistic `mergeServerSettings` on save/language change with revert on error
    - merge API `serverSettings` after successful PATCH
  - Similar changes in Backups and logs settings
  - Settings pages no longer pass `serverSettings` into clients that only need live context data
  - `settings/actions.ts` uses a file-level `'use server'` so client components can import server actions safely
- Chromecast launcher reacts when Chromecast support is toggled off in settings (no full page reload)
  - `ChromecastLauncher` gates on `serverSettings.chromecastEnabled` from context
  - `ChromecastContext` clears init/casting state and notifies cast session inactive when support is disabled
- Keep series page filter/sort in toolbar when a filter returns no results
  - `Toolbar` uses `seriesFilterBy` (not `filterBy`) to detect an empty series bookshelf
- Fix uncaught error when removing the last item from a playlist on the playlist page
  - Backend deletes empty playlists; client now navigates to the playlists list instead of refreshing the detail page
  - `PlaylistClient` listens for `playlist_removed` and redirects away (Vue parity)

*Note: this depends on #151. Please do not merge before I rebase to master.*
