### PR TITLE
Fix text field trimming behavior across the code

### DIFF
--- a/src/app/(blank)/login/ServerInitForm.tsx
+++ b/src/app/(blank)/login/ServerInitForm.tsx
@@ -38,7 +38,7 @@ export default function ServerInitForm() {
       try {
         const payload = {
           newRoot: {
-            username,
+            username: username.trim(),
             password
           }
         }
@@ -67,7 +67,7 @@ export default function ServerInitForm() {
       <h2 className="text-foreground mb-6 text-center text-2xl font-bold">{t('HeaderServerInit')}</h2>
 
       <div className="mb-4 flex flex-col gap-4">
-        <TextInput label={t('LabelUsername')} value={username} onChange={setUsername} />
+        <TextInput label={t('LabelUsername')} value={username} trimWhitespace onChange={setUsername} />
         <TextInput label={t('LabelPassword')} value={password} type="password" onChange={setPassword} />
         <TextInput label={t('LabelConfirmPassword')} value={confirmPassword} type="password" onChange={setConfirmPassword} />
       </div>

--- a/src/app/(main)/settings/api-keys/EditApiKeyModal.tsx
+++ b/src/app/(main)/settings/api-keys/EditApiKeyModal.tsx
@@ -83,7 +83,7 @@ export default function EditApiKeyModal({ isOpen, apiKey, users, onClose, onSubm
     if (expiresInSeconds) {
       formData.expiresIn = parseInt(expiresInSeconds)
     }
-    onSubmit(formData)
+    onSubmit({ ...formData, name: formData.name.trim() })
   }
 
   // Convert users to dropdown items with username:type format
@@ -114,6 +114,7 @@ export default function EditApiKeyModal({ isOpen, apiKey, users, onClose, onSubm
               placeholder={t('LabelName')}
               readOnly={isEditing}
               onChange={(value) => setFormData((prev) => ({ ...prev, name: value }))}
+              trimWhitespace={!isEditing}
             />
 
             {/* Expires In (seconds) - Hidden when editing */}

--- a/src/app/(main)/settings/libraries/LibraryDetailsTab.tsx
+++ b/src/app/(main)/settings/libraries/LibraryDetailsTab.tsx
@@ -70,6 +70,7 @@ export default function LibraryDetailsTab({
           placeholder={t('LabelLibraryName')}
           onChange={(value) => onFormDataChange((prev) => ({ ...prev, name: value }))}
           className="w-full sm:flex-1"
+          trimWhitespace
         />
 
         {/* Icon */}

--- a/src/app/(main)/settings/libraries/LibraryEditModal.tsx
+++ b/src/app/(main)/settings/libraries/LibraryEditModal.tsx
@@ -37,7 +37,7 @@ const defaultLibrarySettings: LibrarySettings = {
 const getInitialFormData = (library: Library | null): LibraryFormData => {
   if (library) {
     return {
-      name: library.name,
+      name: library.name.trim(),
       mediaType: library.mediaType,
       icon: library.icon || 'database',
       provider: library.provider || '',
@@ -53,6 +53,13 @@ const getInitialFormData = (library: Library | null): LibraryFormData => {
     provider: '',
     folders: [],
     settings: { ...defaultLibrarySettings }
+  }
+}
+
+function normalizeLibraryFormData(formData: LibraryFormData): LibraryFormData {
+  return {
+    ...formData,
+    name: formData.name.trim()
   }
 }
 
@@ -187,20 +194,21 @@ export default function LibraryEditModal({ isOpen, library, processing = false, 
     if (!isEditing) return true
     const trimmedNew = newFolderPath.trim()
     if (trimmedNew && !formData.folders.some((f) => f.fullPath.trim() === trimmedNew)) return true
-    return JSON.stringify(formData) !== initialFormDataRef.current
+    return JSON.stringify(normalizeLibraryFormData(formData)) !== initialFormDataRef.current
   }, [formData, isEditing, newFolderPath])
 
   const handleSubmit = () => {
     if (!isValid || !hasChanges || processing) return
 
+    const normalizedFormData = normalizeLibraryFormData(formData)
     const trimmedNew = newFolderPath.trim()
-    if (trimmedNew && !formData.folders.some((f) => f.fullPath.trim() === trimmedNew)) {
+    if (trimmedNew && !normalizedFormData.folders.some((f) => f.fullPath.trim() === trimmedNew)) {
       onSubmit({
-        ...formData,
-        folders: [...formData.folders, { fullPath: trimmedNew }]
+        ...normalizedFormData,
+        folders: [...normalizedFormData.folders, { fullPath: trimmedNew }]
       })
     } else {
-      onSubmit(formData)
+      onSubmit(normalizedFormData)
     }
   }
 

--- a/src/app/(main)/settings/notifications/NotificationEditModal.tsx
+++ b/src/app/(main)/settings/notifications/NotificationEditModal.tsx
@@ -95,7 +95,12 @@ export default function NotificationEditModal({ isOpen, notification, notificati
 
     startTransition(async () => {
       try {
-        const updatedSettings = isEditing ? await updateNotification(formState.id!, formState) : await createNotification(formState)
+        const payload = {
+          ...formState,
+          titleTemplate: formState.titleTemplate.trim(),
+          bodyTemplate: formState.bodyTemplate.trim()
+        }
+        const updatedSettings = isEditing ? await updateNotification(payload.id!, payload) : await createNotification(payload)
         onSaved(updatedSettings)
         if (isEditing) {
           showToast(t('ToastNotificationUpdateSuccess'), { type: 'success' })
@@ -148,6 +153,7 @@ export default function NotificationEditModal({ isOpen, notification, notificati
             value={formState.titleTemplate}
             disabled={isPending}
             onChange={(value) => setFormState((prev) => ({ ...prev, titleTemplate: value }))}
+            trimWhitespace
           />
 
           <TextareaInput
@@ -156,6 +162,7 @@ export default function NotificationEditModal({ isOpen, notification, notificati
             rows={4}
             disabled={isPending}
             onChange={(value) => setFormState((prev) => ({ ...prev, bodyTemplate: value }))}
+            trimWhitespace
           />
 
           {selectedEvent?.variables?.length ? (

--- a/src/app/(main)/settings/users/UserAccountModal.tsx
+++ b/src/app/(main)/settings/users/UserAccountModal.tsx
@@ -157,7 +157,11 @@ export default function UserAccountModal({ isOpen, user, processing = false, onC
       return
     }
 
-    onSubmit(formData)
+    onSubmit({
+      ...formData,
+      username: formData.username.trim(),
+      email: formData.email.trim()
+    })
   }
 
   const handleUnlinkOpenIdClick = () => {
@@ -275,6 +279,7 @@ export default function UserAccountModal({ isOpen, user, processing = false, onC
               placeholder={t('LabelUsername')}
               disabled={processing}
               onChange={(value) => setFormData((prev) => ({ ...prev, username: value }))}
+              trimWhitespace
             />
 
             {/* Change Password */}
@@ -297,6 +302,7 @@ export default function UserAccountModal({ isOpen, user, processing = false, onC
               placeholder={t('LabelEmail')}
               disabled={processing}
               onChange={(value) => setFormData((prev) => ({ ...prev, email: value }))}
+              trimWhitespace
             />
 
             {/* Account Type & Enable */}

--- a/src/components/modals/AuthorEditModal.tsx
+++ b/src/components/modals/AuthorEditModal.tsx
@@ -19,6 +19,14 @@ interface AuthorEditModalProps {
   onClose: () => void
 }
 
+function normalizeEditedAuthor(edited: Partial<Author>): Partial<Author> {
+  return {
+    ...edited,
+    name: edited.name?.trim() ?? '',
+    asin: edited.asin?.trim() ?? ''
+  }
+}
+
 export default function AuthorEditModal({ isOpen, user, author: authorProp, onClose }: AuthorEditModalProps) {
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
@@ -33,9 +41,8 @@ export default function AuthorEditModal({ isOpen, user, author: authorProp, onCl
 
   const isDirty = useMemo(() => {
     if (!editedAuthor || !author) return false
-    return (
-      editedAuthor.name !== author.name || (editedAuthor.asin || '') !== (author.asin || '') || (editedAuthor.description || '') !== (author.description || '')
-    )
+    const normalized = normalizeEditedAuthor(editedAuthor)
+    return normalized.name !== author.name || (normalized.asin || '') !== (author.asin || '') || (editedAuthor.description || '') !== (author.description || '')
   }, [editedAuthor, author])
 
   const saveDisabled = !isDirty
@@ -74,7 +81,7 @@ export default function AuthorEditModal({ isOpen, user, author: authorProp, onCl
       return
     }
     startTransition(async () => {
-      const success = await handleSave(author.id, author.name || '', editedAuthor)
+      const success = await handleSave(author.id, author.name || '', normalizeEditedAuthor(editedAuthor))
       if (success) onClose()
     })
   }
@@ -136,16 +143,17 @@ export default function AuthorEditModal({ isOpen, user, author: authorProp, onCl
               {/* form */}
               <div className="mb-2 grow px-2 pt-2">
                 <div className="flex flex-col gap-2 sm:flex-row sm:gap-0">
-                  <TextInput className="w-full" placeholder={t('LabelImageURLFromTheWeb')} value={imgUrl} onChange={setImgUrl}></TextInput>
+                  <TextInput className="w-full" placeholder={t('LabelImageURLFromTheWeb')} value={imgUrl} onChange={setImgUrl} trimWhitespace />
                   <Btn
                     color="bg-success"
                     className="flex-shrink-0 sm:ml-2"
                     onClick={() => {
-                      if (!imgUrl?.startsWith('http:') && !imgUrl?.startsWith('https:')) {
+                      const trimmedUrl = imgUrl.trim()
+                      if (!trimmedUrl.startsWith('http:') && !trimmedUrl.startsWith('https:')) {
                         showToast(t('ToastInvalidImageUrl'), { type: 'error' })
                         return
                       }
-                      handleSubmitImageWrapper(imgUrl)
+                      handleSubmitImageWrapper(trimmedUrl)
                       setImgUrl('')
                     }}
                   >
@@ -162,13 +170,19 @@ export default function AuthorEditModal({ isOpen, user, author: authorProp, onCl
                       placeholder={t('LabelName')}
                       value={editedAuthor.name || ''}
                       onChange={(value) => setEditedAuthor({ ...editedAuthor, name: value })}
+                      trimWhitespace
                     />
                   </div>
                   <div className="w-full sm:w-1/4">
                     <label htmlFor="" className="mb-1 px-1 text-sm">
                       ASIN
                     </label>
-                    <TextInput placeholder="ASIN" value={editedAuthor.asin || ''} onChange={(value) => setEditedAuthor({ ...editedAuthor, asin: value })} />
+                    <TextInput
+                      placeholder="ASIN"
+                      value={editedAuthor.asin || ''}
+                      onChange={(value) => setEditedAuthor({ ...editedAuthor, asin: value })}
+                      trimWhitespace
+                    />
                   </div>
                 </div>
                 <div className="flex grow pt-4">

--- a/src/components/modals/NewPodcastModal.tsx
+++ b/src/components/modals/NewPodcastModal.tsx
@@ -16,7 +16,7 @@ import { PodcastSearchResult, RssPodcast } from '@/types/api'
 import path from 'path'
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
-interface NewPodcastFormState {
+interface NewPodcastCreateState {
   title: string
   author: string
   description: string
@@ -33,7 +33,7 @@ interface NewPodcastFormState {
   type: string
 }
 
-const emptyFormState = (): NewPodcastFormState => ({
+const emptyFormState = (): NewPodcastCreateState => ({
   title: '',
   author: '',
   description: '',
@@ -64,6 +64,16 @@ function parseExplicitFromFeed(explicit: string | undefined): boolean {
   return explicit === 'yes' || explicit === 'true'
 }
 
+function trimPodcastCreateState(podcast: NewPodcastCreateState): NewPodcastCreateState {
+  return {
+    ...podcast,
+    title: podcast.title.trim(),
+    author: podcast.author.trim(),
+    description: podcast.description.trim(),
+    language: podcast.language.trim()
+  }
+}
+
 export interface NewPodcastModalProps {
   isOpen: boolean
   podcastData: PodcastSearchResult | null
@@ -78,7 +88,7 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
   const { library } = useLibrary()
   const [isPending, startTransition] = useTransition()
 
-  const [podcast, setPodcast] = useState<NewPodcastFormState>(emptyFormState)
+  const [podcast, setPodcast] = useState<NewPodcastCreateState>(emptyFormState)
   const [selectedFolderId, setSelectedFolderId] = useState<string>('')
   const [fullPath, setFullPath] = useState('')
 
@@ -117,7 +127,7 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
     const feedMetadata = podcastFeedData?.metadata
     const genres = podcastData?.genres ? normalizeGenres(podcastData.genres) : feedMetadata?.categories || []
 
-    const next: NewPodcastFormState = {
+    const next: NewPodcastCreateState = {
       title: podcastData?.title || feedMetadata?.title || '',
       author: podcastData?.artistName || feedMetadata?.author || '',
       description: podcastData?.description || feedMetadata?.descriptionPlain || '',
@@ -178,32 +188,36 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
   }, [])
 
   const handleSubmit = useCallback(() => {
-    if (!fullPath || !selectedFolderId) {
+    const trimmedPodcast = trimPodcastCreateState(podcast)
+    const folder = library.folders?.find((f) => f.id === selectedFolderId)
+    const podcastPath = folder?.fullPath && trimmedPodcast.title ? path.join(folder.fullPath, sanitizeFileName(trimmedPodcast.title)) : fullPath
+
+    if (!podcastPath || !selectedFolderId) {
       showToast(t('ToastPodcastCreateFailed'), { type: 'error' })
       return
     }
 
     const podcastPayload = {
-      path: fullPath,
+      path: podcastPath,
       folderId: selectedFolderId,
       libraryId: library.id,
       media: {
         metadata: {
-          title: podcast.title,
-          author: podcast.author,
-          description: podcast.description,
-          releaseDate: podcast.releaseDate,
-          genres: [...podcast.genres],
-          feedUrl: podcast.feedUrl,
-          imageUrl: podcast.imageUrl,
-          itunesPageUrl: podcast.itunesPageUrl,
-          itunesId: podcast.itunesId,
-          itunesArtistId: podcast.itunesArtistId,
-          language: podcast.language,
-          explicit: podcast.explicit,
-          type: podcast.type
+          title: trimmedPodcast.title,
+          author: trimmedPodcast.author,
+          description: trimmedPodcast.description,
+          releaseDate: trimmedPodcast.releaseDate,
+          genres: [...trimmedPodcast.genres],
+          feedUrl: trimmedPodcast.feedUrl,
+          imageUrl: trimmedPodcast.imageUrl,
+          itunesPageUrl: trimmedPodcast.itunesPageUrl,
+          itunesId: trimmedPodcast.itunesId,
+          itunesArtistId: trimmedPodcast.itunesArtistId,
+          language: trimmedPodcast.language,
+          explicit: trimmedPodcast.explicit,
+          type: trimmedPodcast.type
         },
-        autoDownloadEpisodes: podcast.autoDownloadEpisodes
+        autoDownloadEpisodes: trimmedPodcast.autoDownloadEpisodes
       }
     }
 
@@ -219,7 +233,7 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
         showToast(message, { type: 'error' })
       }
     })
-  }, [fullPath, library.id, onClose, onCreated, podcast, selectedFolderId, showToast, t])
+  }, [fullPath, library.folders, library.id, onClose, onCreated, podcast, selectedFolderId, showToast, t])
 
   const outerContent = (
     <div className="absolute start-0 top-0 max-w-[75%] p-4">
@@ -241,8 +255,8 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
           ) : null}
 
           <div className="grid gap-2 md:grid-cols-2">
-            <TextInput label={t('LabelTitle')} value={podcast.title} onChange={handleTitleChange} />
-            <TextInput label={t('LabelAuthor')} value={podcast.author} onChange={(author) => setPodcast((prev) => ({ ...prev, author }))} />
+            <TextInput label={t('LabelTitle')} value={podcast.title} onChange={handleTitleChange} trimWhitespace />
+            <TextInput label={t('LabelAuthor')} value={podcast.author} onChange={(author) => setPodcast((prev) => ({ ...prev, author }))} trimWhitespace />
           </div>
 
           <div className="grid gap-2 md:grid-cols-2">
@@ -265,7 +279,12 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
               className="w-full"
               onChange={(type) => setPodcast((prev) => ({ ...prev, type: String(type) }))}
             />
-            <TextInput label={t('LabelLanguage')} value={podcast.language} onChange={(language) => setPodcast((prev) => ({ ...prev, language }))} />
+            <TextInput
+              label={t('LabelLanguage')}
+              value={podcast.language}
+              onChange={(language) => setPodcast((prev) => ({ ...prev, language }))}
+              trimWhitespace
+            />
             <div className="flex items-end">
               <Checkbox
                 value={podcast.explicit}
@@ -282,6 +301,7 @@ export default function NewPodcastModal({ isOpen, podcastData, podcastFeedData, 
             value={podcast.description}
             rows={3}
             onChange={(description) => setPodcast((prev) => ({ ...prev, description }))}
+            trimWhitespace
           />
 
           <div className="grid gap-2 md:grid-cols-2">

--- a/src/components/modals/RssFeedOpenCloseModal.tsx
+++ b/src/components/modals/RssFeedOpenCloseModal.tsx
@@ -81,8 +81,8 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
         slug: sanitized,
         metadataDetails: {
           preventIndexing: metadataDetails.preventIndexing,
-          ownerName: metadataDetails.ownerName || '',
-          ownerEmail: metadataDetails.ownerEmail || ''
+          ownerName: metadataDetails.ownerName.trim(),
+          ownerEmail: metadataDetails.ownerEmail.trim()
         }
       })
       setCurrentFeed(res.feed)
@@ -192,7 +192,7 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
             <p className="mb-4 text-lg font-semibold">{t('HeaderOpenRSSFeed')}</p>
             <div className="mb-2 space-y-2">
               <label className="text-foreground-subdued block text-xs uppercase">{t('LabelRSSFeedSlug')}</label>
-              <TextInput value={newFeedSlug} onChange={(value) => setNewFeedSlug(value)} className="text-sm" />
+              <TextInput value={newFeedSlug} onChange={(value) => setNewFeedSlug(value)} className="text-sm" trimWhitespace />
               <p className="text-foreground-muted text-xs">{t('MessageFeedURLWillBe', { 0: demoFeedUrl })}</p>
             </div>
             <div className="space-y-3 py-2">
@@ -207,6 +207,7 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
                   value={metadataDetails.ownerName}
                   onChange={(value) => setMetadataDetails((prev) => ({ ...prev, ownerName: value }))}
                   className="text-sm"
+                  trimWhitespace
                 />
               </div>
               <div>
@@ -215,6 +216,7 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
                   value={metadataDetails.ownerEmail}
                   onChange={(value) => setMetadataDetails((prev) => ({ ...prev, ownerEmail: value }))}
                   className="text-sm"
+                  trimWhitespace
                 />
               </div>
             </div>

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -35,6 +35,8 @@ export interface TextInputProps {
   ref?: React.Ref<HTMLInputElement>
   error?: boolean | string
   autocomplete?: 'off' | 'username' | 'current-password' | 'new-password' | 'email' | 'tel' | string
+  /** Trim leading/trailing whitespace on blur (Vue `trim-whitespace` parity). */
+  trimWhitespace?: boolean
 }
 
 export default function TextInput({
@@ -63,7 +65,8 @@ export default function TextInput({
   className,
   ref,
   error,
-  autocomplete = 'off'
+  autocomplete = 'off',
+  trimWhitespace = false
 }: TextInputProps) {
   const t = useTypeSafeTranslations()
   const generatedId = useId()
@@ -111,6 +114,12 @@ export default function TextInput({
   }
 
   const handleBlur = () => {
+    if (trimWhitespace && typeof value === 'string') {
+      const trimmed = value.trim()
+      if (trimmed !== value) {
+        onChange?.(trimmed)
+      }
+    }
     onBlur?.()
   }
 

--- a/src/components/ui/TextareaInput.tsx
+++ b/src/components/ui/TextareaInput.tsx
@@ -16,6 +16,8 @@ export interface TextareaInputProps {
   onChange?: (value: string) => void
   className?: string
   fillHeight?: boolean
+  /** Trim leading/trailing whitespace on blur (Vue `trim-whitespace` parity). */
+  trimWhitespace?: boolean
 }
 
 /**
@@ -32,7 +34,8 @@ export default function TextareaInput({
   disabled = false,
   onChange,
   className,
-  fillHeight = false
+  fillHeight = false,
+  trimWhitespace = false
 }: TextareaInputProps) {
   const generatedId = useId()
   const textareaInputId = id || generatedId
@@ -41,6 +44,15 @@ export default function TextareaInput({
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onChange?.(e.target.value)
+  }
+
+  const handleBlur = () => {
+    if (trimWhitespace && typeof value === 'string') {
+      const trimmed = value.trim()
+      if (trimmed !== value) {
+        onChange?.(trimmed)
+      }
+    }
   }
 
   const textareaClass = mergeClasses('w-full', fillHeight && (label ? 'h-full grid grid-rows-[auto_1fr]' : 'h-full flex flex-col'), className)
@@ -73,6 +85,7 @@ export default function TextareaInput({
           aria-readonly={readOnly || undefined}
           aria-multiline="true"
           onChange={handleChange}
+          onBlur={handleBlur}
           cy-id="textarea-input-textarea"
         />
       </InputWrapper>

--- a/src/components/widgets/BookDetailsEdit.tsx
+++ b/src/components/widgets/BookDetailsEdit.tsx
@@ -15,6 +15,8 @@ type Details = Omit<BookMetadata, 'titleIgnorePrefix' | 'descriptionPlain' | 'pu
   series: Series[]
 }
 
+const BOOK_TEXT_TRIM_FIELDS = ['title', 'subtitle', 'isbn', 'asin', 'publisher', 'language'] as const satisfies readonly (keyof Details)[]
+
 export type BookDetailsEditRef = DetailsEditRef<Details>
 export type BookUpdatePayload = UpdatePayload<Details>
 
@@ -89,7 +91,8 @@ const BookDetailsEdit = ({
     extractAuthor,
     onChange,
     onSubmit,
-    batchAppendLogic
+    batchAppendLogic,
+    trimFields: BOOK_TEXT_TRIM_FIELDS
   })
 
   const authorItems = useMemo(() => details.authors.map((a) => ({ value: a.id, content: a.name })), [details.authors])
@@ -207,10 +210,10 @@ const BookDetailsEdit = ({
       >
         <div className="-mx-1 flex flex-wrap">
           <div className="w-full px-1 md:w-1/2">
-            <TextInput value={details.title || ''} onChange={handleFieldUpdate('title')} label={t('LabelTitle')} />
+            <TextInput value={details.title || ''} onChange={handleFieldUpdate('title')} label={t('LabelTitle')} trimWhitespace />
           </div>
           <div className="mt-2 grow px-1 md:mt-0">
-            <TextInput value={details.subtitle || ''} onChange={handleFieldUpdate('subtitle')} label={t('LabelSubtitle')} />
+            <TextInput value={details.subtitle || ''} onChange={handleFieldUpdate('subtitle')} label={t('LabelSubtitle')} trimWhitespace />
           </div>
         </div>
 
@@ -280,19 +283,19 @@ const BookDetailsEdit = ({
             />
           </div>
           <div className="mt-2 w-1/2 px-1 md:mt-0 md:w-1/4">
-            <TextInput value={details.isbn || ''} onChange={handleFieldUpdate('isbn')} label="ISBN" />
+            <TextInput value={details.isbn || ''} onChange={handleFieldUpdate('isbn')} label="ISBN" trimWhitespace />
           </div>
           <div className="mt-2 w-1/2 px-1 md:mt-0 md:w-1/4">
-            <TextInput value={details.asin || ''} onChange={handleFieldUpdate('asin')} label="ASIN" />
+            <TextInput value={details.asin || ''} onChange={handleFieldUpdate('asin')} label="ASIN" trimWhitespace />
           </div>
         </div>
 
         <div className="-mx-1 mt-2 flex flex-wrap">
           <div className="w-full px-1 md:w-1/4">
-            <TextInput value={details.publisher || ''} onChange={handleFieldUpdate('publisher')} label={t('LabelPublisher')} />
+            <TextInput value={details.publisher || ''} onChange={handleFieldUpdate('publisher')} label={t('LabelPublisher')} trimWhitespace />
           </div>
           <div className="mt-2 w-1/2 px-1 md:mt-0 md:w-1/4">
-            <TextInput value={details.language || ''} onChange={handleFieldUpdate('language')} label={t('LabelLanguage')} />
+            <TextInput value={details.language || ''} onChange={handleFieldUpdate('language')} label={t('LabelLanguage')} trimWhitespace />
           </div>
           <div className="mt-2 flex w-full items-center gap-6 px-1 md:contents">
             <div className="flex h-10 flex-1 items-center md:mt-6 md:w-1/4 md:flex-none md:px-1">

--- a/src/components/widgets/CoverEdit.tsx
+++ b/src/components/widgets/CoverEdit.tsx
@@ -79,12 +79,10 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
     const libraryFiles = (libraryItem.libraryFiles || []) as LibraryFile[]
     return libraryFiles
       .filter((f) => f.fileType === 'image')
-      .map(
-        (file): LocalCover => ({
-          ...file,
-          localPath: getLibraryFileUrl(libraryItem.id, file.ino, libraryItem.updatedAt)
-        })
-      )
+      .map((file): LocalCover => ({
+        ...file,
+        localPath: getLibraryFileUrl(libraryItem.id, file.ino, libraryItem.updatedAt)
+      }))
   }, [libraryItem.libraryFiles, libraryItem.id, libraryItem.updatedAt])
 
   const userCanUpload = user.permissions?.upload || false
@@ -180,7 +178,7 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
 
   const submitForm = (e: React.FormEvent) => {
     e.preventDefault()
-    handleUpdateCover(imageUrl)
+    handleUpdateCover(imageUrl.trim())
   }
 
   const persistProvider = () => {
@@ -199,8 +197,8 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
 
     // Initiate search via hook
     searchCovers({
-      title: searchTitle,
-      author: searchAuthor || '',
+      title: searchTitle.trim(),
+      author: searchAuthor.trim(),
       provider: provider,
       podcast: isPodcast
     })
@@ -279,8 +277,16 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
                 placeholder={t('LabelImageURLFromTheWeb')}
                 className="min-w-0 flex-1"
                 disabled={isPendingUpdate}
+                trimWhitespace
               />
-              <Btn size="small" color="bg-success" type="submit" disabled={!imageUrl || isPendingUpdate} loading={isPendingUpdate} className="w-24 shrink-0">
+              <Btn
+                size="small"
+                color="bg-success"
+                type="submit"
+                disabled={!imageUrl.trim() || isPendingUpdate}
+                loading={isPendingUpdate}
+                className="w-24 shrink-0"
+              >
                 {t('ButtonSubmit')}
               </Btn>
             </form>
@@ -337,6 +343,7 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
           label={searchTitleLabel}
           placeholder={t('PlaceholderSearch')}
           className="min-w-0 grow basis-48"
+          trimWhitespace
         />
         {showAuthorField && (
           <TextInput
@@ -346,6 +353,7 @@ export default function CoverEdit({ libraryItem }: CoverEditProps) {
             disabled={searchInProgress}
             label={t('LabelAuthor')}
             className="min-w-0 grow basis-48"
+            trimWhitespace
           />
         )}
         {searchInProgress ? (

--- a/src/components/widgets/EpisodeDetailsEdit.tsx
+++ b/src/components/widgets/EpisodeDetailsEdit.tsx
@@ -22,6 +22,8 @@ type EpisodeDetails = {
 
 export type EpisodeBatchDetails = Pick<EpisodeDetails, 'season' | 'episode' | 'episodeType' | 'subtitle'>
 
+const TRIM_FIELDS = new Set<keyof EpisodeDetails>(['season', 'episode', 'title', 'subtitle'])
+
 function episodeToDetails(episode: PodcastEpisode): EpisodeDetails {
   return {
     season: episode.season || '',
@@ -115,10 +117,12 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
     const payload: UpdatePodcastEpisodePayload = {}
     const keys: (keyof EpisodeDetails)[] = ['season', 'episode', 'episodeType', 'title', 'subtitle', 'description', 'pubDate', 'publishedAt']
     for (const key of keys) {
-      if (details[key] != initial[key]) {
-        const value = details[key]
-        if (value !== null && value !== undefined) {
-          ;(payload as Record<string, unknown>)[key] = value
+      const raw = details[key]
+      const currentValue = TRIM_FIELDS.has(key) && typeof raw === 'string' ? raw.trim() : raw
+      const initialValue = initial[key]
+      if (currentValue != initialValue) {
+        if (currentValue !== null && currentValue !== undefined) {
+          ;(payload as Record<string, unknown>)[key] = currentValue
         }
       }
     }
@@ -173,10 +177,10 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
     >
       <div className="-mx-1 flex flex-wrap">
         <div className="w-1/2 p-1 md:w-1/5">
-          <TextInput value={details.season} onChange={(v) => updateField('season', v)} label={t('LabelSeason')} />
+          <TextInput value={details.season} onChange={(v) => updateField('season', v)} label={t('LabelSeason')} trimWhitespace />
         </div>
         <div className="w-1/2 p-1 md:w-1/5">
-          <TextInput value={details.episode} onChange={(v) => updateField('episode', v)} label={t('LabelEpisode')} />
+          <TextInput value={details.episode} onChange={(v) => updateField('episode', v)} label={t('LabelEpisode')} trimWhitespace />
         </div>
         <div className="mt-2 w-28 p-1 md:mt-0 md:w-1/5">
           <Dropdown
@@ -197,10 +201,10 @@ export default function EpisodeDetailsEdit({ episode, onChange, onSubmit, ref }:
           />
         </div>
         <div className="mt-2 w-full p-1">
-          <TextInput value={details.title} onChange={(v) => updateField('title', v)} label={t('LabelTitle')} />
+          <TextInput value={details.title} onChange={(v) => updateField('title', v)} label={t('LabelTitle')} trimWhitespace />
         </div>
         <div className="mt-2 w-full p-1">
-          <TextareaInput value={details.subtitle} onChange={(v) => updateField('subtitle', v)} label={t('LabelSubtitle')} rows={3} />
+          <TextareaInput value={details.subtitle} onChange={(v) => updateField('subtitle', v)} label={t('LabelSubtitle')} rows={3} trimWhitespace />
         </div>
         <div className="mt-2 w-full p-1">
           <SlateEditor srcContent={initial.description || ''} onUpdate={(v) => updateField('description', v)} label={t('LabelDescription')} />

--- a/src/components/widgets/PodcastDetailsEdit.tsx
+++ b/src/components/widgets/PodcastDetailsEdit.tsx
@@ -12,6 +12,8 @@ import TextInput from '../ui/TextInput'
 
 type Details = Omit<PodcastMetadata, 'titleIgnorePrefix' | 'descriptionPlain' | 'imageUrl' | 'itunesPageUrl' | 'itunesArtistId'>
 
+const PODCAST_TEXT_TRIM_FIELDS = ['title', 'author', 'feedUrl', 'releaseDate', 'itunesId', 'language'] as const satisfies readonly (keyof Details)[]
+
 export type PodcastDetailsEditRef = DetailsEditRef<Details>
 export type PodcastUpdatePayload = UpdatePayload<Details>
 
@@ -57,7 +59,8 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
     onChange,
     onSubmit,
     batchAppendLogic,
-    useLooseEquality: true
+    useLooseEquality: true,
+    trimFields: PODCAST_TEXT_TRIM_FIELDS
   })
 
   const podcastTypeItems = useMemo<DropdownItem[]>(
@@ -114,10 +117,10 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
       >
         <div className="-mx-1 flex flex-wrap">
           <div className="w-full px-1 md:w-1/2">
-            <TextInput value={details.title || ''} onChange={handleFieldUpdate('title') as (value: string) => void} label={t('LabelTitle')} />
+            <TextInput value={details.title || ''} onChange={handleFieldUpdate('title') as (value: string) => void} label={t('LabelTitle')} trimWhitespace />
           </div>
           <div className="mt-2 grow px-1 md:mt-0">
-            <TextInput value={details.author || ''} onChange={handleFieldUpdate('author') as (value: string) => void} label={t('LabelAuthor')} />
+            <TextInput value={details.author || ''} onChange={handleFieldUpdate('author') as (value: string) => void} label={t('LabelAuthor')} trimWhitespace />
           </div>
         </div>
 
@@ -126,6 +129,7 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
           onChange={handleFieldUpdate('feedUrl') as (value: string) => void}
           label={t('LabelRSSFeedURL')}
           className="mt-2"
+          trimWhitespace
         />
 
         <SlateEditor srcContent={initialDetails.description || ''} onUpdate={handleFieldUpdate('description')} label={t('LabelDescription')} className="mt-2" />
@@ -155,13 +159,28 @@ const PodcastDetailsEdit = ({ libraryItem, availableGenres = [], availableTags =
 
         <div className="-mx-1 mt-2 flex flex-wrap">
           <div className="w-full px-1 md:w-1/4">
-            <TextInput value={details.releaseDate || ''} onChange={handleFieldUpdate('releaseDate') as (value: string) => void} label={t('LabelReleaseDate')} />
+            <TextInput
+              value={details.releaseDate || ''}
+              onChange={handleFieldUpdate('releaseDate') as (value: string) => void}
+              label={t('LabelReleaseDate')}
+              trimWhitespace
+            />
           </div>
           <div className="mt-2 w-full px-1 md:mt-0 md:w-1/4">
-            <TextInput value={details.itunesId || ''} onChange={handleFieldUpdate('itunesId') as (value: string | number) => void} label="iTunes ID" />
+            <TextInput
+              value={details.itunesId || ''}
+              onChange={handleFieldUpdate('itunesId') as (value: string | number) => void}
+              label="iTunes ID"
+              trimWhitespace
+            />
           </div>
           <div className="mt-2 w-full px-1 md:mt-0 md:w-1/4">
-            <TextInput value={details.language || ''} onChange={handleFieldUpdate('language') as (value: string) => void} label={t('LabelLanguage')} />
+            <TextInput
+              value={details.language || ''}
+              onChange={handleFieldUpdate('language') as (value: string) => void}
+              label={t('LabelLanguage')}
+              trimWhitespace
+            />
           </div>
           <div className="mt-2 grow px-1 pt-6 md:mt-0">
             <div className="flex justify-center">

--- a/src/components/widgets/batch-edit/BatchEpisodeMapDetailsPanel.tsx
+++ b/src/components/widgets/batch-edit/BatchEpisodeMapDetailsPanel.tsx
@@ -91,9 +91,11 @@ export default function BatchEpisodeMapDetailsPanel({ episodes, onApply, onHasSe
 
   const handleApply = useCallback(() => {
     const payload: Partial<EpisodeBatchDetails> = {}
+    const trimFields: EpisodeBatchFieldKey[] = ['season', 'episode', 'subtitle']
     for (const key of Object.keys(usage) as EpisodeBatchFieldKey[]) {
       if (!usage[key]) continue
-      payload[key] = details[key]
+      const value = details[key]
+      payload[key] = trimFields.includes(key) && typeof value === 'string' ? value.trim() : value
     }
     onApply(payload)
   }, [details, onApply, usage])
@@ -135,6 +137,7 @@ export default function BatchEpisodeMapDetailsPanel({ episodes, onApply, onHasSe
               disabled={fieldDisabled('season')}
               label={t('LabelSeason')}
               className={MAP_FIELD_INPUT_CLASS}
+              trimWhitespace
             />
           </div>
 
@@ -146,6 +149,7 @@ export default function BatchEpisodeMapDetailsPanel({ episodes, onApply, onHasSe
               disabled={fieldDisabled('episode')}
               label={t('LabelEpisode')}
               className={MAP_FIELD_INPUT_CLASS}
+              trimWhitespace
             />
           </div>
 
@@ -171,6 +175,7 @@ export default function BatchEpisodeMapDetailsPanel({ episodes, onApply, onHasSe
               label={t('LabelSubtitle')}
               rows={2}
               className={MAP_FIELD_INPUT_CLASS}
+              trimWhitespace
             />
           </div>
 

--- a/src/components/widgets/batch-edit/BatchLibraryItemMapDetailsPanel.tsx
+++ b/src/components/widgets/batch-edit/BatchLibraryItemMapDetailsPanel.tsx
@@ -231,7 +231,7 @@ export default function BatchLibraryItemMapDetailsPanel({
         case 'publishedYear':
         case 'publisher':
         case 'language':
-          payload[key] = details[key]
+          payload[key] = details[key].trim()
           break
         case 'explicit':
         case 'abridged':
@@ -319,6 +319,7 @@ export default function BatchLibraryItemMapDetailsPanel({
                 disabled={fieldDisabled('subtitle')}
                 label={t('LabelSubtitle')}
                 className={MAP_FIELD_INPUT_CLASS}
+                trimWhitespace
               />
             </div>
           )}
@@ -349,6 +350,7 @@ export default function BatchLibraryItemMapDetailsPanel({
                 disabled={fieldDisabled('publishedYear')}
                 label={t('LabelPublishYear')}
                 className={MAP_FIELD_INPUT_CLASS}
+                trimWhitespace
               />
             </div>
           )}
@@ -432,6 +434,7 @@ export default function BatchLibraryItemMapDetailsPanel({
                 disabled={fieldDisabled('publisher')}
                 label={t('LabelPublisher')}
                 className={MAP_FIELD_INPUT_CLASS}
+                trimWhitespace
               />
             </div>
           )}
@@ -446,6 +449,7 @@ export default function BatchLibraryItemMapDetailsPanel({
                   disabled={fieldDisabled('language')}
                   label={t('LabelLanguage')}
                   className={MAP_FIELD_INPUT_CLASS}
+                  trimWhitespace
                 />
               </div>
               <div className={MAP_FIELD_FLAGS_HALF_CLASS}>

--- a/src/components/widgets/match/BookMatchView.tsx
+++ b/src/components/widgets/match/BookMatchView.tsx
@@ -34,6 +34,8 @@ interface BookMatchUsage {
   [key: string]: boolean
 }
 
+const BOOK_MATCH_STRING_METADATA_KEYS = ['title', 'subtitle', 'description', 'publisher', 'publishedYear', 'language', 'isbn', 'asin']
+
 interface BookMatchViewProps {
   selectedMatchOrig: BookSearchResult
   libraryItemId: string
@@ -221,11 +223,13 @@ export default function BookMatchView({
       } else if (key === 'tags') {
         updatePayload.tags = Array.isArray(value) ? value.filter((t): t is string => !!t) : [value].filter((t): t is string => !!t)
       } else if (key === 'cover') {
-        updatePayload.url = value as string
+        updatePayload.url = (value as string).trim()
       } else if (key === 'explicit' || key === 'abridged') {
         updatePayload.metadata![key] = value as boolean
-      } else if (['title', 'subtitle', 'description', 'publisher', 'publishedYear', 'language', 'isbn', 'asin'].includes(key)) {
-        updatePayload.metadata![key] = value as string | undefined
+      } else if (BOOK_MATCH_STRING_METADATA_KEYS.includes(key)) {
+        if (typeof value === 'string') {
+          updatePayload.metadata![key] = value.trim()
+        }
       }
     }
 

--- a/src/components/widgets/match/PodcastMatchView.tsx
+++ b/src/components/widgets/match/PodcastMatchView.tsx
@@ -29,6 +29,8 @@ interface PodcastMatchUsage {
   [key: string]: boolean
 }
 
+const PODCAST_MATCH_STRING_METADATA_KEYS = ['title', 'description', 'language', 'feedUrl', 'itunesPageUrl', 'releaseDate', 'author']
+
 interface PodcastMatchViewProps {
   selectedMatchOrig: PodcastSearchResult
   libraryItemId: string
@@ -118,11 +120,13 @@ export default function PodcastMatchView({
         } else if (key === 'itunesId') {
           updatePayload.metadata!.itunesId = String(value)
         } else if (key === 'cover') {
-          updatePayload.url = value as string
+          updatePayload.url = (value as string).trim()
         } else if (key === 'explicit') {
           updatePayload.metadata!.explicit = value as boolean
-        } else if (['title', 'description', 'language', 'feedUrl', 'itunesPageUrl', 'releaseDate', 'author'].includes(key)) {
-          updatePayload.metadata![key] = value as string | undefined
+        } else if (PODCAST_MATCH_STRING_METADATA_KEYS.includes(key)) {
+          if (typeof value === 'string') {
+            updatePayload.metadata![key] = value.trim()
+          }
         }
       }
 

--- a/src/components/widgets/match/TextInputMatchFieldEditor.tsx
+++ b/src/components/widgets/match/TextInputMatchFieldEditor.tsx
@@ -57,7 +57,16 @@ function TextInputMatchFieldEditor({
       hasCurrentValue={hasCurrentValue}
       className={className}
     >
-      <TextInput value={value} onChange={onChange} disabled={disabled || !usageChecked} label={label} type={type} readOnly={readOnly} className={className} />
+      <TextInput
+        value={value}
+        onChange={onChange}
+        disabled={disabled || !usageChecked}
+        label={label}
+        type={type}
+        readOnly={readOnly}
+        className={className}
+        trimWhitespace={type !== 'password' && type !== 'number'}
+      />
     </BaseMatchFieldEditor>
   )
 }

--- a/src/hooks/useDetailsEdit.ts
+++ b/src/hooks/useDetailsEdit.ts
@@ -94,6 +94,8 @@ interface UseDetailsEditOptions<TDetails> {
   batchAppendLogic?: (state: EditState<TDetails>, detailsToUpdate: Partial<TDetails>) => TDetails
   /** Use loose equality (!=) instead of strict equality (!==) for change detection */
   useLooseEquality?: boolean
+  /** Trim string values for these keys when diffing and building the update payload */
+  trimFields?: ReadonlyArray<keyof TDetails>
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,7 +108,8 @@ export function useDetailsEdit<TDetails extends Record<string, any>>({
   onChange,
   onSubmit,
   batchAppendLogic,
-  useLooseEquality = false
+  useLooseEquality = false,
+  trimFields
 }: UseDetailsEditOptions<TDetails>) {
   const reducer = useMemo(() => createDetailsReducer<TDetails>(batchAppendLogic), [batchAppendLogic])
 
@@ -148,10 +151,18 @@ export function useDetailsEdit<TDetails extends Record<string, any>>({
 
   // Calculate changes
   const changes = useMemo(() => {
+    const effectiveValue = (key: keyof TDetails) => {
+      const value = details[key]
+      if (trimFields?.includes(key) && typeof value === 'string') {
+        return value.trim() as TDetails[typeof key]
+      }
+      return value
+    }
+
     const changedEntries = (Object.keys(details) as Array<keyof TDetails>)
       .filter((key) => {
         const initialValue = initialDetails[key]
-        const currentValue = details[key]
+        const currentValue = effectiveValue(key)
 
         if (Array.isArray(currentValue) && Array.isArray(initialValue)) {
           return JSON.stringify(currentValue) !== JSON.stringify(initialValue)
@@ -160,7 +171,7 @@ export function useDetailsEdit<TDetails extends Record<string, any>>({
         // Use loose or strict equality based on option
         return useLooseEquality ? currentValue != initialValue : currentValue !== initialValue
       })
-      .map((key) => [key, details[key]])
+      .map((key) => [key, effectiveValue(key)])
 
     const metadataUpdate = Object.fromEntries(changedEntries) as Partial<TDetails>
 
@@ -177,7 +188,7 @@ export function useDetailsEdit<TDetails extends Record<string, any>>({
       updatePayload,
       hasChanges: Object.keys(updatePayload).length > 0
     }
-  }, [details, initialDetails, currentTags, initialTags, useLooseEquality])
+  }, [details, initialDetails, currentTags, initialTags, useLooseEquality, trimFields])
 
   // Notify parent of changes
   const handleInputChange = useCallback(() => {


### PR DESCRIPTION
## Summary

Trailing/leading whitespace in text fields could reach save actions or leave Save enabled with no real change, because  `Btn` uses `mousedown` `preventDefault` (which is the desired behavior and matches Vue), so focused inputs do not blur on click and blur-only cleanup never runs.

This PR applies a consistent fix across forms:

- **Handler-level trim** — normalize strings when building save payloads and when comparing dirty state / validation
- **Blur cleanup (Vue parity)** — opt-in `trimWhitespace` on `TextInput` / `TextareaInput`
- **`useDetailsEdit`** — new `trimFields` option for book/podcast item editors

### Areas updated

- **Shared:** `TextInput`, `TextareaInput`, `useDetailsEdit`
- **Item editors:** book, podcast, episode details
- **Modals:** author edit, new podcast, RSS feed open
- **Settings:** library edit, API key create, notification templates, user account
- **Widgets:** batch map details, metadata match apply, cover URL/search

*Note: this depends on #153. Please do not merge before I rebase to master.*
