### PR TITLE
OIDC login

### DIFF
--- a/src/app/(blank)/login/LoginForm.tsx
+++ b/src/app/(blank)/login/LoginForm.tsx
@@ -3,14 +3,17 @@
 import Btn from '@/components/ui/Btn'
 import TextInput from '@/components/ui/TextInput'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { AuthFormData } from '@/types/api'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 interface LoginFormProps {
-  loginCustomMessage?: string | null
+  authMethods: string[]
+  authFormData: AuthFormData
+  serverUrl: string
 }
 
-export default function LoginForm({ loginCustomMessage }: LoginFormProps) {
+export default function LoginForm({ authMethods, authFormData, serverUrl }: LoginFormProps) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -18,6 +21,39 @@ export default function LoginForm({ loginCustomMessage }: LoginFormProps) {
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+
+  const showLocalLogin = authMethods.includes('local') || authMethods.length === 0
+  const showOpenIdLogin = authMethods.includes('openid')
+
+  const openIdButtonText = authFormData.authOpenIDButtonText || 'Login with OpenId'
+  const loginCustomMessage = authFormData.authLoginCustomMessage || null
+
+  const redirectParam = searchParams.get('redirect')
+  const openIdAuthUri = useMemo(() => {
+    const callbackUrl = new URL(`${serverUrl}/login`)
+    if (redirectParam) {
+      callbackUrl.searchParams.set('redirect', redirectParam)
+    }
+    return `${serverUrl}/auth/openid?callback=${encodeURIComponent(callbackUrl.href)}`
+  }, [serverUrl, redirectParam])
+
+  useEffect(() => {
+    const errorParam = searchParams.get('error')
+    if (errorParam) {
+      setError(errorParam)
+      const url = new URL(window.location.href)
+      url.searchParams.delete('error')
+      window.history.replaceState({}, '', url.href)
+    }
+
+    if (!showOpenIdLogin) return
+
+    const autoLaunchParam = searchParams.get('autoLaunch')
+    const shouldAutoLaunch = (authFormData.authOpenIDAutoLaunch && autoLaunchParam !== '0') || autoLaunchParam === '1'
+    if (shouldAutoLaunch) {
+      window.location.href = openIdAuthUri
+    }
+  }, [searchParams, showOpenIdLogin, authFormData.authOpenIDAutoLaunch, openIdAuthUri])
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -40,7 +76,6 @@ export default function LoginForm({ loginCustomMessage }: LoginFormProps) {
         const userResponse = await res.json()
         const userDefaultLibraryId = userResponse?.userDefaultLibraryId
 
-        // Get redirect parameter
         const redirect = searchParams.get('redirect')
         if (redirect) {
           router.replace(redirect)
@@ -59,23 +94,38 @@ export default function LoginForm({ loginCustomMessage }: LoginFormProps) {
   )
 
   return (
-    <form onSubmit={handleSubmit} className="bg-bg border-border w-full max-w-md rounded-lg border p-4 shadow-lg">
+    <div className="bg-bg border-border w-full max-w-md rounded-lg border p-4 shadow-lg">
       <h1 className="text-center text-2xl font-bold">{t('LabelLogin')}</h1>
 
       <div className="bg-border my-4 h-px w-full" />
 
       {loginCustomMessage ? <div className="default-style mb-4" dangerouslySetInnerHTML={{ __html: loginCustomMessage }} /> : null}
 
-      <div className="mb-4 flex flex-col gap-4">
-        <TextInput label={t('LabelUsername')} value={username} autocomplete="username" onChange={setUsername} />
-        <TextInput label={t('LabelPassword')} value={password} type="password" autocomplete="current-password" onChange={setPassword} />
-      </div>
-      {error && <div className="mb-4 text-center text-sm text-red-400">{error}</div>}
-      <div className="flex justify-end">
-        <Btn type="submit" loading={loading}>
-          {t('LabelSubmit')}
-        </Btn>
-      </div>
-    </form>
+      {error ? <div className="mb-4 text-center text-sm text-red-400">{error}</div> : null}
+
+      {showLocalLogin ? (
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4 flex flex-col gap-4">
+            <TextInput label={t('LabelUsername')} value={username} autocomplete="username" onChange={setUsername} />
+            <TextInput label={t('LabelPassword')} value={password} type="password" autocomplete="current-password" onChange={setPassword} />
+          </div>
+          <div className="flex justify-end">
+            <Btn type="submit" loading={loading}>
+              {t('LabelSubmit')}
+            </Btn>
+          </div>
+        </form>
+      ) : null}
+
+      {showLocalLogin && showOpenIdLogin ? <div className="bg-border my-4 h-px w-full" /> : null}
+
+      {showOpenIdLogin ? (
+        <div className="flex py-3">
+          <a href={openIdAuthUri} className="bg-primary w-full rounded-md border border-gray-600 px-8 py-2 text-center leading-none text-white shadow-md">
+            {openIdButtonText}
+          </a>
+        </div>
+      ) : null}
+    </div>
   )
 }

--- a/src/app/(blank)/login/page.tsx
+++ b/src/app/(blank)/login/page.tsx
@@ -1,19 +1,36 @@
-import { getServerStatus } from '@/lib/api'
+import { completeOidcLogin, getClientBaseUrl, getServerStatus } from '@/lib/api'
+import { AuthFormData } from '@/types/api'
+import { redirect } from 'next/navigation'
 import LoginForm from './LoginForm'
 import ServerInitForm from './ServerInitForm'
 
 export const dynamic = 'force-dynamic'
 
-export default async function LoginPage() {
+interface LoginPageProps {
+  searchParams: Promise<{ accessToken?: string; redirect?: string }>
+}
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const params = await searchParams
+
+  if (params.accessToken) {
+    const redirectPath = await completeOidcLogin(params.accessToken, params.redirect ?? null)
+    if (!redirectPath) {
+      redirect('/login?error=Authorization%20failed&autoLaunch=0')
+    }
+    redirect(redirectPath)
+  }
+
   try {
-    const status = await getServerStatus()
+    const [status, serverUrl] = await Promise.all([getServerStatus(), getClientBaseUrl()])
     const isServerInitialized = !!status?.isInit
 
-    const loginCustomMessage = status.authFormData?.authLoginCustomMessage || null
+    const authMethods = status.authMethods ?? []
+    const authFormData: AuthFormData = status.authFormData ?? {}
 
     return (
       <div className="-mt-[var(--header-height)] flex min-h-full items-center justify-center">
-        {isServerInitialized ? <LoginForm loginCustomMessage={loginCustomMessage} /> : <ServerInitForm />}
+        {isServerInitialized ? <LoginForm authMethods={authMethods} authFormData={authFormData} serverUrl={serverUrl} /> : <ServerInitForm />}
       </div>
     )
   } catch (error) {

--- a/src/app/(main)/AppBarNav.tsx
+++ b/src/app/(main)/AppBarNav.tsx
@@ -2,6 +2,7 @@
 
 import ButtonBase from '@/components/ui/ButtonBase'
 import { useClickOutside } from '@/hooks/useClickOutside'
+import { useLogout } from '@/hooks/useLogout'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { mergeClasses } from '@/lib/merge-classes'
@@ -23,6 +24,7 @@ interface AppBarNavProps {
 export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNavProps) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
+  const logout = useLogout()
   const isDesktop = useMediaQuery(DESKTOP_MEDIA_QUERY, true)
   const menuId = useId()
   const [menuOpen, setMenuOpen] = useState(false)
@@ -81,21 +83,13 @@ export default function AppBarNav({ userCanUpload, isAdmin, username }: AppBarNa
 
   const handleLogout = useCallback(async () => {
     try {
-      // Calls the Abs server logout endpoint and clears the NextJS server cookies
-      const res = await fetch('/internal-api/logout', {
-        method: 'POST'
-      })
-      if (!res.ok) {
-        console.error('Logout error:', res.status, res.statusText)
-        return
-      }
-      router.replace('/login')
+      await logout()
     } catch (err) {
       console.error('Logout error:', err)
     } finally {
       closeMenu()
     }
-  }, [router, closeMenu])
+  }, [logout, closeMenu])
 
   const activateMenuItem = useCallback(
     (index: number) => {

--- a/src/app/(main)/account/LogoutBtn.tsx
+++ b/src/app/(main)/account/LogoutBtn.tsx
@@ -1,8 +1,8 @@
 'use client'
 
 import Btn from '@/components/ui/Btn'
+import { useLogout } from '@/hooks/useLogout'
 import { useTranslations } from 'next-intl'
-import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 interface LogoutBtnProps {
@@ -11,21 +11,13 @@ interface LogoutBtnProps {
 
 export default function LogoutBtn({ size = 'medium' }: LogoutBtnProps) {
   const t = useTranslations()
-  const router = useRouter()
+  const logout = useLogout()
   const [loading, setLoading] = useState(false)
 
   const handleLogout = async () => {
     setLoading(true)
     try {
-      // Calls the Abs server logout endpoint and clears the NextJS server cookies
-      const res = await fetch('/internal-api/logout', {
-        method: 'POST'
-      })
-      if (!res.ok) {
-        console.error('Logout error:', res.status, res.statusText)
-        return
-      }
-      router.replace('/login')
+      await logout()
     } catch (err) {
       console.error('Logout error:', err)
     } finally {

--- a/src/app/internal-api/login/route.ts
+++ b/src/app/internal-api/login/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { getServerBaseUrl, setTokenCookies } from '../../../lib/api'
+import { getServerBaseUrl, setLanguageCookie, setTokenCookies } from '../../../lib/api'
 import { getTypeSafeTranslations } from '../../../lib/getTypeSafeTranslations'
 
 export async function POST(request: Request) {
@@ -36,17 +36,7 @@ export async function POST(request: Request) {
 
     const response = NextResponse.json(data)
     setTokenCookies(response, newAccessToken, newRefreshToken)
-
-    // Set language cookie from user's server settings
-    if (userLanguage) {
-      response.cookies.set('language', userLanguage, {
-        httpOnly: false,
-        secure: false,
-        sameSite: 'lax',
-        path: '/',
-        maxAge: 365 * 24 * 60 * 60 // 1 year
-      })
-    }
+    setLanguageCookie(response.cookies, userLanguage)
 
     return response
   } catch (error) {

--- a/src/app/internal-api/logout/route.ts
+++ b/src/app/internal-api/logout/route.ts
@@ -7,8 +7,13 @@ export async function POST(request: Request) {
   try {
     const cookieStore = await cookies()
     const refreshToken = cookieStore.get('refresh_token')?.value
+    const authMethod = cookieStore.get('auth_method')?.value
+    const openidIdToken = cookieStore.get('openid_id_token')?.value
 
     const audiobookshelfServerUrl = getServerBaseUrl()
+
+    // Abs server reads auth_method and openid_id_token from cookies to build the OIDC end-session URL.
+    const oidcCookies = [authMethod ? `auth_method=${authMethod}` : null, openidIdToken ? `openid_id_token=${openidIdToken}` : null].filter(Boolean)
 
     // Make logout request to the Audiobookshelf server
     const logoutResponse = await fetch(`${audiobookshelfServerUrl}/logout`, {
@@ -16,7 +21,8 @@ export async function POST(request: Request) {
       headers: {
         'Content-Type': 'application/json',
         // Pass refresh token so the session can be deleted on the Abs server
-        ...(refreshToken ? { 'x-refresh-token': refreshToken } : {})
+        ...(refreshToken ? { 'x-refresh-token': refreshToken } : {}),
+        ...(oidcCookies.length ? { Cookie: oidcCookies.join('; ') } : {})
       }
     })
 
@@ -28,6 +34,8 @@ export async function POST(request: Request) {
     // Delete token cookies
     response.cookies.delete('refresh_token')
     response.cookies.delete('access_token')
+    response.cookies.delete('auth_method')
+    response.cookies.delete('openid_id_token')
     // Clear language cookie on logout so it gets re-initialized on next login
     response.cookies.delete('language')
     return response

--- a/src/app/internal-api/logout/route.ts
+++ b/src/app/internal-api/logout/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Logout failed' }, { status: 401 })
     }
 
-    const response = NextResponse.json({ success: true })
+    const response = NextResponse.json(await logoutResponse.json())
     // Delete token cookies
     response.cookies.delete('refresh_token')
     response.cookies.delete('access_token')

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,0 +1,24 @@
+'use client'
+
+import type { ServerLogoutResponse } from '@/types/api'
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+/** Calls /internal-api/logout, then redirects to the IdP end-session URL (OIDC) or /login. */
+export function useLogout() {
+  const router = useRouter()
+
+  return useCallback(async () => {
+    const res = await fetch('/internal-api/logout', { method: 'POST' })
+    if (!res.ok) {
+      throw new Error(`Logout failed: ${res.status} ${res.statusText}`)
+    }
+
+    const data = (await res.json()) as ServerLogoutResponse
+    if (data.redirect_url) {
+      window.location.href = data.redirect_url
+    } else {
+      router.replace('/login')
+    }
+  }, [router])
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,14 +114,30 @@ export function getServerBaseUrl() {
 }
 
 /**
- * Client-facing origin from request headers (for redirects out of internal API routes).
+ * Client-facing origin from request headers (protocol + host, no ROUTER_BASE_PATH).
  * The server may use an internal hostname; the browser must be sent to the URL it used.
  */
-export function getClientBaseUrlFromRequest(request: Request): string {
-  const headers = new Headers(request.headers)
-  const host = headers.get('x-forwarded-host') || headers.get('host') || 'localhost'
-  const protocol = headers.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
+function getClientOriginFromHeaders(headerStore: { get(name: string): string | null }): string {
+  const host = headerStore.get('x-forwarded-host') || headerStore.get('host') || 'localhost'
+  const protocol = headerStore.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
   return `${protocol}://${host}`
+}
+
+export function getClientBaseUrlFromRequest(request: Request): string {
+  return getClientOriginFromHeaders(request.headers)
+}
+
+/**
+ * Browser-facing app base URL (origin + ROUTER_BASE_PATH), e.g. for OIDC callback URLs.
+ * Parallels the server's getRequestOrigin() plus global.RouterBasePath (see OidcAuthStrategy).
+ */
+export function getClientBaseUrlFromHeaders(headerStore: { get(name: string): string | null }): string {
+  const routerBasePath = process.env.ROUTER_BASE_PATH ?? ''
+  return `${getClientOriginFromHeaders(headerStore)}${routerBasePath}`
+}
+
+export async function getClientBaseUrl(): Promise<string> {
+  return getClientBaseUrlFromHeaders(await headers())
 }
 
 /**
@@ -414,6 +430,23 @@ export const getCurrentUser = cache(async (): Promise<UserLoginResponse> => {
     next: { tags: ['current-user'] }
   })
 })
+
+/**
+ * Exchange an OIDC access token (from the Express post-login redirect) into Next.js session cookies.
+ * Returns the in-app path to redirect to, or null if authorization failed.
+ */
+export async function completeOidcLogin(accessToken: string, redirectParam?: string | null): Promise<string | null> {
+  try {
+    await persistAccessTokenInCookies(accessToken)
+    const data = await getCurrentUser()
+    setLanguageCookie(await cookies(), data.serverSettings?.language)
+
+    return redirectParam || getUserDefaultUrlPath(data.userDefaultLibraryId ?? null, data.user?.type ?? 'user')
+  } catch (error) {
+    console.error('[completeOidcLogin] Error:', error)
+    return null
+  }
+}
 
 export const getListeningStats = cache(async (): Promise<ListeningStats> => {
   return apiRequest<ListeningStats>('/api/me/listening-stats')

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,10 +12,12 @@ import {
   AuthorQuickMatchPayload,
   AuthorResponse,
   AuthorUpdateResponse,
+  BatchGetLibraryItemsResponse,
+  BatchUpdateLibraryItemPayload,
+  BatchUpdateLibraryItemsResponse,
   BookSearchResult,
   Chapter,
   Collection,
-  OrderedTrackFileData,
   CreateApiKeyPayload,
   CreateCustomMetadataProviderPayload,
   CreateCustomMetadataProviderResponse,
@@ -33,6 +35,7 @@ import {
   GetCollectionsResponse,
   GetCustomMetadataProvidersResponse,
   GetEmailSettingsResponse,
+  GetEpisodeDownloadQueueResponse,
   GetFilesystemPathsResponse,
   GetLibrariesResponse,
   GetLibraryItemsResponse,
@@ -42,9 +45,8 @@ import {
   GetNotificationsResponse,
   GetOpenListeningSessionsResponse,
   GetPlaylistsResponse,
-  GetEpisodeDownloadQueueResponse,
-  GetRecentEpisodesResponse,
   GetPodcastTitlesResponse,
+  GetRecentEpisodesResponse,
   GetRssFeedsResponse,
   GetSeriesResponse,
   GetUsersResponse,
@@ -65,6 +67,7 @@ import {
   OpenMediaItemSharePayload,
   OpenRssFeedPayload,
   OpenRssFeedResponse,
+  OrderedTrackFileData,
   ParseOpmlFeedsResponse,
   PersonalizedShelf,
   Playlist,
@@ -87,12 +90,9 @@ import {
   UpdateEReaderDevicesResponse,
   UpdateLibraryItemMediaPayload,
   UpdateLibraryItemMediaResponse,
-  BatchGetLibraryItemsResponse,
-  BatchUpdateLibraryItemPayload,
-  BatchUpdateLibraryItemsResponse,
   UpdatePodcastEpisodePayload,
-  UploadCoverResponse,
   UpdateUserResponse,
+  UploadCoverResponse,
   User,
   UserAccountPayload,
   UserLoginResponse
@@ -100,9 +100,9 @@ import {
 
 import { ApiError, NetworkError, UnauthorizedError } from './apiErrors'
 
-const publicEndpoints = ['/status']
-const RefreshTokenExpiry = parseInt(process.env.REFRESH_TOKEN_EXPIRY || '') || 7 * 24 * 60 * 60 // 7 days
-const AccessTokenExpiry = parseInt(process.env.ACCESS_TOKEN_EXPIRY || '') || 12 * 60 * 60 // 12 hours
+const PUBLIC_ENDPOINTS = ['/status']
+const refreshTokenExpiry = parseInt(process.env.REFRESH_TOKEN_EXPIRY || '') || 7 * 24 * 60 * 60 // 7 days
+const accessTokenExpiry = parseInt(process.env.ACCESS_TOKEN_EXPIRY || '') || 12 * 60 * 60 // 12 hours
 
 export function getServerBaseUrl() {
   let host = process.env.HOST || 'localhost'
@@ -158,14 +158,28 @@ function sessionCookieOptions(maxAgeSeconds: number) {
   }
 }
 
+const LANGUAGE_COOKIE_OPTIONS = {
+  httpOnly: false,
+  secure: false,
+  sameSite: 'lax' as const,
+  path: '/',
+  maxAge: 365 * 24 * 60 * 60 // 1 year
+}
+
 type SessionCookieSetter = {
-  set(name: string, value: string, options: ReturnType<typeof sessionCookieOptions>): void
+  set(name: string, value: string, options: ReturnType<typeof sessionCookieOptions> | typeof LANGUAGE_COOKIE_OPTIONS): void
 }
 
 function writeSessionCookies(store: SessionCookieSetter, accessToken: string, refreshToken: string | null) {
-  store.set('access_token', accessToken, sessionCookieOptions(AccessTokenExpiry))
+  store.set('access_token', accessToken, sessionCookieOptions(accessTokenExpiry))
   if (refreshToken) {
-    store.set('refresh_token', refreshToken, sessionCookieOptions(RefreshTokenExpiry))
+    store.set('refresh_token', refreshToken, sessionCookieOptions(refreshTokenExpiry))
+  }
+}
+
+export function setLanguageCookie(store: SessionCookieSetter, language: string | null | undefined) {
+  if (language) {
+    store.set('language', language, LANGUAGE_COOKIE_OPTIONS)
   }
 }
 
@@ -295,7 +309,7 @@ async function parseApiResponseBody<T>(response: Response): Promise<T> {
  */
 export async function apiRequest<T = unknown>(endpoint: string, options: RequestInit = {}): Promise<T> {
   try {
-    const isPublic = publicEndpoints.includes(endpoint)
+    const isPublic = PUBLIC_ENDPOINTS.includes(endpoint)
     const cookieStore = await cookies()
     const baseUrl = getServerBaseUrl()
     const url = `${baseUrl}${endpoint}`

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1165,6 +1165,11 @@ export interface UserLoginResponse {
   Source: string
 }
 
+/** Response from POST /logout on the Audiobookshelf server (and /internal-api/logout passthrough) */
+export interface ServerLogoutResponse {
+  redirect_url?: string | null
+}
+
 export interface ApiKey {
   createdAt: string
   createdByUser: {


### PR DESCRIPTION
This migrates **OpenID Connect login and logout** from Vue. React handles the Express post-auth redirect (`/login?accessToken=...`), shows the OpenID button on the login page, and follows the IdP end-session URL on logout when configured.

### Notable implementation points

- **Token exchange**: `accessToken` is exchanged into httpOnly cookies in `login/page.tsx` via `completeOidcLogin()` — no extra redirect through an internal API route
- **Callback URL**: Built with `getClientBaseUrl()` (origin + `ROUTER_BASE_PATH`) so it matches the server's `isValidWebCallbackUrl` check (a more comprehensive handling of base path is left for a future PR)
- **Login UI**: `LoginForm` shows local and/or OpenID login based on `authMethods`, supports auto-launch and custom button text from `authFormData`
- **Logout**: New `useLogout` hook; `/internal-api/logout` passes through backend `redirect_url` for OIDC end-session before falling back to `/login`
- **Session cookies**: Shared `setLanguageCookie()` used by local login and OIDC completion

*Note: this depends on #154 . Please do not merge before I rebase to master.*