### PR TITLE
Fix clipped focus ring on Narrators table remove buttons

### DIFF
--- a/src/components/ui/EditList.tsx
+++ b/src/components/ui/EditList.tsx
@@ -183,7 +183,7 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
                     </td>
                   )}
                   <td className="w-1/4">
-                    <div className="flex justify-end pr-2">
+                    <div className="flex justify-end pe-2">
                       <IconBtn
                         size="small"
                         borderless={true}

--- a/src/components/ui/EditList.tsx
+++ b/src/components/ui/EditList.tsx
@@ -183,7 +183,7 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
                     </td>
                   )}
                   <td className="w-1/4">
-                    <div className="flex justify-end">
+                    <div className="flex justify-end pr-2">
                       <IconBtn
                         size="small"
                         borderless={true}


### PR DESCRIPTION
## Summary

Fixes the focus ring being clipped on the remove buttons in the Narrators table.

## Changes

- Adjusted the styles to prevent the focus ring from being clipped.
- Preserves the existing layout and behavior.

## Testing

- Verified keyboard navigation.
- Confirmed the focus ring is fully visible.

Fixes #159 