### PR TITLE
Fix #161: activate Series/Collection/Playlist cards on Enter key

### DIFF
--- a/src/components/widgets/media-card/CollapsedSeriesCard.tsx
+++ b/src/components/widgets/media-card/CollapsedSeriesCard.tsx
@@ -78,7 +78,7 @@ export default function CollapsedSeriesCard(props: CollapsedSeriesCardProps) {
 
   const handleCardKeyDown = (event: KeyboardEvent) => {
     if (event.defaultPrevented) return
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       event.stopPropagation()
       handleCardClick()

--- a/src/components/widgets/media-card/CollapsedSeriesCard.tsx
+++ b/src/components/widgets/media-card/CollapsedSeriesCard.tsx
@@ -10,7 +10,7 @@ import { computeProgress } from '@/lib/mediaProgress'
 import type { LibraryItem } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
-import { useId, useMemo, useState } from 'react'
+import { useId, useMemo, useState, type KeyboardEvent } from 'react'
 import { MediaCardProps } from './MediaCard'
 import MediaCardDetailView from './MediaCardDetailView'
 import MediaCardFrame from './MediaCardFrame'
@@ -73,6 +73,15 @@ export default function CollapsedSeriesCard(props: CollapsedSeriesCardProps) {
   const handleCardClick = () => {
     if (collapsedSeries) {
       router.push(`/library/${libraryItem.libraryId}/series/${collapsedSeries.id}`)
+    }
+  }
+
+  const handleCardKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      handleCardClick()
     }
   }
 
@@ -144,6 +153,7 @@ export default function CollapsedSeriesCard(props: CollapsedSeriesCardProps) {
       width={coverWidth}
       height={coverHeight}
       onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       cardId={cardId}

--- a/src/components/widgets/media-card/CollectionCard.tsx
+++ b/src/components/widgets/media-card/CollectionCard.tsx
@@ -16,7 +16,7 @@ import { mergeClasses } from '@/lib/merge-classes'
 import type { Collection } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
-import { memo, useCallback, useId, useMemo, useState } from 'react'
+import { memo, useCallback, useId, useMemo, useState, type KeyboardEvent } from 'react'
 import LoadingSpinner from '../LoadingSpinner'
 
 export interface CollectionCardProps {
@@ -123,12 +123,25 @@ function CollectionCard(props: CollectionCardProps) {
     onOpenRssFeedModal: handleOpenRssFeedModal
   })
 
+  const handleCardKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.defaultPrevented || processing) return
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        event.stopPropagation()
+        handleCardClick()
+      }
+    },
+    [handleCardClick, processing]
+  )
+
   return (
     <>
       <MediaCardFrame
         width={coverWidth}
         height={coverHeight}
         onClick={!processing ? handleCardClick : undefined}
+        onKeyDown={handleCardKeyDown}
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => setIsHovering(false)}
         cardId={cardId}

--- a/src/components/widgets/media-card/CollectionCard.tsx
+++ b/src/components/widgets/media-card/CollectionCard.tsx
@@ -126,7 +126,7 @@ function CollectionCard(props: CollectionCardProps) {
   const handleCardKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.defaultPrevented || processing) return
-      if (event.key === 'Enter') {
+      if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault()
         event.stopPropagation()
         handleCardClick()

--- a/src/components/widgets/media-card/PlaylistCard.tsx
+++ b/src/components/widgets/media-card/PlaylistCard.tsx
@@ -103,7 +103,7 @@ function PlaylistCard(props: PlaylistCardProps) {
   const handleCardKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (event.defaultPrevented || processing) return
-      if (event.key === 'Enter') {
+      if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault()
         event.stopPropagation()
         handleCardClick()
@@ -111,13 +111,14 @@ function PlaylistCard(props: PlaylistCardProps) {
     },
     [handleCardClick, processing]
   )
+
   return (
     <>
       <MediaCardFrame
         width={coverWidth}
         height={coverHeight}
         onClick={!processing ? handleCardClick : undefined}
-        onKeyDown={handleCardKeyDown}     
+        onKeyDown={handleCardKeyDown}
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => setIsHovering(false)}
         cardId={cardId}

--- a/src/components/widgets/media-card/PlaylistCard.tsx
+++ b/src/components/widgets/media-card/PlaylistCard.tsx
@@ -15,7 +15,7 @@ import { mergeClasses } from '@/lib/merge-classes'
 import type { Playlist } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
-import { memo, useCallback, useId, useMemo, useState } from 'react'
+import { memo, useCallback, useId, useMemo, useState, type KeyboardEvent } from 'react'
 import LoadingSpinner from '../LoadingSpinner'
 
 export interface PlaylistCardProps {
@@ -100,12 +100,24 @@ function PlaylistCard(props: PlaylistCardProps) {
 
   const { processing, confirmState, closeConfirm, handleMoreAction, moreMenuItems } = usePlaylistCardActions({ playlist })
 
+  const handleCardKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.defaultPrevented || processing) return
+      if (event.key === 'Enter') {
+        event.preventDefault()
+        event.stopPropagation()
+        handleCardClick()
+      }
+    },
+    [handleCardClick, processing]
+  )
   return (
     <>
       <MediaCardFrame
         width={coverWidth}
         height={coverHeight}
         onClick={!processing ? handleCardClick : undefined}
+        onKeyDown={handleCardKeyDown}     
         onMouseEnter={() => setIsHovering(true)}
         onMouseLeave={() => setIsHovering(false)}
         cardId={cardId}

--- a/src/components/widgets/media-card/SeriesCard.tsx
+++ b/src/components/widgets/media-card/SeriesCard.tsx
@@ -14,8 +14,7 @@ import { mergeClasses } from '@/lib/merge-classes'
 import type { MediaProgress, Series } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
-import { memo, useId, useMemo, useState } from 'react'
-
+import { memo, useId, useMemo, useState, type KeyboardEvent } from 'react'
 export interface SeriesCardProps {
   /** The series to display */
   series: Series
@@ -161,6 +160,15 @@ function SeriesCard(props: SeriesCardProps) {
     router.push(`/library/${libraryId}/series/${series.id}`)
   }
 
+  const handleCardKeyDown = (event: KeyboardEvent) => {
+    if (event.defaultPrevented) return
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      event.stopPropagation()
+      handleCardClick()
+    }
+  }
+
   const handleSelectClick = (event: React.MouseEvent) => {
     event.preventDefault()
     event.stopPropagation()
@@ -172,6 +180,7 @@ function SeriesCard(props: SeriesCardProps) {
       width={coverWidth}
       height={coverHeight}
       onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
       cardId={cardId}

--- a/src/components/widgets/media-card/SeriesCard.tsx
+++ b/src/components/widgets/media-card/SeriesCard.tsx
@@ -15,6 +15,7 @@ import type { MediaProgress, Series } from '@/types/api'
 import { BookshelfView } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { memo, useId, useMemo, useState, type KeyboardEvent } from 'react'
+
 export interface SeriesCardProps {
   /** The series to display */
   series: Series
@@ -162,7 +163,7 @@ function SeriesCard(props: SeriesCardProps) {
 
   const handleCardKeyDown = (event: KeyboardEvent) => {
     if (event.defaultPrevented) return
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
       event.stopPropagation()
       handleCardClick()


### PR DESCRIPTION
Closes #161

  MediaCardFrame (a div, not a button) only activates on Enter if the
  caller passes it an onKeyDown handler. MediaCard already did this for
  book/podcast cards, but SeriesCard, CollapsedSeriesCard, CollectionCard,
  and PlaylistCard only wired up onClick, never onKeyDown — so keyboard
  users couldn't open those cards.

  Added a handleCardKeyDown to each (mirroring MediaCard's pattern) that
  activates the card on Enter.

  Tested manually: keyboard-only Tab + Enter navigation now works on the
  Series, Collections, and Playlists pages.