### PR TITLE
Rename Settings page to General and reorganize sections

### DIFF
--- a/src/app/(main)/settings/GeneralSettingsClient.tsx
+++ b/src/app/(main)/settings/GeneralSettingsClient.tsx
@@ -15,7 +15,7 @@ import { updateServerSettings, updateSortingPrefixes } from './actions'
 import { dateFormatOptions, timeFormatOptions } from './settingsConstants'
 import SettingsToggleSwitch from './SettingsToggleSwitch'
 
-export default function SettingsClient() {
+export default function GeneralSettingsClient() {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
@@ -167,7 +167,7 @@ export default function SettingsClient() {
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
       <div className="flex flex-col gap-4 py-4">
         <div className="flex flex-col gap-2">
-          <h2 className="text-base font-semibold">{t('HeaderSettingsGeneral')}</h2>
+          <h2 className="text-base font-semibold">{t('HeaderSettingsStorage')}</h2>
           <SettingsToggleSwitch
             label={t('LabelSettingsStoreCoversWithItem')}
             value={serverSettings?.storeCoverWithItem}
@@ -180,42 +180,6 @@ export default function SettingsClient() {
             onChange={(value) => handleSettingChanged('storeMetadataWithItem', value)}
             tooltip={t('LabelSettingsStoreMetadataWithItemHelp')}
           />
-          <SettingsToggleSwitch
-            label={t('LabelSettingsSortingIgnorePrefixes')}
-            value={serverSettings?.sortingIgnorePrefix}
-            onChange={(value) => handleSettingChanged('sortingIgnorePrefix', value)}
-            tooltip={t('LabelSettingsSortingIgnorePrefixesHelp')}
-          />
-          {serverSettings?.sortingIgnorePrefix && (
-            <div className="mb-2 ml-14 w-full max-w-72">
-              <MultiSelect
-                label={t('LabelPrefixesToIgnore')}
-                items={sortingPrefixItems}
-                showEdit
-                onItemEdited={(value: MultiSelectItem<string>) => {
-                  const updatedPrefixes = sortingPrefixes.map((item) => (item === value.value ? value.content : item))
-                  handleSortingPrefixesChanged(updatedPrefixes.map((p) => ({ content: p, value: p })))
-                }}
-                onItemRemoved={(value: MultiSelectItem<string>) => {
-                  const updatedPrefixes = sortingPrefixes.filter((item) => item !== value.content)
-                  handleSortingPrefixesChanged(updatedPrefixes.map((p) => ({ content: p, value: p })))
-                }}
-                onItemAdded={(value: MultiSelectItem<string>) => {
-                  if (!sortingPrefixes.includes(value.content)) {
-                    handleSortingPrefixesChanged([...sortingPrefixes, value.content].map((p) => ({ content: p, value: p })))
-                  }
-                }}
-                selectedItems={sortingPrefixItems}
-              />
-              {hasPrefixesChanged && (
-                <div className="flex justify-end py-1">
-                  <Btn onClick={handleSaveSortingPrefixes} disabled={isPending} loading={isPending} color="bg-success text-white" size="small">
-                    {t('ButtonSave')}
-                  </Btn>
-                </div>
-              )}
-            </div>
-          )}
         </div>
         <div className="flex flex-col gap-2">
           <h2 className="text-base font-semibold">{t('HeaderSettingsScanner')}</h2>
@@ -279,6 +243,42 @@ export default function SettingsClient() {
             onChange={(value) => handleSettingChanged('bookshelfView', value)}
             tooltip={t('LabelSettingsBookshelfViewHelp')}
           />
+          <SettingsToggleSwitch
+            label={t('LabelSettingsSortingIgnorePrefixes')}
+            value={serverSettings?.sortingIgnorePrefix}
+            onChange={(value) => handleSettingChanged('sortingIgnorePrefix', value)}
+            tooltip={t('LabelSettingsSortingIgnorePrefixesHelp')}
+          />
+          {serverSettings?.sortingIgnorePrefix && (
+            <div className="mb-2 ml-14 w-full max-w-72">
+              <MultiSelect
+                label={t('LabelPrefixesToIgnore')}
+                items={sortingPrefixItems}
+                showEdit
+                onItemEdited={(value: MultiSelectItem<string>) => {
+                  const updatedPrefixes = sortingPrefixes.map((item) => (item === value.value ? value.content : item))
+                  handleSortingPrefixesChanged(updatedPrefixes.map((p) => ({ content: p, value: p })))
+                }}
+                onItemRemoved={(value: MultiSelectItem<string>) => {
+                  const updatedPrefixes = sortingPrefixes.filter((item) => item !== value.content)
+                  handleSortingPrefixesChanged(updatedPrefixes.map((p) => ({ content: p, value: p })))
+                }}
+                onItemAdded={(value: MultiSelectItem<string>) => {
+                  if (!sortingPrefixes.includes(value.content)) {
+                    handleSortingPrefixesChanged([...sortingPrefixes, value.content].map((p) => ({ content: p, value: p })))
+                  }
+                }}
+                selectedItems={sortingPrefixItems}
+              />
+              {hasPrefixesChanged && (
+                <div className="flex justify-end py-1">
+                  <Btn onClick={handleSaveSortingPrefixes} disabled={isPending} loading={isPending} color="bg-success text-white" size="small">
+                    {t('ButtonSave')}
+                  </Btn>
+                </div>
+              )}
+            </div>
+          )}
           <div className="w-full max-w-72">
             <Dropdown
               items={dateFormatOptions}

--- a/src/app/(main)/settings/SideNavContent.tsx
+++ b/src/app/(main)/settings/SideNavContent.tsx
@@ -22,7 +22,7 @@ export default function SideNavContent({ handleItemClick, serverVersion, install
   const items = useMemo(
     () => [
       {
-        label: t('HeaderSettings'),
+        label: t('HeaderSettingsGeneral'),
         href: '/settings'
       },
       {

--- a/src/app/(main)/settings/page.tsx
+++ b/src/app/(main)/settings/page.tsx
@@ -2,7 +2,7 @@ import { getCurrentUser, getData } from '@/lib/api'
 import { getTypeSafeTranslations } from '@/lib/getTypeSafeTranslations'
 import { purgeCache, purgeItemsCache } from './actions'
 import SettingsCachePurge from './SettingsCachePurge'
-import SettingsClient from './SettingsClient'
+import GeneralSettingsClient from './GeneralSettingsClient'
 import SettingsContent from './SettingsContent'
 import SettingsFooter from './SettingsFooter'
 
@@ -21,8 +21,8 @@ export default async function SettingsPage() {
 
   return (
     <>
-      <SettingsContent title={t('HeaderSettings')}>
-        <SettingsClient />
+      <SettingsContent title={t('HeaderSettingsGeneral')}>
+        <GeneralSettingsClient />
       </SettingsContent>
       <SettingsCachePurge purgeCache={purgeCache} purgeItemsCache={purgeItemsCache} />
       <SettingsFooter />

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -249,6 +249,7 @@
   "HeaderSettingsGeneral": "General",
   "HeaderSettingsScanner": "Scanner",
   "HeaderSettingsSecurity": "Security",
+  "HeaderSettingsStorage": "Storage",
   "HeaderSettingsWebClient": "Web Client",
   "HeaderSleepTimer": "Sleep Timer",
   "HeaderStats": "Stats",


### PR DESCRIPTION
Fixes #149 :
- Renames the main settings page/nav item from "Settings" to "General" to avoid Settings-within-Settings
- Moves store cover/metadata toggles into a new Storage section and ignore-prefixes into Display
- Renames `SettingsClient` to `GeneralSettingsClient`