### PR TITLE
Fix collection group cover backgrounds

### DIFF
--- a/cypress/tests/components/widgets/media-card/CollectionGroupCover.cy.tsx
+++ b/cypress/tests/components/widgets/media-card/CollectionGroupCover.cy.tsx
@@ -1,0 +1,105 @@
+import CollectionGroupCover from '@/components/widgets/media-card/CollectionGroupCover'
+import { CardSizeProvider } from '@/contexts/CardSizeContext'
+import type { LibraryItem } from '@/types/api'
+
+const bookWithCover = {
+  id: 'book-1',
+  updatedAt: 1,
+  media: { coverPath: '/cover.jpg' }
+} as LibraryItem
+
+const secondBookWithCover = {
+  id: 'book-2',
+  updatedAt: 2,
+  media: { coverPath: '/second-cover.jpg' }
+} as LibraryItem
+
+function mockImageLoad(naturalWidth: number, naturalHeight: number) {
+  cy.window().then((win) => {
+    cy.stub(win, 'Image').callsFake(() => {
+      const image = {
+        naturalWidth,
+        naturalHeight,
+        onload: null as (() => void) | null,
+        onerror: null as (() => void) | null,
+        set src(_src: string) {
+          win.setTimeout(() => image.onload?.(), 0)
+        }
+      }
+
+      return image as unknown as HTMLImageElement
+    })
+  })
+}
+
+function mockImageError() {
+  cy.window().then((win) => {
+    cy.stub(win, 'Image').callsFake(() => {
+      const image = {
+        onload: null as (() => void) | null,
+        onerror: null as (() => void) | null,
+        set src(_src: string) {
+          win.setTimeout(() => image.onerror?.(), 0)
+        }
+      }
+
+      return image as unknown as HTMLImageElement
+    })
+  })
+}
+
+function mountCollectionGroupCover(books: LibraryItem[]) {
+  cy.mount(
+    <CardSizeProvider>
+      <CollectionGroupCover books={books} width={240} height={120} />
+    </CardSizeProvider>
+  )
+}
+
+describe('<CollectionGroupCover />', () => {
+  it('preserves a non-standard cover aspect ratio with a cover background', () => {
+    mockImageLoad(900, 675)
+    mountCollectionGroupCover([bookWithCover])
+
+    cy.get('.cover-bg').should('exist').parent().should('have.css', 'width', '240px')
+    cy.get('img').should('have.class', 'object-contain').should('have.css', 'width', '160px').should('have.css', 'height', '120px')
+  })
+
+  it('uses a cover background when a square cover leaves space in a single-book layout', () => {
+    mockImageLoad(400, 400)
+    mountCollectionGroupCover([bookWithCover])
+
+    cy.get('.cover-bg').should('exist')
+    cy.get('img').should('have.class', 'object-contain').should('have.css', 'width', '120px').should('have.css', 'height', '120px')
+  })
+
+  it('preserves non-standard covers in both side-by-side cells', () => {
+    mockImageLoad(900, 675)
+    mountCollectionGroupCover([bookWithCover, secondBookWithCover])
+
+    cy.get('.cover-bg').should('have.length', 2)
+    cy.get('img')
+      .should('have.length', 2)
+      .each(($image) => {
+        cy.wrap($image).should('have.class', 'object-contain').should('have.css', 'width', '120px').should('have.css', 'height', '90px')
+      })
+  })
+
+  it('keeps covers matching their square cells in cover mode', () => {
+    mockImageLoad(400, 400)
+    mountCollectionGroupCover([bookWithCover, secondBookWithCover])
+
+    cy.get('.cover-bg').should('not.exist')
+    cy.get('img')
+      .should('have.length', 2)
+      .each(($image) => cy.wrap($image).should('have.class', 'object-cover'))
+  })
+
+  it('falls back to cover mode when image dimensions cannot be loaded', () => {
+    mockImageError()
+    mountCollectionGroupCover([bookWithCover])
+
+    cy.get('.cover-bg').should('not.exist')
+    cy.get('img').should('have.class', 'object-cover')
+  })
+})

--- a/src/components/widgets/media-card/CollectionGroupCover.tsx
+++ b/src/components/widgets/media-card/CollectionGroupCover.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useCardSize } from '@/contexts/CardSizeContext'
-import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
+import { getContainedCoverDimensions, shouldShowCoverBackground, useGroupCoverData } from '@/hooks/useGroupCoverData'
+import { mergeClasses } from '@/lib/merge-classes'
 import type { LibraryItem } from '@/types/api'
 import { useMemo } from 'react'
 
@@ -20,7 +21,37 @@ interface CollectionGroupCoverProps {
  */
 export default function CollectionGroupCover({ books, width, height }: CollectionGroupCoverProps) {
   const { sizeMultiplier } = useCardSize()
-  const placeholderUrl = useMemo(() => getPlaceholderCoverUrl(), [])
+  const displayedBooks = useMemo(() => books.slice(0, 2), [books])
+  const coverData = useGroupCoverData(displayedBooks)
+  const cellWidth = width / 2
+
+  const renderCover = (index: number, containerWidth: number = cellWidth) => {
+    const cover = coverData[index]!
+    const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, containerWidth, height)
+    const imageStyle = showCoverBg
+      ? getContainedCoverDimensions(containerWidth, height, cover.imageAspectRatio!)
+      : containerWidth > cellWidth
+        ? { width: `${cellWidth}px`, height: '100%' }
+        : undefined
+
+    return (
+      <div className="relative z-10 flex h-full items-center justify-center" style={{ width: `${containerWidth}px` }}>
+        {showCoverBg && (
+          <div className="bg-primary absolute start-0 top-0 h-full w-full overflow-hidden">
+            <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
+          </div>
+        )}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={cover.coverUrl}
+          alt=""
+          aria-hidden="true"
+          className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
+          style={imageStyle}
+        />
+      </div>
+    )
+  }
 
   // No books - show empty collection message
   if (!books.length) {
@@ -43,10 +74,7 @@ export default function CollectionGroupCover({ books, width, height }: Collectio
       <div className="relative overflow-hidden rounded-xs" style={{ width: `${width}px`, height: `${height}px` }}>
         <div className="bg-primary relative flex h-full items-center justify-center rounded-xs">
           <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
-          <div className="relative z-10 h-full" style={{ width: `${width / 2}px` }}>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src={getLibraryItemCoverSrc(books[0], placeholderUrl)} alt="" aria-hidden="true" className="h-full w-full object-cover" />
-          </div>
+          {renderCover(0, width)}
         </div>
       </div>
     )
@@ -58,17 +86,8 @@ export default function CollectionGroupCover({ books, width, height }: Collectio
       <div className="bg-primary/95 relative flex h-full justify-center rounded-xs">
         <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
 
-        {/* First book cover */}
-        <div className="relative h-full" style={{ width: `${width / 2}px` }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={getLibraryItemCoverSrc(books[0], placeholderUrl)} alt="" aria-hidden="true" className="h-full w-full object-cover" />
-        </div>
-
-        {/* Second book cover */}
-        <div className="relative h-full" style={{ width: `${width / 2}px` }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={getLibraryItemCoverSrc(books[1], placeholderUrl)} alt="" aria-hidden="true" className="h-full w-full object-cover" />
-        </div>
+        {renderCover(0)}
+        {renderCover(1)}
       </div>
     </div>
   )

--- a/src/components/widgets/media-card/CollectionGroupCover.tsx
+++ b/src/components/widgets/media-card/CollectionGroupCover.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import { GroupCoverCell, GroupCoverEmptyState } from '@/components/widgets/media-card/GroupCoverParts'
 import { useCardSize } from '@/contexts/CardSizeContext'
-import { getContainedCoverDimensions, shouldShowCoverBackground, useGroupCoverData } from '@/hooks/useGroupCoverData'
-import { mergeClasses } from '@/lib/merge-classes'
+import { useGroupCoverData } from '@/hooks/useGroupCoverData'
 import type { LibraryItem } from '@/types/api'
 import { useMemo } from 'react'
 
@@ -25,47 +25,9 @@ export default function CollectionGroupCover({ books, width, height }: Collectio
   const coverData = useGroupCoverData(displayedBooks)
   const cellWidth = width / 2
 
-  const renderCover = (index: number, containerWidth: number = cellWidth) => {
-    const cover = coverData[index]!
-    const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, containerWidth, height)
-    const imageStyle = showCoverBg
-      ? getContainedCoverDimensions(containerWidth, height, cover.imageAspectRatio!)
-      : containerWidth > cellWidth
-        ? { width: `${cellWidth}px`, height: '100%' }
-        : undefined
-
-    return (
-      <div className="relative z-10 flex h-full items-center justify-center" style={{ width: `${containerWidth}px` }}>
-        {showCoverBg && (
-          <div className="bg-primary absolute start-0 top-0 h-full w-full overflow-hidden">
-            <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
-          </div>
-        )}
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={cover.coverUrl}
-          alt=""
-          aria-hidden="true"
-          className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
-          style={imageStyle}
-        />
-      </div>
-    )
-  }
-
   // No books - show empty collection message
   if (!books.length) {
-    return (
-      <div
-        className="bg-primary relative flex h-full w-full items-center justify-center rounded-xs"
-        style={{ width: `${width}px`, height: `${height}px`, padding: `${sizeMultiplier}em` }}
-      >
-        <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
-        <p className="z-10 text-center text-white/60" style={{ fontSize: `${Math.min(1, sizeMultiplier)}em` }}>
-          Empty Collection
-        </p>
-      </div>
-    )
+    return <GroupCoverEmptyState width={width} height={height} sizeMultiplier={sizeMultiplier} label="Empty Collection" />
   }
 
   // Single book - center it with empty collection background
@@ -74,7 +36,7 @@ export default function CollectionGroupCover({ books, width, height }: Collectio
       <div className="relative overflow-hidden rounded-xs" style={{ width: `${width}px`, height: `${height}px` }}>
         <div className="bg-primary relative flex h-full items-center justify-center rounded-xs">
           <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
-          {renderCover(0, width)}
+          <GroupCoverCell cover={coverData[0]!} width={width} height={height} fallbackImageStyle={{ width: `${cellWidth}px`, height: '100%' }} />
         </div>
       </div>
     )
@@ -86,8 +48,8 @@ export default function CollectionGroupCover({ books, width, height }: Collectio
       <div className="bg-primary/95 relative flex h-full justify-center rounded-xs">
         <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
 
-        {renderCover(0)}
-        {renderCover(1)}
+        <GroupCoverCell cover={coverData[0]!} width={cellWidth} height={height} />
+        <GroupCoverCell cover={coverData[1]!} width={cellWidth} height={height} />
       </div>
     </div>
   )

--- a/src/components/widgets/media-card/GroupCoverParts.tsx
+++ b/src/components/widgets/media-card/GroupCoverParts.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { getContainedCoverDimensions, shouldShowCoverBackground, type GroupCoverData } from '@/hooks/useGroupCoverData'
+import { mergeClasses } from '@/lib/merge-classes'
+import type { CSSProperties } from 'react'
+
+interface GroupCoverEmptyStateProps {
+  width: number
+  height: number
+  sizeMultiplier: number
+  label: string
+}
+
+export function GroupCoverEmptyState({ width, height, sizeMultiplier, label }: GroupCoverEmptyStateProps) {
+  return (
+    <div
+      className="bg-primary relative flex h-full w-full items-center justify-center rounded-xs"
+      style={{ width: `${width}px`, height: `${height}px`, padding: `${sizeMultiplier}em` }}
+    >
+      <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
+      <p className="z-10 text-center text-white/60" style={{ fontSize: `${Math.min(1, sizeMultiplier)}em` }}>
+        {label}
+      </p>
+    </div>
+  )
+}
+
+interface GroupCoverCellProps {
+  cover: GroupCoverData
+  width: number
+  height: number
+  /** Image style used when the cover fills the cell without an aspect-ratio background */
+  fallbackImageStyle?: CSSProperties
+  /** Extra classes on the blurred cover background wrapper */
+  coverBgClassName?: string
+  className?: string
+}
+
+export function GroupCoverCell({ cover, width, height, fallbackImageStyle, coverBgClassName, className }: GroupCoverCellProps) {
+  const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, width, height)
+  const imageStyle = showCoverBg ? getContainedCoverDimensions(width, height, cover.imageAspectRatio!) : fallbackImageStyle
+
+  return (
+    <div className={mergeClasses('relative z-10 flex items-center justify-center', className)} style={{ width: `${width}px`, height: `${height}px` }}>
+      {showCoverBg && (
+        <div className={mergeClasses('bg-primary absolute start-0 top-0 h-full w-full overflow-hidden', coverBgClassName)}>
+          <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
+        </div>
+      )}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={cover.coverUrl}
+        alt=""
+        aria-hidden="true"
+        className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
+        style={imageStyle}
+      />
+    </div>
+  )
+}

--- a/src/components/widgets/media-card/SquareGridGroupCover.tsx
+++ b/src/components/widgets/media-card/SquareGridGroupCover.tsx
@@ -1,23 +1,16 @@
 'use client'
 
 import { useCardSize } from '@/contexts/CardSizeContext'
-import { useBookCoverAspectRatio } from '@/contexts/LibraryContext'
-import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
+import { getContainedCoverDimensions, shouldShowCoverBackground, useGroupCoverData } from '@/hooks/useGroupCoverData'
 import { mergeClasses } from '@/lib/merge-classes'
 import type { LibraryItem } from '@/types/api'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo } from 'react'
 
 interface SquareGridGroupCoverProps {
   libraryItems: LibraryItem[]
   width: number
   height: number
   emptyLabel?: string
-}
-
-interface CoverData {
-  id: string
-  coverUrl: string
-  showCoverBg: boolean
 }
 
 /**
@@ -27,11 +20,7 @@ interface CoverData {
  * - 3+ items: first 4 in 2x2 grid (cycles if fewer than 4 unique items passed)
  */
 export default function SquareGridGroupCover({ libraryItems, width, height, emptyLabel = 'Empty Playlist' }: SquareGridGroupCoverProps) {
-  const bookCoverAspectRatio = useBookCoverAspectRatio()
   const { sizeMultiplier } = useCardSize()
-  const placeholderUrl = useMemo(() => getPlaceholderCoverUrl(), [])
-  const [coverData, setCoverData] = useState<CoverData[]>([])
-  const mountedRef = useRef(true)
 
   const itemCount = libraryItems.length
 
@@ -44,33 +33,6 @@ export default function SquareGridGroupCover({ libraryItems, width, height, empt
     if (itemCount === 1) return height
     return height / 2
   }, [itemCount, height])
-
-  const itemCoverWidth = useMemo(() => {
-    const fitByHeight = cellHeight / bookCoverAspectRatio
-    const fitByWidth = cellWidth
-    return Math.min(fitByHeight, fitByWidth)
-  }, [cellWidth, cellHeight, bookCoverAspectRatio])
-
-  const itemCoverHeight = useMemo(() => {
-    return itemCoverWidth * bookCoverAspectRatio
-  }, [itemCoverWidth, bookCoverAspectRatio])
-
-  const checkImageAspectRatio = useCallback(
-    (src: string): Promise<boolean> => {
-      return new Promise((resolve) => {
-        const image = new Image()
-        image.onload = () => {
-          const { naturalWidth, naturalHeight } = image
-          const aspectRatio = naturalHeight / naturalWidth
-          const arDiff = Math.abs(aspectRatio - bookCoverAspectRatio)
-          resolve(arDiff > 0.15)
-        }
-        image.onerror = () => resolve(false)
-        image.src = src
-      })
-    },
-    [bookCoverAspectRatio]
-  )
 
   const gridLibraryItems = useMemo(() => {
     if (!libraryItems.length) return []
@@ -86,41 +48,7 @@ export default function SquareGridGroupCover({ libraryItems, width, height, empt
     }
     return covers
   }, [libraryItems])
-
-  useEffect(() => {
-    mountedRef.current = true
-    return () => {
-      mountedRef.current = false
-    }
-  }, [])
-
-  useEffect(() => {
-    async function loadCovers() {
-      if (!gridLibraryItems.length) {
-        if (mountedRef.current) {
-          setCoverData([])
-        }
-        return
-      }
-
-      const results = await Promise.all(
-        gridLibraryItems.map(async (item, index) => {
-          const coverUrl = getLibraryItemCoverSrc(item, placeholderUrl)
-          return {
-            id: `${item.id}-${index}`,
-            coverUrl,
-            showCoverBg: await checkImageAspectRatio(coverUrl)
-          }
-        })
-      )
-
-      if (mountedRef.current) {
-        setCoverData(results)
-      }
-    }
-
-    loadCovers()
-  }, [gridLibraryItems, checkImageAspectRatio, placeholderUrl])
+  const coverData = useGroupCoverData(gridLibraryItems)
 
   if (!itemCount) {
     return (
@@ -137,24 +65,25 @@ export default function SquareGridGroupCover({ libraryItems, width, height, empt
   }
 
   if (itemCount === 1) {
-    const cover = coverData[0]
+    const cover = coverData[0]!
+    const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, cellWidth, cellHeight)
     return (
       <div className="relative overflow-hidden rounded-xs" style={{ width: `${width}px`, height: `${height}px` }}>
         <div className="bg-primary relative flex h-full items-center justify-center rounded-xs">
           <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
           <div className="relative z-10 flex items-center justify-center" style={{ width: `${cellWidth}px`, height: `${cellHeight}px` }}>
-            {cover?.showCoverBg && (
+            {showCoverBg && (
               <div className="bg-primary absolute start-0 top-0 h-full w-full overflow-hidden rounded-xs">
                 <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
               </div>
             )}
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={getLibraryItemCoverSrc(gridLibraryItems[0], placeholderUrl)}
+              src={cover.coverUrl}
               alt=""
               aria-hidden="true"
-              className={mergeClasses('relative z-10', cover?.showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
-              style={cover?.showCoverBg ? { width: `${itemCoverWidth}px`, height: `${itemCoverHeight}px` } : undefined}
+              className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
+              style={showCoverBg ? getContainedCoverDimensions(cellWidth, cellHeight, cover.imageAspectRatio!) : undefined}
             />
           </div>
         </div>
@@ -168,25 +97,26 @@ export default function SquareGridGroupCover({ libraryItems, width, height, empt
         <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
 
         {gridLibraryItems.map((libraryItem, index) => {
-          const cover = coverData[index]
+          const cover = coverData[index]!
+          const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, cellWidth, cellHeight)
           return (
             <div
               key={`${libraryItem.id}-${index}`}
               className="relative z-10 flex items-center justify-center"
               style={{ width: `${cellWidth}px`, height: `${cellHeight}px` }}
             >
-              {cover?.showCoverBg && (
+              {showCoverBg && (
                 <div className="bg-primary absolute start-0 top-0 h-full w-full overflow-hidden">
                   <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
                 </div>
               )}
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
-                src={getLibraryItemCoverSrc(libraryItem, placeholderUrl)}
+                src={cover.coverUrl}
                 alt=""
                 aria-hidden="true"
-                className={mergeClasses('relative z-10', cover?.showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
-                style={cover?.showCoverBg ? { width: `${itemCoverWidth}px`, height: `${itemCoverHeight}px` } : undefined}
+                className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
+                style={showCoverBg ? getContainedCoverDimensions(cellWidth, cellHeight, cover.imageAspectRatio!) : undefined}
               />
             </div>
           )

--- a/src/components/widgets/media-card/SquareGridGroupCover.tsx
+++ b/src/components/widgets/media-card/SquareGridGroupCover.tsx
@@ -1,8 +1,8 @@
 'use client'
 
+import { GroupCoverCell, GroupCoverEmptyState } from '@/components/widgets/media-card/GroupCoverParts'
 import { useCardSize } from '@/contexts/CardSizeContext'
-import { getContainedCoverDimensions, shouldShowCoverBackground, useGroupCoverData } from '@/hooks/useGroupCoverData'
-import { mergeClasses } from '@/lib/merge-classes'
+import { useGroupCoverData } from '@/hooks/useGroupCoverData'
 import type { LibraryItem } from '@/types/api'
 import { useMemo } from 'react'
 
@@ -51,41 +51,15 @@ export default function SquareGridGroupCover({ libraryItems, width, height, empt
   const coverData = useGroupCoverData(gridLibraryItems)
 
   if (!itemCount) {
-    return (
-      <div
-        className="bg-primary relative flex h-full w-full items-center justify-center rounded-xs"
-        style={{ width: `${width}px`, height: `${height}px`, padding: `${sizeMultiplier}em` }}
-      >
-        <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
-        <p className="z-10 text-center text-white/60" style={{ fontSize: `${Math.min(1, sizeMultiplier)}em` }}>
-          {emptyLabel}
-        </p>
-      </div>
-    )
+    return <GroupCoverEmptyState width={width} height={height} sizeMultiplier={sizeMultiplier} label={emptyLabel} />
   }
 
   if (itemCount === 1) {
-    const cover = coverData[0]!
-    const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, cellWidth, cellHeight)
     return (
       <div className="relative overflow-hidden rounded-xs" style={{ width: `${width}px`, height: `${height}px` }}>
         <div className="bg-primary relative flex h-full items-center justify-center rounded-xs">
           <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
-          <div className="relative z-10 flex items-center justify-center" style={{ width: `${cellWidth}px`, height: `${cellHeight}px` }}>
-            {showCoverBg && (
-              <div className="bg-primary absolute start-0 top-0 h-full w-full overflow-hidden rounded-xs">
-                <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
-              </div>
-            )}
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={cover.coverUrl}
-              alt=""
-              aria-hidden="true"
-              className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
-              style={showCoverBg ? getContainedCoverDimensions(cellWidth, cellHeight, cover.imageAspectRatio!) : undefined}
-            />
-          </div>
+          <GroupCoverCell cover={coverData[0]!} width={cellWidth} height={cellHeight} coverBgClassName="rounded-xs" />
         </div>
       </div>
     )
@@ -96,31 +70,9 @@ export default function SquareGridGroupCover({ libraryItems, width, height, empt
       <div className="bg-primary/95 relative flex h-full flex-wrap rounded-xs">
         <div className="absolute top-0 left-0 h-full w-full bg-gray-400/5" />
 
-        {gridLibraryItems.map((libraryItem, index) => {
-          const cover = coverData[index]!
-          const showCoverBg = shouldShowCoverBackground(cover.imageAspectRatio, cellWidth, cellHeight)
-          return (
-            <div
-              key={`${libraryItem.id}-${index}`}
-              className="relative z-10 flex items-center justify-center"
-              style={{ width: `${cellWidth}px`, height: `${cellHeight}px` }}
-            >
-              {showCoverBg && (
-                <div className="bg-primary absolute start-0 top-0 h-full w-full overflow-hidden">
-                  <div className="cover-bg absolute" style={{ backgroundImage: `url("${cover.coverUrl}")` }} />
-                </div>
-              )}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src={cover.coverUrl}
-                alt=""
-                aria-hidden="true"
-                className={mergeClasses('relative z-10', showCoverBg ? 'object-contain' : 'h-full w-full object-cover')}
-                style={showCoverBg ? getContainedCoverDimensions(cellWidth, cellHeight, cover.imageAspectRatio!) : undefined}
-              />
-            </div>
-          )
-        })}
+        {gridLibraryItems.map((libraryItem, index) => (
+          <GroupCoverCell key={`${libraryItem.id}-${index}`} cover={coverData[index]!} width={cellWidth} height={cellHeight} />
+        ))}
       </div>
     </div>
   )

--- a/src/hooks/useGroupCoverData.ts
+++ b/src/hooks/useGroupCoverData.ts
@@ -1,0 +1,87 @@
+'use client'
+
+import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
+import type { LibraryItem } from '@/types/api'
+import { useEffect, useMemo, useState } from 'react'
+
+const ASPECT_RATIO_TOLERANCE = 0.15
+
+export interface GroupCoverData {
+  coverUrl: string
+  imageAspectRatio: number | null
+}
+
+export function getContainedCoverDimensions(containerWidth: number, containerHeight: number, imageAspectRatio: number) {
+  const width = Math.min(containerWidth, containerHeight / imageAspectRatio)
+  return { width, height: width * imageAspectRatio }
+}
+
+export function shouldShowCoverBackground(imageAspectRatio: number | null, containerWidth: number, containerHeight: number) {
+  if (imageAspectRatio === null) return false
+  const containerAspectRatio = containerHeight / containerWidth
+  return Math.abs(imageAspectRatio - containerAspectRatio) > ASPECT_RATIO_TOLERANCE
+}
+
+/**
+ * Resolves group cover URLs and determines which ones need an aspect-ratio background.
+ */
+export function useGroupCoverData(libraryItems: LibraryItem[]): GroupCoverData[] {
+  const placeholderUrl = useMemo(() => getPlaceholderCoverUrl(), [])
+  const [loadedCoverData, setLoadedCoverData] = useState<GroupCoverData[]>([])
+
+  const coverUrls = useMemo(() => libraryItems.map((item) => getLibraryItemCoverSrc(item, placeholderUrl)), [libraryItems, placeholderUrl])
+
+  const coverData = useMemo(
+    () =>
+      coverUrls.map((coverUrl, index) => {
+        const loadedCover = loadedCoverData[index]
+        const hasCurrentCoverData = loadedCover?.coverUrl === coverUrl
+        return {
+          coverUrl,
+          // Only reuse a completed result when it belongs to the current cover URL.
+          imageAspectRatio: hasCurrentCoverData ? loadedCover.imageAspectRatio : null
+        }
+      }),
+    [coverUrls, loadedCoverData]
+  )
+
+  useEffect(() => {
+    let isCurrent = true
+
+    async function loadCoverData() {
+      if (!coverUrls.length) {
+        setLoadedCoverData([])
+        return
+      }
+
+      const results = await Promise.all(
+        coverUrls.map(
+          (coverUrl): Promise<GroupCoverData> =>
+            new Promise((resolve) => {
+              const image = new Image()
+              image.onload = () => {
+                const imageAspectRatio = image.naturalWidth ? image.naturalHeight / image.naturalWidth : null
+                resolve({
+                  coverUrl,
+                  imageAspectRatio
+                })
+              }
+              image.onerror = () => resolve({ coverUrl, imageAspectRatio: null })
+              image.src = coverUrl
+            })
+        )
+      )
+
+      if (isCurrent) {
+        setLoadedCoverData(results)
+      }
+    }
+
+    loadCoverData()
+    return () => {
+      isCurrent = false
+    }
+  }, [coverUrls])
+
+  return coverData
+}


### PR DESCRIPTION
## Brief summary

Preserves collection cover artwork without cropping when its aspect ratio does not match the rendered group-cover cell.

## Which issue is fixed?

Fixes #172

## In-depth Description

The group-cover components now compare each image's natural aspect ratio with the actual dimensions of its rendered cell. When an image leaves space in that cell, the component renders a blurred background behind an `object-contain` foreground image; covers that fill the cell keep the existing `object-cover` rendering.

The shared hook also cancels stale image-dimension requests, so rapid collection updates cannot apply an old cover's dimensions to a new entry. Square-grid and collection-group covers now use the same sizing logic.

## How have you tested this?

- ESLint on the changed source and component-test files
- Cypress component test: `CollectionGroupCover.cy.tsx` (5 passing)
- Manual Chrome verification of a square cover displayed in a wide single-cover cell
- `git diff --check`

## Screenshots

<img width="854" height="269" alt="image" src="https://github.com/user-attachments/assets/a673e887-cbcf-42f3-b24c-09672e7ed8ca" />

