### PR TITLE
Fix #160: narrator rename/remove confirmation dialogs

### DIFF
--- a/src/components/ui/EditList.tsx
+++ b/src/components/ui/EditList.tsx
@@ -3,10 +3,10 @@
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { TranslationKey } from '@/types/translations'
 import { Fragment, useEffect, useRef, useState } from 'react'
-import Modal from '../modals/Modal'
 import Btn from './Btn'
 import IconBtn from './IconBtn'
 import TextInput from './TextInput'
+import ConfirmDialog from '../widgets/ConfirmDialog'
 
 export interface EditListItem {
   id: string
@@ -241,28 +241,30 @@ export default function EditList({ items, onItemEditSaveClick, onItemDeleteClick
           ))}
         </tbody>
       </table>
-      <Modal isOpen={isProcessingModalOpen} onClose={() => setIsProcessingModalOpen(false)} processing={isProcessing} className="w-[500px]">
-        <div className="flex h-full flex-col p-6">
-          {isDeleting ? (
-            <p className="text-foreground mb-6 flex-1">{t(listTypeDeleteString, { 0: delRef.current?.name || '' })}</p>
+      <ConfirmDialog
+        isOpen={isProcessingModalOpen}
+        message={
+          isDeleting ? (
+            t(listTypeDeleteString, { 0: delRef.current?.name || '' })
           ) : (
             <>
-              <p className="text-foreground mb-6 flex-1">{t(listTypeEditString, { 0: editedItem.name, 1: newName })}</p>
-              {/* Show warning if the new value already exists or has a different casing*/}
-              {hasSameName && <p className="mb-6 flex-1 text-yellow-500">{t(listTypeMergeString)}</p>}
-              {sameNameWithDifferentCase !== '' && <p className="mb-6 flex-1 text-yellow-500">{t(listTypeWarningString, { 0: sameNameWithDifferentCase })}</p>}
+              <p>{t(listTypeEditString, { 0: editedItem.name, 1: newName })}</p>
+              {/* Show warning if the new value already exists or has a different casing. */}
+              {hasSameName && <p className="mt-4 text-yellow-500">{t(listTypeMergeString)}</p>}
+              {sameNameWithDifferentCase !== '' && <p className="mt-4 text-yellow-500">{t(listTypeWarningString, { 0: sameNameWithDifferentCase })}</p>}
             </>
-          )}
-          <div className="flex justify-end gap-3">
-            <Btn onClick={isDeleting ? handleDeleteModalClick : handleSaveModalClick} color="bg-success" disabled={isProcessing}>
-              {t('ButtonYes')}
-            </Btn>
-            <Btn onClick={handleCancelEditClick} disabled={isProcessing}>
-              {t('ButtonCancel')}
-            </Btn>
-          </div>
-        </div>
-      </Modal>
+          )
+        }
+        processing={isProcessing}
+        onClose={handleCancelEditClick}
+        onConfirm={() => {
+          if (isDeleting) {
+            handleDeleteModalClick()
+          } else {
+            handleSaveModalClick()
+          }
+        }}
+      />
     </div>
   )
 }


### PR DESCRIPTION

## Description

Fixes #160

Updated the shared `EditList` component to use the standard `ConfirmDialog` component instead of the non-standard `Modal` for rename and remove confirmation dialogs.

Since `EditList` is shared across multiple pages, this also ensures that confirmation dialogs on other pages using the component follow the same standard UI pattern.

### Changes

* Replaced the rename confirmation `Modal` with `ConfirmDialog`
* Replaced the remove confirmation `Modal` with `ConfirmDialog`
* Applied the change at the shared `EditList` component level
* Preserved the existing rename/remove behaviour and actions

### Testing

* Verified narrator rename confirmation
* Verified narrator remove confirmation
* Verified rename and remove flows on other pages using `EditList`
* Verified both confirm and cancel actions work as expected
* Verified existing functionality remains unchanged

@mikiher 