### PR TITLE
Prevent text selection of Material Symbols icon glyphs

### DIFF
--- a/src/assets/fonts.css
+++ b/src/assets/fonts.css
@@ -18,6 +18,8 @@
   direction: ltr;
   -webkit-font-smoothing: antialiased;
   vertical-align: middle;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .material-symbols.fill {


### PR DESCRIPTION
Same fix as advplyr/audiobookshelf#5390, ported across at @mikiher's suggestion in #188.

The icons are Material Symbols ligatures, so the span genuinely contains the word `pause` or `forward_media` as text. Click or double click one and the browser selects it, which drops a blue highlight over the player controls. Most noticeable when you are jabbing at skip forward a few times in a row.

Two lines on the base `.material-symbols` class in `src/assets/fonts.css`. That file is imported globally from `app.css`, so it covers all 143 icon usages in one go. I kept the `-webkit-` prefix to match what Tailwind's own `select-none` utility emits, since older iOS Safari still wants it and this is a thing people use on their phones.

Left `.abs-icons` alone deliberately. Those glyphs come from `content:` on a `:before`, and generated content is not selectable anyway, so there is nothing to fix there.

Closes #188
