### PR TITLE
feat(player): apply natural volume scaling

### DIFF
--- a/cypress/tests/lib/player/LocalAudioPlayer.cy.tsx
+++ b/cypress/tests/lib/player/LocalAudioPlayer.cy.tsx
@@ -1,0 +1,29 @@
+import { LocalAudioPlayer } from '@/lib/player/LocalAudioPlayer'
+
+describe('LocalAudioPlayer volume scaling', () => {
+  let player: LocalAudioPlayer
+
+  beforeEach(() => {
+    cy.mount(<div />)
+    cy.then(() => {
+      player = new LocalAudioPlayer()
+    })
+  })
+
+  afterEach(() => {
+    cy.then(() => {
+      player.destroy()
+    })
+  })
+
+  it('applies a quadratic curve to the audio element volume', () => {
+    cy.then(() => player.setVolume(0))
+    cy.get<HTMLAudioElement>('#audio-player').should('have.prop', 'volume', 0)
+
+    cy.then(() => player.setVolume(0.5))
+    cy.get<HTMLAudioElement>('#audio-player').should('have.prop', 'volume', 0.25)
+
+    cy.then(() => player.setVolume(1))
+    cy.get<HTMLAudioElement>('#audio-player').should('have.prop', 'volume', 1)
+  })
+})

--- a/src/lib/player/LocalAudioPlayer.ts
+++ b/src/lib/player/LocalAudioPlayer.ts
@@ -375,7 +375,8 @@ export class LocalAudioPlayer {
 
   setVolume(volume: number): void {
     if (this.player) {
-      this.player.volume = volume
+      // Keep slider values linear while giving listeners finer control at low volumes.
+      this.player.volume = volume ** 2
     }
   }
 


### PR DESCRIPTION
## Brief summary

Applies quadratic volume scaling to local audio playback so the volume slider provides finer control at low volumes.

## Which issue is fixed?

Fixes #190

## In-depth Description

`LocalAudioPlayer` now maps the linear slider value to `volume²` before assigning it to the HTML audio element. This keeps the slider range and persisted values unchanged while producing 25% output at 50% slider position and 100% output at 100%.

The behaviour applies to all local playback without adding a player setting or toggle.

## How have you tested this?

- `node_modules/.bin/eslint.cmd src/lib/player/LocalAudioPlayer.ts cypress/tests/lib/player/LocalAudioPlayer.cy.tsx`
- `node_modules/.bin/cypress.cmd run --component --browser electron --spec cypress/tests/lib/player/LocalAudioPlayer.cy.tsx` (1 passing)
- `git diff upstream/master...HEAD --check`

## Screenshots

Not included: this is an audio-output behaviour change with no visual UI change.