### PR TITLE
New SectionedModal and migrate to library item metadata edit modal

### DIFF
--- a/src/app/(main)/components_catalog/examples/AdvancedModalExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/AdvancedModalExamples.tsx
@@ -1,12 +1,65 @@
 'use client'
 
 import Modal from '@/components/modals/Modal'
+import SectionedModal from '@/components/modals/SectionedModal'
 import TabbedModal from '@/components/modals/TabbedModal'
 import Btn from '@/components/ui/Btn'
 import MultiSelect, { MultiSelectItem } from '@/components/ui/MultiSelect'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useState } from 'react'
 import { ComponentExamples, Example, ExamplesBlock } from '../ComponentExamples'
+
+const DEMO_SECTIONS = [
+  { id: 'alpha', label: 'Alpha', icon: 'edit' },
+  { id: 'beta', label: 'Beta', icon: 'image' },
+  { id: 'gamma', label: 'Gamma', icon: 'travel_explore' }
+]
+
+function SectionedModalExample() {
+  const [isOpen, setIsOpen] = useState(false)
+  const [selectedSection, setSelectedSection] = useState('alpha')
+
+  return (
+    <>
+      <Btn
+        onClick={() => {
+          setSelectedSection('alpha')
+          setIsOpen(true)
+        }}
+      >
+        Open Sectioned Modal
+      </Btn>
+      <SectionedModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        sections={DEMO_SECTIONS}
+        selectedSection={selectedSection}
+        onSectionChange={setSelectedSection}
+        className="md:max-w-[min(95vw,48rem)]"
+        outerContent={
+          <div className="absolute start-0 top-0 p-4">
+            <h2 className="max-w-[calc(100vw-4rem)] truncate text-xl text-white">Example Item</h2>
+          </div>
+        }
+      >
+        <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
+          <div className="min-h-0 flex-1 overflow-y-auto p-6">
+            <p className="text-foreground-muted text-sm">
+              Placeholder content for the <strong className="text-foreground">{DEMO_SECTIONS.find((s) => s.id === selectedSection)!.label}</strong> section.
+              Each section can define its own layout, actions, and footer.
+            </p>
+          </div>
+          {selectedSection === 'alpha' ? (
+            <div className="border-border flex shrink-0 justify-end gap-3 border-t px-4 py-3">
+              <Btn size="small">Save</Btn>
+              <Btn size="small">Save & Close</Btn>
+            </div>
+          ) : null}
+        </div>
+      </SectionedModal>
+    </>
+  )
+}
 
 export function AdvancedModalExamples() {
   const [isModalOpen, setIsModalOpen] = useState(false)
@@ -186,6 +239,12 @@ export function AdvancedModalExamples() {
                 </div>
               )}
             </TabbedModal>
+          </div>
+        </Example>
+        <Example title="Modal with Section Navigation">
+          <div>
+            <p className="mb-4 text-sm text-gray-400">One modal with multiple sections, each with its own actions.</p>
+            <SectionedModalExample />
           </div>
         </Example>
       </ExamplesBlock>

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
@@ -2,7 +2,6 @@
 
 import AddToCollectionModal from '@/components/modals/AddToCollectionModal'
 import AddToPlaylistModal from '@/components/modals/AddToPlaylistModal'
-import MatchModal from '@/components/modals/MatchModal'
 import PodcastCheckNewEpisodesModal from '@/components/modals/PodcastCheckNewEpisodesModal'
 import PodcastDownloadScheduleModal from '@/components/modals/PodcastDownloadScheduleModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
@@ -19,12 +18,13 @@ import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getEbookFormat } from '@/lib/ereader/ereaderEbook'
 import { PlayerState, type BookLibraryItem, type PodcastLibraryItem, type RssFeed } from '@/types/api'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 
 interface LibraryItemActionButtonsProps {
   libraryItem: BookLibraryItem | PodcastLibraryItem
   onEdit: () => void
   onOpenCoverEdit?: () => void
+  onOpenMatch?: () => void
   /** Current RSS feed state (from useItemPageSocket + initial server data). */
   rssFeed?: RssFeed | null
   showPlayButton: boolean
@@ -36,6 +36,7 @@ export default function LibraryItemActionButtons({
   libraryItem,
   onEdit,
   onOpenCoverEdit,
+  onOpenMatch,
   rssFeed = null,
   showPlayButton,
   isItemPlaying,
@@ -54,10 +55,6 @@ export default function LibraryItemActionButtons({
     playerLoadState
   } = useMediaContext()
   const t = useTypeSafeTranslations()
-  const [matchModalOpen, setMatchModalOpen] = useState(false)
-  const handleOpenMatch = useCallback(() => {
-    setMatchModalOpen(true)
-  }, [])
 
   const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
   const isRead = mediaProgress?.isFinished ?? false
@@ -115,7 +112,7 @@ export default function LibraryItemActionButtons({
     onDeleteSuccess: () => {
       window.location.href = `/library/${libraryItem.libraryId}`
     },
-    onOpenMatch: handleOpenMatch,
+    onOpenMatch,
     onOpenCoverEdit,
     playerControls
   })
@@ -291,7 +288,6 @@ export default function LibraryItemActionButtons({
           headerTitle={libraryItem.media.metadata.title ?? ''}
         />
       )}
-      <MatchModal isOpen={matchModalOpen} onClose={() => setMatchModalOpen(false)} libraryItem={libraryItem} />
     </>
   )
 }

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { clearPodcastDownloadQueueAction } from '@/app/actions/mediaActions'
-import CoverEditModal from '@/components/modals/CoverEditModal'
-import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import LibraryItemMetadataEditModal, { type MetadataEditSection } from '@/components/modals/LibraryItemMetadataEditModal'
 import AudioTracksTable from '@/components/widgets/AudioTracksTable'
 import ChaptersTable from '@/components/widgets/ChaptersTable'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
@@ -39,8 +38,7 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
   const t = useTypeSafeTranslations()
 
   const [libraryItem, setLibraryItem] = useState(initialLibraryItem)
-  const [isEditModalOpen, setIsEditModalOpen] = useState(false)
-  const [isCoverEditModalOpen, setIsCoverEditModalOpen] = useState(false)
+  const [metadataEditSection, setMetadataEditSection] = useState<MetadataEditSection | null>(null)
   const [isClearQueueDialogOpen, setIsClearQueueDialogOpen] = useState(false)
   const [podcastEpisodesInOrder, setPodcastEpisodesInOrder] = useState<PodcastEpisode[]>([])
   const handlePodcastEpisodesInOrderChange = useCallback((episodes: PodcastEpisode[]) => {
@@ -68,12 +66,12 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
     return computeProgress({ progress: userProgress, useSeriesProgress: false }).percent > 0
   }, [isPodcast, userProgress])
 
-  const handleOpenEditModal = () => {
-    setIsEditModalOpen(true)
+  const handleOpenMetadataEdit = (section: MetadataEditSection) => {
+    setMetadataEditSection(section)
   }
 
-  const handleCloseEditModal = () => {
-    setIsEditModalOpen(false)
+  const handleCloseMetadataEdit = () => {
+    setMetadataEditSection(null)
   }
 
   const handleItemUpdated = (updatedItem: BookLibraryItem | PodcastLibraryItem) => {
@@ -133,7 +131,7 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                 libraryItem={libraryItem}
                 canUpdate={userCanUpdate}
                 mediaProgress={userProgress}
-                onEdit={() => setIsCoverEditModalOpen(true)}
+                onEdit={() => handleOpenMetadataEdit('cover')}
                 showPlayButton={showPlayButton}
                 isItemPlaying={isItemPlaying}
                 onPlay={handlePlay}
@@ -220,8 +218,9 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
 
               <LibraryItemActionButtons
                 libraryItem={libraryItem}
-                onEdit={handleOpenEditModal}
-                onOpenCoverEdit={() => setIsCoverEditModalOpen(true)}
+                onEdit={() => handleOpenMetadataEdit('details')}
+                onOpenCoverEdit={() => handleOpenMetadataEdit('cover')}
+                onOpenMatch={() => handleOpenMetadataEdit('match')}
                 rssFeed={rssFeed ?? null}
                 showPlayButton={showPlayButton}
                 isItemPlaying={isItemPlaying}
@@ -259,8 +258,12 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
           </div>
         </div>
 
-        <LibraryItemEditModal isOpen={isEditModalOpen} libraryItem={libraryItem} onClose={handleCloseEditModal} />
-        <CoverEditModal isOpen={isCoverEditModalOpen} libraryItem={libraryItem} onClose={() => setIsCoverEditModalOpen(false)} />
+        <LibraryItemMetadataEditModal
+          isOpen={metadataEditSection !== null}
+          initialSection={metadataEditSection ?? 'details'}
+          libraryItem={libraryItem}
+          onClose={handleCloseMetadataEdit}
+        />
         <ConfirmDialog
           isOpen={isClearQueueDialogOpen}
           message={t('MessageConfirmClearEpisodeFetchQueue')}

--- a/src/components/modals/CoverEditModal.tsx
+++ b/src/components/modals/CoverEditModal.tsx
@@ -12,15 +12,23 @@ export type CoverEditModalProps = {
 type CoverEditModalBodyProps = {
   /** When true (navCtx), body height stays fixed so prev/next does not resize the panel. */
   stableBodyHeight: boolean
+  /** When true, fill a parent with a fixed height (e.g. SectionedModalBody). */
+  fillParent?: boolean
 }
 
-function CoverEditModalBody({ stableBodyHeight }: CoverEditModalBodyProps) {
+export function CoverEditModalBody({ stableBodyHeight, fillParent = false }: CoverEditModalBodyProps) {
   const { resolvedItem, fetchPending } = useLibraryItemModal()
   const showLoading = fetchPending && !resolvedItem
 
-  if (stableBodyHeight) {
+  if (fillParent || stableBodyHeight) {
     return (
-      <div className="flex h-[min(40rem,85vh)] max-h-[85vh] w-full flex-col overflow-hidden rounded-lg">
+      <div
+        className={
+          fillParent
+            ? 'flex h-full min-h-0 w-full flex-col overflow-hidden rounded-lg'
+            : 'flex h-[min(40rem,85vh)] max-h-[85vh] w-full flex-col overflow-hidden rounded-lg'
+        }
+      >
         {showLoading ? (
           <div className="flex flex-1 items-center justify-center">
             <LoadingIndicator variant="inline" />

--- a/src/components/modals/LibraryItemEditModal.tsx
+++ b/src/components/modals/LibraryItemEditModal.tsx
@@ -73,16 +73,25 @@ export type LibraryItemEditModalProps = {
   onClose: () => void
 } & LibraryItemModalItemSource
 
-type LibraryItemEditModalContentProps = {
+export type LibraryItemEditModalContentProps = {
   isOpen: boolean
   startSaveTransition: TransitionStartFunction
   isSavePending: boolean
   onClose: () => void
   /** When true (navCtx), body height stays fixed so prev/next does not resize the panel. */
   stableBodyHeight: boolean
+  /** When true, fill a parent with a fixed height (e.g. SectionedModalBody). */
+  fillParent?: boolean
 }
 
-function LibraryItemEditModalContent({ isOpen, startSaveTransition, isSavePending, onClose, stableBodyHeight }: LibraryItemEditModalContentProps) {
+export function LibraryItemEditModalContent({
+  isOpen,
+  startSaveTransition,
+  isSavePending,
+  onClose,
+  stableBodyHeight,
+  fillParent = false
+}: LibraryItemEditModalContentProps) {
   const { resolvedItem, fetchPending, pendingEntityId } = useLibraryItemModal()
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
@@ -280,10 +289,12 @@ function LibraryItemEditModalContent({ isOpen, startSaveTransition, isSavePendin
   return (
     <div
       className={
-        stableBodyHeight
-          ? /* Slightly above empty book placeholder; extra content scrolls in the inner region. */
-            'flex h-[min(50rem,85vh)] max-h-[85vh] w-full flex-col overflow-hidden rounded-lg'
-          : 'flex max-h-[85vh] w-full flex-col rounded-lg'
+        fillParent
+          ? 'flex h-full min-h-0 w-full flex-col overflow-hidden rounded-lg'
+          : stableBodyHeight
+            ? /* Slightly above empty book placeholder; extra content scrolls in the inner region. */
+              'flex h-[min(50rem,85vh)] max-h-[85vh] w-full flex-col overflow-hidden rounded-lg'
+            : 'flex max-h-[85vh] w-full flex-col rounded-lg'
       }
     >
       <div ref={scrollContainerRef} className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">

--- a/src/components/modals/LibraryItemMetadataEditModal.tsx
+++ b/src/components/modals/LibraryItemMetadataEditModal.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { CoverEditModalBody } from '@/components/modals/CoverEditModal'
+import { LibraryItemEditModalContent } from '@/components/modals/LibraryItemEditModal'
+import LibraryItemModal, { type LibraryItemModalItemSource } from '@/components/modals/LibraryItemModal'
+import { MatchModalBody } from '@/components/modals/MatchModal'
+import { SectionedModalBody, type Section } from '@/components/modals/SectionedModal'
+import { useLibrary } from '@/contexts/LibraryContext'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { useEffect, useMemo, useState, useTransition } from 'react'
+
+export type MetadataEditSection = 'details' | 'cover' | 'match'
+
+export type LibraryItemMetadataEditModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  initialSection?: MetadataEditSection
+} & LibraryItemModalItemSource
+
+/**
+ * Combined Details, Cover, and Match editor for a library item.
+ */
+export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataEditModalProps) {
+  const { isOpen, onClose, initialSection } = props
+  const navCtxMode = 'navCtx' in props
+  const t = useTypeSafeTranslations()
+  const { filterDataLoading } = useLibrary()
+  const [isSavePending, startSaveTransition] = useTransition()
+  const [selectedSection, setSelectedSection] = useState<MetadataEditSection>(initialSection ?? 'details')
+
+  useEffect(() => {
+    if (!isOpen) return
+    setSelectedSection(initialSection ?? 'details')
+  }, [isOpen, initialSection])
+
+  const sections = useMemo<Section[]>(
+    () => [
+      { id: 'details', label: t('HeaderDetails'), icon: 'edit' },
+      { id: 'cover', label: t('HeaderCover'), icon: 'image' },
+      { id: 'match', label: t('HeaderMatch'), icon: 'travel_explore' }
+    ],
+    [t]
+  )
+
+  return (
+    <LibraryItemModal
+      isOpen={isOpen}
+      onClose={onClose}
+      {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem })}
+      additionalProcessing={isSavePending || filterDataLoading}
+      className="md:max-w-[min(95vw,60rem)]"
+    >
+      <SectionedModalBody
+        sections={sections}
+        selectedSection={selectedSection}
+        onSectionChange={(sectionId) => setSelectedSection(sectionId as MetadataEditSection)}
+        isOpen={isOpen}
+        initialSection={initialSection}
+      >
+        {selectedSection === 'details' ? (
+          <LibraryItemEditModalContent
+            isOpen={isOpen}
+            startSaveTransition={startSaveTransition}
+            isSavePending={isSavePending}
+            onClose={onClose}
+            stableBodyHeight={false}
+            fillParent
+          />
+        ) : selectedSection === 'cover' ? (
+          <CoverEditModalBody stableBodyHeight={false} fillParent />
+        ) : (
+          <MatchModalBody fillParent />
+        )}
+      </SectionedModalBody>
+    </LibraryItemModal>
+  )
+}

--- a/src/components/modals/MatchModal.tsx
+++ b/src/components/modals/MatchModal.tsx
@@ -9,10 +9,10 @@ export type MatchModalProps = {
   onClose: () => void
 } & LibraryItemModalItemSource
 
-function MatchModalBody() {
+export function MatchModalBody({ fillParent = false }: { fillParent?: boolean }) {
   const { resolvedItem, fetchPending } = useLibraryItemModal()
   return (
-    <div className="flex h-[80vh] flex-col overflow-hidden">
+    <div className={fillParent ? 'flex h-full min-h-0 flex-col overflow-hidden' : 'flex h-[80vh] flex-col overflow-hidden'}>
       {fetchPending && !resolvedItem ? (
         <div className="flex flex-1 items-center justify-center">
           <LoadingIndicator variant="inline" />

--- a/src/components/modals/SectionedModal.tsx
+++ b/src/components/modals/SectionedModal.tsx
@@ -102,10 +102,11 @@ export function SectionedModalBody({ sections, selectedSection, onSectionChange,
               type="button"
               onClick={() => onSectionChange(item.id)}
               className={mergeClasses(
-                'flex items-center gap-3 px-4 py-2.5 text-start text-sm font-medium transition-colors',
-                isActive ? 'bg-bg text-foreground border-s-warning border-s-4' : 'text-foreground-muted hover:text-foreground border-s-4 border-s-transparent'
+                'relative flex items-center gap-3 px-4 py-2.5 text-start text-sm font-medium transition-colors',
+                isActive ? 'bg-bg text-foreground' : 'text-foreground-muted hover:text-foreground'
               )}
             >
+              {isActive ? <div className="absolute start-0 top-0 h-full w-0.5 bg-yellow-400" aria-hidden /> : null}
               <span className="material-symbols text-xl" aria-hidden>
                 {item.icon}
               </span>

--- a/src/components/modals/SectionedModal.tsx
+++ b/src/components/modals/SectionedModal.tsx
@@ -1,0 +1,174 @@
+'use client'
+
+import IconBtn from '@/components/ui/IconBtn'
+import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { mergeClasses } from '@/lib/merge-classes'
+import { useEffect, useState, type ReactNode } from 'react'
+import Modal, { type ModalProps } from './Modal'
+
+export interface Section {
+  id: string
+  label: string
+  icon: string
+}
+
+/** Fixed panel height for sectioned modals */
+export const SECTIONED_MODAL_STABLE_HEIGHT_CLASS = 'h-[min(50rem,85vh)] max-h-[85vh]'
+
+export interface SectionedModalBodyProps {
+  sections: Section[]
+  selectedSection: string
+  onSectionChange: (sectionId: string) => void
+  isOpen: boolean
+  initialSection?: string
+  children?: ReactNode
+  className?: string
+}
+
+export function SectionedModalBody({ sections, selectedSection, onSectionChange, isOpen, initialSection, children, className }: SectionedModalBodyProps) {
+  const t = useTypeSafeTranslations()
+  const isMobile = useMediaQuery('max-md')
+  const [mobileScreen, setMobileScreen] = useState<'hub' | string>(initialSection ?? 'hub')
+
+  useEffect(() => {
+    if (!isOpen) {
+      setMobileScreen(initialSection ?? 'hub')
+      return
+    }
+    if (initialSection) {
+      setMobileScreen(initialSection)
+    }
+  }, [isOpen, initialSection])
+
+  const handleMobileSelect = (sectionId: string) => {
+    onSectionChange(sectionId)
+    setMobileScreen(sectionId)
+  }
+
+  if (isMobile) {
+    // List of sections displayed on mobile
+    if (mobileScreen === 'hub') {
+      return (
+        <div className={mergeClasses('flex min-h-0 flex-1 flex-col overflow-y-auto p-2', className)}>
+          <nav className="flex flex-col gap-2 px-2 py-2">
+            {sections.map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => handleMobileSelect(item.id)}
+                className="bg-primary/40 hover:bg-primary/60 text-foreground-muted hover:text-foreground rounded-md p-4 text-start transition-colors"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="flex min-w-0 items-center gap-3">
+                    <span className="material-symbols text-2xl" aria-hidden>
+                      {item.icon}
+                    </span>
+                    <span>{item.label}</span>
+                  </span>
+                  <span className="material-symbols shrink-0 text-xl" aria-hidden>
+                    arrow_forward
+                  </span>
+                </div>
+              </button>
+            ))}
+          </nav>
+        </div>
+      )
+    }
+
+    const section = sections.find((item) => item.id === mobileScreen)!
+    return (
+      <div className={mergeClasses('flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden', SECTIONED_MODAL_STABLE_HEIGHT_CLASS, className)}>
+        <div className="border-border flex shrink-0 items-center gap-1 border-b px-2 py-2">
+          <IconBtn borderless ariaLabel={t('ButtonBack')} onClick={() => setMobileScreen('hub')} className="shrink-0">
+            arrow_back
+          </IconBtn>
+          <span className="min-w-0 truncate text-xl font-semibold">{section.label}</span>
+        </div>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div className={mergeClasses('flex min-w-0 flex-1 flex-row overflow-hidden rounded-lg', SECTIONED_MODAL_STABLE_HEIGHT_CLASS, className)}>
+      <nav className="border-border bg-primary flex w-36 shrink-0 flex-col border-e py-3" aria-label={t('AriaLabelModalSections')}>
+        {sections.map((item) => {
+          const isActive = item.id === selectedSection
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onSectionChange(item.id)}
+              className={mergeClasses(
+                'flex items-center gap-3 px-4 py-2.5 text-start text-sm font-medium transition-colors',
+                isActive ? 'bg-bg text-foreground border-s-warning border-s-4' : 'text-foreground-muted hover:text-foreground border-s-4 border-s-transparent'
+              )}
+            >
+              <span className="material-symbols text-xl" aria-hidden>
+                {item.icon}
+              </span>
+              {item.label}
+            </button>
+          )
+        })}
+      </nav>
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">{children}</div>
+    </div>
+  )
+}
+
+export type SectionedModalProps = Omit<ModalProps, 'children'> &
+  Omit<SectionedModalBodyProps, 'className'> & {
+    bodyClassName?: string
+  }
+
+/**
+ * Modal with section navigation. Desktop: left rail. Mobile: hub list with drill-in and Back.
+ * Section panel height is fixed so switching sections does not resize the modal.
+ */
+export default function SectionedModal({
+  isOpen,
+  processing,
+  persistent,
+  zIndexClass,
+  bgOpacityClass,
+  outerContent,
+  sideNavigation,
+  onClose,
+  className,
+  style,
+  sections,
+  selectedSection,
+  onSectionChange,
+  initialSection,
+  children,
+  bodyClassName
+}: SectionedModalProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      processing={processing}
+      persistent={persistent}
+      zIndexClass={zIndexClass}
+      bgOpacityClass={bgOpacityClass}
+      outerContent={outerContent}
+      sideNavigation={sideNavigation}
+      onClose={onClose}
+      className={className}
+      style={style}
+    >
+      <SectionedModalBody
+        sections={sections}
+        selectedSection={selectedSection}
+        onSectionChange={onSectionChange}
+        isOpen={isOpen}
+        initialSection={initialSection}
+        className={bodyClassName}
+      >
+        {children}
+      </SectionedModalBody>
+    </Modal>
+  )
+}

--- a/src/components/widgets/audiobook-tools/AudiobookTools.tsx
+++ b/src/components/widgets/audiobook-tools/AudiobookTools.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import LibraryItemMetadataEditModal from '@/components/modals/LibraryItemMetadataEditModal'
 import Dropdown from '@/components/ui/Dropdown'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import LibraryItemSubpageHeader from '@/components/widgets/LibraryItemSubpageHeader'
@@ -121,7 +121,7 @@ export default function AudiobookTools({ libraryItem: initialLibraryItem }: Audi
         />
       )}
 
-      <LibraryItemEditModal isOpen={tools.isEditModalOpen} libraryItem={tools.libraryItem} onClose={() => tools.setIsEditModalOpen(false)} />
+      <LibraryItemMetadataEditModal isOpen={tools.isEditModalOpen} libraryItem={tools.libraryItem} onClose={() => tools.setIsEditModalOpen(false)} />
     </div>
   )
 }

--- a/src/components/widgets/chapters-edit/ChaptersEditClient.tsx
+++ b/src/components/widgets/chapters-edit/ChaptersEditClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import LibraryItemMetadataEditModal from '@/components/modals/LibraryItemMetadataEditModal'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import LibraryItemSubpageHeader from '@/components/widgets/LibraryItemSubpageHeader'
@@ -203,7 +203,7 @@ export default function ChaptersEditClient({ libraryItem: initialLibraryItem }: 
 
       {confirmState && <ConfirmDialog isOpen message={confirmState.message} onClose={() => setConfirmState(null)} onConfirm={() => confirmState.onConfirm()} />}
 
-      {isEditModalOpen && <LibraryItemEditModal isOpen libraryItem={libraryItem} onClose={() => setIsEditModalOpen(false)} />}
+      {isEditModalOpen && <LibraryItemMetadataEditModal isOpen libraryItem={libraryItem} onClose={() => setIsEditModalOpen(false)} />}
     </div>
   )
 }

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -6,7 +6,7 @@ import { batchRemoveFromPlaylistAction } from '@/app/actions/playlistActions'
 import PreviewCover from '@/components/covers/PreviewCover'
 import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
 import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
-import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import LibraryItemMetadataEditModal from '@/components/modals/LibraryItemMetadataEditModal'
 import ViewEpisodeModal from '@/components/modals/ViewEpisodeModal'
 import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
 import IconBtn from '@/components/ui/IconBtn'
@@ -169,7 +169,7 @@ function CompilationItemListRowBody({
       return
     }
     const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
-    setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+    setBoundModal(<LibraryItemMetadataEditModal key="library-item-metadata-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
   }, [clearBoundModal, entityIndex, episode, libraryItem, setBoundModal, shelfEntities])
 
   const handleMatch = useCallback(() => {

--- a/src/components/widgets/media-card/MediaCard.tsx
+++ b/src/components/widgets/media-card/MediaCard.tsx
@@ -3,11 +3,9 @@
 import AddToCollectionModal from '@/components/modals/AddToCollectionModal'
 import AddToPlaylistModal from '@/components/modals/AddToPlaylistModal'
 import AudioFileDataModal from '@/components/modals/AudioFileDataModal'
-import CoverEditModal from '@/components/modals/CoverEditModal'
 import EpisodeEditModal from '@/components/modals/EpisodeEditModal'
 import EpisodeMatchModal from '@/components/modals/EpisodeMatchModal'
-import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
-import MatchModal from '@/components/modals/MatchModal'
+import LibraryItemMetadataEditModal, { type MetadataEditSection } from '@/components/modals/LibraryItemMetadataEditModal'
 import PodcastCheckNewEpisodesModal from '@/components/modals/PodcastCheckNewEpisodesModal'
 import PodcastDownloadScheduleModal from '@/components/modals/PodcastDownloadScheduleModal'
 import RssFeedOpenCloseModal from '@/components/modals/RssFeedOpenCloseModal'
@@ -201,34 +199,35 @@ function MediaCard(props: MediaCardProps) {
     setIsHovering(false)
   }, [])
 
-  const handleOpenMatch = useCallback(() => {
-    closeMoreMenu()
-    if (episode) {
-      const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
-      setBoundModal(<EpisodeMatchModal key={`episode-match-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-      return
-    }
-    const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
-    setBoundModal(<MatchModal key="match-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, closeMoreMenu, episode, entityIndex, libraryItem.id, shelfEntities, setBoundModal])
+  const handleOpenMetadataEdit = useCallback(
+    (section: MetadataEditSection) => {
+      closeMoreMenu()
+      if (episode) {
+        const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
+        if (section === 'match') {
+          setBoundModal(<EpisodeMatchModal key={`episode-match-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+          return
+        }
+        setBoundModal(<EpisodeEditModal key={`episode-edit-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
+        return
+      }
+      const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
+      setBoundModal(
+        <LibraryItemMetadataEditModal
+          key={`metadata-edit-modal-${section}`}
+          isOpen
+          initialSection={section}
+          navCtx={navCtx}
+          onClose={clearBoundModal}
+        />
+      )
+    },
+    [clearBoundModal, closeMoreMenu, episode, entityIndex, libraryItem.id, shelfEntities, setBoundModal]
+  )
 
-  const handleOpenEdit = useCallback(() => {
-    closeMoreMenu()
-    if (episode) {
-      const navCtx = getMediaCardEpisodeEditNavigationContext(episode.id, libraryItem.id, shelfEntities, entityIndex)
-      setBoundModal(<EpisodeEditModal key={`episode-edit-modal-${episode.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-      return
-    }
-    const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
-    setBoundModal(<LibraryItemEditModal key="library-item-edit-modal" isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, closeMoreMenu, episode, libraryItem, shelfEntities, entityIndex, setBoundModal])
-
-  const handleOpenCoverEdit = useCallback(() => {
-    closeMoreMenu()
-    if (episode) return
-    const navCtx = getMediaCardModalNavigationContext(libraryItem.id, shelfEntities, entityIndex)
-    setBoundModal(<CoverEditModal key={`cover-edit-modal-${libraryItem.id}`} isOpen navCtx={navCtx} onClose={clearBoundModal} />)
-  }, [clearBoundModal, closeMoreMenu, episode, libraryItem.id, shelfEntities, entityIndex, setBoundModal])
+  const handleOpenEdit = useCallback(() => handleOpenMetadataEdit('details'), [handleOpenMetadataEdit])
+  const handleOpenCoverEdit = useCallback(() => handleOpenMetadataEdit('cover'), [handleOpenMetadataEdit])
+  const handleOpenMatch = useCallback(() => handleOpenMetadataEdit('match'), [handleOpenMetadataEdit])
 
   const handleMoreMenuOpenChange = (isOpen: boolean) => {
     setIsMoreMenuOpen(isOpen)

--- a/src/components/widgets/tracks-edit/TracksEditClient.tsx
+++ b/src/components/widgets/tracks-edit/TracksEditClient.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import LibraryItemEditModal from '@/components/modals/LibraryItemEditModal'
+import LibraryItemMetadataEditModal from '@/components/modals/LibraryItemMetadataEditModal'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import LibraryItemSubpageHeader, { libraryItemSubpageMaxWidthClass } from '@/components/widgets/LibraryItemSubpageHeader'
 import TracksEditToolbar, { TracksEditActions } from '@/components/widgets/tracks-edit/TracksEditToolbar'
@@ -72,7 +72,7 @@ export default function TracksEditClient({ libraryItem: initialLibraryItem }: Tr
         }}
       />
 
-      {isEditModalOpen && <LibraryItemEditModal isOpen libraryItem={editor.libraryItem} onClose={() => setIsEditModalOpen(false)} />}
+      {isEditModalOpen && <LibraryItemMetadataEditModal isOpen libraryItem={editor.libraryItem} onClose={() => setIsEditModalOpen(false)} />}
     </div>
   )
 }

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -3,6 +3,7 @@
   "AriaLabelFileDropZone": "File drop zone",
   "AriaLabelJumpBackwardWithDuration": "Jump Backward, {0}",
   "AriaLabelJumpForwardWithDuration": "Jump Forward, {0}",
+  "AriaLabelModalSections": "Modal sections",
   "AriaLabelNumberOfEpisodes": "Number of episodes",
   "AriaLabelPlaybackRateWithValue": "Playback Rate: {0}x",
   "AriaLabelSearchResults": "Search results",


### PR DESCRIPTION
This PR adds a new type of modal: `SectionedModal`

Sectioned modals allow for each section to have their own actions. In comparison to tabbed modals where each tab shares the same actions.


This is the first pass but not complete. The mobile design is not great because the "hub" (screen where the buttons are listed) is not fixed height right now. Fixed height will look strange so I'm going to do more testing there.

This exports from the library item edit modal, cover edit modal, and match modal. Since those individual modals will no longer be used we can simplify those components to just be for exporting the section. It was a smaller change to use the existing components.

Lastly, I left in the "Match" and "Edit Cover" context menu items for now. Those can be removed in a future PR to simplify the context menus.

<img width="759" height="566" alt="image" src="https://github.com/user-attachments/assets/bc2eec94-02e2-49f4-b953-9b3d20678f05" />


Mobile "hub"

<img width="230" height="226" alt="image" src="https://github.com/user-attachments/assets/28f121d0-278d-49a0-b978-fbf4f15428fd" />

