### PR TITLE
Improve item page table layout on mobile

### DIFF
--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -7,7 +7,7 @@ import Dropdown from './Dropdown'
 import IconBtn from './IconBtn'
 
 /** Tailwind responsive breakpoints */
-export type TailwindBreakpoint = 'sm' | 'md' | 'lg'
+export type TailwindBreakpoint = 'sm' | 'md' | 'lg' | 'xl'
 
 export interface DataTableColumn<T> {
   /** Header label to display */
@@ -216,7 +216,8 @@ export default function DataTable<T>({
     const hiddenClasses: Record<TailwindBreakpoint, string> = {
       sm: 'hidden sm:table-cell',
       md: 'hidden md:table-cell',
-      lg: 'hidden lg:table-cell'
+      lg: 'hidden lg:table-cell',
+      xl: 'hidden xl:table-cell'
     }
     return hiddenClasses[breakpoint]
   }

--- a/src/components/widgets/AudioTracksTable.tsx
+++ b/src/components/widgets/AudioTracksTable.tsx
@@ -2,9 +2,10 @@
 
 import { deleteLibraryFileAction } from '@/app/actions/audioFileActions'
 import AudioFileDataModal from '@/components/modals/AudioFileDataModal'
-import Btn from '@/components/ui/Btn'
 import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
+import IconBtn from '@/components/ui/IconBtn'
 import SimpleDataTable from '@/components/ui/SimpleDataTable'
+import Tooltip from '@/components/ui/Tooltip'
 import CollapsibleSection from '@/components/widgets/CollapsibleSection'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import { useGlobalToast } from '@/contexts/ToastContext'
@@ -110,8 +111,8 @@ export default function AudioTracksTable({ libraryItem, keepOpen = false, expand
         cellClassName: 'text-center px-2 py-1 align-middle'
       },
       {
-        label: t('LabelFilename'),
-        accessor: (row: TrackWithAudioFile) => <span className="font-sans text-sm break-all">{showFullPath ? row.metadata.path : row.metadata.filename}</span>,
+        label: t('LabelPath'),
+        accessor: (row: TrackWithAudioFile) => <span className="font-sans text-sm break-all">{showFullPath ? row.metadata.path : row.metadata.relPath}</span>,
         headerClassName: 'text-start px-2 min-w-[300px]',
         cellClassName: 'text-start px-2 py-1 align-middle'
       },
@@ -182,35 +183,43 @@ export default function AudioTracksTable({ libraryItem, keepOpen = false, expand
 
   const headerActions = useMemo(() => {
     const audioFileCount = libraryItem.media.audioFiles?.length ?? 0
+    const tracksPath = `/library/${libraryItem.libraryId}/item/${libraryItem.id}/tracks`
     const manageTracksBtn =
       userCanUpdate && !libraryItem.isFile && audioFileCount > 1 ? (
-        <Btn
-          key="manage-tracks"
-          to={`/library/${libraryItem.libraryId}/item/${libraryItem.id}/tracks`}
-          color="bg-primary"
-          size="small"
-          className="me-2"
-          onClick={(e) => {
-            e.stopPropagation()
-          }}
-        >
-          {t('ButtonManageTracks')}
-        </Btn>
+        <Tooltip key="manage-tracks" text={t('ButtonManageTracks')} position="top">
+          <span className="me-2 inline-flex">
+            <IconBtn
+              to={tracksPath}
+              size="small"
+              ariaLabel={t('ButtonManageTracks')}
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+            >
+              edit
+            </IconBtn>
+          </span>
+        </Tooltip>
       ) : null
 
+    const pathToggleLabel = showFullPath ? t('ButtonRelativePath') : t('ButtonFullPath')
     const fullPathBtn = userIsAdminOrUp ? (
-      <Btn
-        key="full-path"
-        color={showFullPath ? 'bg-button-selected-bg' : ''}
-        size="small"
-        className="me-2 hidden md:inline-flex"
-        onClick={(e) => {
-          e.stopPropagation()
-          handleToggleFullPath()
-        }}
-      >
-        {t('ButtonFullPath')}
-      </Btn>
+      <Tooltip key="full-path" text={pathToggleLabel} position="top">
+        <span className="me-2 hidden md:inline-flex">
+          <IconBtn
+            size="small"
+            ariaLabel={pathToggleLabel}
+            aria-pressed={showFullPath}
+            className={showFullPath ? 'bg-button-selected-bg' : undefined}
+            onClick={(e) => {
+              e.stopPropagation()
+              handleToggleFullPath()
+            }}
+          >
+            {showFullPath ? 'folder_off' : 'folder'}
+          </IconBtn>
+        </span>
+      </Tooltip>
     ) : null
 
     return (

--- a/src/components/widgets/AudioTracksTable.tsx
+++ b/src/components/widgets/AudioTracksTable.tsx
@@ -17,19 +17,6 @@ import { bytesPretty } from '@/lib/string'
 import { AudioFile, AudioTrack, BookLibraryItem } from '@/types/api'
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
-const MIN_INDEX_WIDTH = 40
-const MIN_ACTIONS_WIDTH = 44
-const MIN_HIDEABLE_COLUMN_WIDTH = 80
-const TABLE_BORDER = 2
-const PATH_MIN_WIDTH = 300
-
-// Calculate minTableWidth for columns
-const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH + MIN_INDEX_WIDTH
-const DURATION_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
-const SIZE_MIN_TABLE_WIDTH = DURATION_MIN_TABLE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
-const BITRATE_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
-const CODEC_MIN_TABLE_WIDTH = BITRATE_MIN_TABLE_WIDTH + MIN_HIDEABLE_COLUMN_WIDTH
-
 interface AudioTracksTableProps {
   libraryItem: BookLibraryItem
   keepOpen?: boolean
@@ -107,42 +94,47 @@ export default function AudioTracksTable({ libraryItem, keepOpen = false, expand
       {
         label: '#',
         accessor: 'index' as const,
-        headerClassName: 'text-center w-10 px-2 min-w-10',
-        cellClassName: 'text-center px-2 py-1 align-middle'
+        headerClassName: 'w-10 min-w-10 px-2 text-center',
+        cellClassName: 'px-2 py-1 text-center align-middle',
+        hiddenBelow: 'sm' as const
       },
       {
         label: t('LabelPath'),
-        accessor: (row: TrackWithAudioFile) => <span className="font-sans text-sm break-all">{showFullPath ? row.metadata.path : row.metadata.relPath}</span>,
-        headerClassName: 'text-start px-2 min-w-[300px]',
-        cellClassName: 'text-start px-2 py-1 align-middle'
+        accessor: (row: TrackWithAudioFile) => (
+          <>
+            <span className="font-sans text-sm break-all md:hidden">{row.metadata.relPath}</span>
+            <span className="hidden font-sans text-sm break-all md:inline">{showFullPath ? row.metadata.path : row.metadata.relPath}</span>
+          </>
+        ),
+        headerClassName: 'min-w-0 px-2 text-start',
+        cellClassName: 'max-w-0 min-w-0 px-2 py-1 text-start align-middle'
       },
       {
         label: t('LabelCodec'),
         accessor: (row: TrackWithAudioFile) => row.audioFile?.codec || '',
-        headerClassName: 'text-start w-20 px-2 min-w-20',
-        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        minTableWidth: CODEC_MIN_TABLE_WIDTH
+        headerClassName: 'w-20 min-w-20 px-2 text-start',
+        cellClassName: 'px-2 py-1 text-start text-sm align-middle',
+        hiddenBelow: 'lg' as const
       },
       {
         label: t('LabelBitrate'),
         accessor: (row: TrackWithAudioFile) => (row.audioFile?.bitRate ? bytesPretty(row.audioFile.bitRate, 0) : ''),
-        headerClassName: 'text-start w-22 px-2 min-w-20',
-        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        minTableWidth: BITRATE_MIN_TABLE_WIDTH
+        headerClassName: 'w-20 min-w-20 px-2 text-start',
+        cellClassName: 'px-2 py-1 text-start text-sm align-middle',
+        hiddenBelow: 'xl' as const
       },
       {
         label: t('LabelSize'),
         accessor: (row: TrackWithAudioFile) => bytesPretty(row.metadata.size),
-        headerClassName: 'text-start w-22 px-2 min-w-20',
-        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        minTableWidth: SIZE_MIN_TABLE_WIDTH
+        headerClassName: 'w-20 min-w-20 px-2 text-start',
+        cellClassName: 'px-2 py-1 text-start text-sm align-middle',
+        hiddenBelow: 'md' as const
       },
       {
         label: t('LabelDuration'),
         accessor: (row: TrackWithAudioFile) => secondsToTimestamp(row.duration),
-        headerClassName: 'text-start w-22 px-2 min-w-20',
-        cellClassName: 'text-start px-2 py-1 text-sm align-middle',
-        minTableWidth: DURATION_MIN_TABLE_WIDTH
+        headerClassName: 'w-20 min-w-20 px-2 text-start',
+        cellClassName: 'px-2 py-1 text-start text-sm align-middle'
       },
       {
         label: '',
@@ -174,8 +166,8 @@ export default function AudioTracksTable({ libraryItem, keepOpen = false, expand
             />
           )
         },
-        headerClassName: 'w-12 min-w-11',
-        cellClassName: 'text-center py-1 align-middle'
+        headerClassName: 'w-11 min-w-11',
+        cellClassName: 'w-11 min-w-11 py-1 text-center align-middle'
       }
     ],
     [t, showFullPath, userCanDownload, userCanDelete, userIsAdminOrUp, handleDeleteFile, downloadFile, showMoreInfo]
@@ -255,7 +247,7 @@ export default function AudioTracksTable({ libraryItem, keepOpen = false, expand
         headerActions={headerActions}
         className={className}
       >
-        <SimpleDataTable data={tracksWithAudioFile} columns={columns} getRowKey={(row) => row.index} />
+        <SimpleDataTable data={tracksWithAudioFile} columns={columns} getRowKey={(row) => row.index} tableClassName="table-fixed" />
       </CollapsibleSection>
 
       <ConfirmDialog

--- a/src/components/widgets/ChaptersTable.tsx
+++ b/src/components/widgets/ChaptersTable.tsx
@@ -41,15 +41,22 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
   const columns = useMemo(
     () => [
       {
+        label: 'Id',
+        accessor: 'id' as const,
+        headerClassName: 'w-12 min-w-12 px-2 text-start md:w-16 md:min-w-16 md:px-4',
+        cellClassName: 'w-12 min-w-12 px-2 text-start md:w-16 md:min-w-16 md:px-4',
+        hiddenBelow: 'sm' as const
+      },
+      {
         label: t('LabelTitle'),
-        accessor: 'title' as const,
-        headerClassName: 'text-start px-4',
-        cellClassName: 'px-4'
+        accessor: (row: Chapter) => <span className="break-words">{row.title}</span>,
+        headerClassName: 'min-w-0 px-2 text-start md:px-4',
+        cellClassName: 'max-w-0 min-w-0 px-2 md:px-4'
       },
       {
         label: t('LabelStart'),
-        headerClassName: 'text-center px-2',
-        cellClassName: 'text-center px-2',
+        headerClassName: 'w-20 min-w-20 px-2 text-center md:w-24 md:min-w-24',
+        cellClassName: 'w-20 min-w-20 px-2 text-center md:w-24 md:min-w-24',
         accessor: (row: Chapter) => (
           <div
             className="cursor-pointer text-center font-mono hover:underline"
@@ -74,10 +81,9 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
       },
       {
         label: t('LabelDuration'),
-        headerClassName: 'text-center px-2 w-16 md:w-24 min-w-16 md:min-w-24',
-        cellClassName: 'text-center px-2 font-mono',
-        accessor: (row: Chapter) => secondsToTimestamp(Math.max(0, row.end - row.start)),
-        hiddenBelow: 'md' as const
+        headerClassName: 'w-24 min-w-24 px-2 pe-3 text-center',
+        cellClassName: 'w-24 min-w-24 px-2 pe-3 text-center font-mono',
+        accessor: (row: Chapter) => secondsToTimestamp(Math.max(0, row.end - row.start))
       }
     ],
     [t, handleGoToTimestamp]
@@ -126,7 +132,7 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
           <p className="text-foreground-muted">{t('MessageNoChapters')}</p>
         </div>
       ) : (
-        <SimpleDataTable data={chapters} columns={columns} getRowKey={(row) => row.id} />
+        <SimpleDataTable data={chapters} columns={columns} getRowKey={(row) => row.id} tableClassName="table-fixed" />
       )}
     </CollapsibleSection>
   )

--- a/src/components/widgets/ChaptersTable.tsx
+++ b/src/components/widgets/ChaptersTable.tsx
@@ -41,13 +41,6 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
   const columns = useMemo(
     () => [
       {
-        label: t('LabelId'),
-        accessor: 'id' as const,
-        headerClassName: 'w-12 min-w-12 px-2 text-start md:w-16 md:min-w-16 md:px-4',
-        cellClassName: 'w-12 min-w-12 px-2 text-start md:w-16 md:min-w-16 md:px-4',
-        hiddenBelow: 'sm' as const
-      },
-      {
         label: t('LabelTitle'),
         accessor: (row: Chapter) => <span className="break-words">{row.title}</span>,
         headerClassName: 'min-w-0 px-2 text-start md:px-4',

--- a/src/components/widgets/ChaptersTable.tsx
+++ b/src/components/widgets/ChaptersTable.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import Btn from '@/components/ui/Btn'
+import IconBtn from '@/components/ui/IconBtn'
 import SimpleDataTable from '@/components/ui/SimpleDataTable'
+import Tooltip from '@/components/ui/Tooltip'
 import CollapsibleSection from '@/components/widgets/CollapsibleSection'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
@@ -84,22 +85,27 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
 
   const chaptersPath = `/library/${libraryItem.libraryId}/item/${libraryItem.id}/chapters`
 
+  const chaptersActionLabel = isEmpty ? t('ButtonAddChapters') : t('ButtonEditChapters')
+
   const headerActions = useMemo(
     () =>
       userCanUpdate ? (
-        <Btn
-          to={chaptersPath}
-          color="bg-primary"
-          size="small"
-          className="me-2"
-          onClick={(e) => {
-            e.stopPropagation()
-          }}
-        >
-          {isEmpty ? t('ButtonAddChapters') : t('ButtonEditChapters')}
-        </Btn>
+        <Tooltip text={chaptersActionLabel} position="top">
+          <span className="me-2 inline-flex">
+            <IconBtn
+              to={chaptersPath}
+              size="small"
+              ariaLabel={chaptersActionLabel}
+              onClick={(e) => {
+                e.stopPropagation()
+              }}
+            >
+              {isEmpty ? 'add' : 'edit'}
+            </IconBtn>
+          </span>
+        </Tooltip>
       ) : null,
-    [userCanUpdate, chaptersPath, isEmpty, t]
+    [userCanUpdate, chaptersPath, chaptersActionLabel, isEmpty]
   )
 
   if (isEmpty && !userCanUpdate) {

--- a/src/components/widgets/ChaptersTable.tsx
+++ b/src/components/widgets/ChaptersTable.tsx
@@ -41,7 +41,7 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
   const columns = useMemo(
     () => [
       {
-        label: 'Id',
+        label: t('LabelId'),
         accessor: 'id' as const,
         headerClassName: 'w-12 min-w-12 px-2 text-start md:w-16 md:min-w-16 md:px-4',
         cellClassName: 'w-12 min-w-12 px-2 text-start md:w-16 md:min-w-16 md:px-4',

--- a/src/components/widgets/EbookFilesTable.tsx
+++ b/src/components/widgets/EbookFilesTable.tsx
@@ -19,16 +19,6 @@ import { bytesPretty } from '@/lib/string'
 import { BookLibraryItem, LibraryFile } from '@/types/api'
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 
-const MIN_ACTIONS_WIDTH = 44
-const MIN_SIZE_WIDTH = 80
-const MIN_READ_WIDTH = 48
-const TABLE_BORDER = 2
-const PATH_MIN_WIDTH = 300
-
-const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH
-const SIZE_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_SIZE_WIDTH
-const READ_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_READ_WIDTH
-
 interface EbookFilesTableProps {
   libraryItem: BookLibraryItem
   keepOpen?: boolean
@@ -137,7 +127,8 @@ export default function EbookFilesTable({ libraryItem, keepOpen = false, expande
           const isPrimary = !row.isSupplementary
           return (
             <span className="break-all">
-              {showFullPath ? row.metadata.path : row.metadata.relPath}
+              <span className="md:hidden">{row.metadata.relPath}</span>
+              <span className="hidden md:inline">{showFullPath ? row.metadata.path : row.metadata.relPath}</span>
               {isPrimary && (
                 <span className="ms-1 inline-block">
                   <Tooltip text={t('LabelPrimaryEbook')} position="top">
@@ -148,21 +139,22 @@ export default function EbookFilesTable({ libraryItem, keepOpen = false, expande
             </span>
           )
         },
-        headerClassName: 'text-start px-2 md:px-4 min-w-[300px]',
-        cellClassName: 'text-start px-2 md:px-4 py-1 align-middle'
+        headerClassName: 'min-w-0 px-2 text-start md:px-4',
+        cellClassName: 'max-w-0 min-w-0 px-2 py-1 text-start align-middle md:px-4'
       },
       {
         label: t('LabelSize'),
         accessor: (row: LibraryFile) => bytesPretty(row.metadata.size),
-        headerClassName: 'text-start w-22 min-w-20 px-2',
-        cellClassName: 'text-start py-1 text-xs md:text-sm whitespace-nowrap px-2 align-middle',
-        minTableWidth: SIZE_MIN_TABLE_WIDTH
+        headerClassName: 'w-16 min-w-16 px-1 text-start sm:w-20 sm:min-w-20 sm:px-2',
+        cellClassName: 'w-16 min-w-16 whitespace-nowrap px-1 py-1 text-start text-xs align-middle sm:w-20 sm:min-w-20 sm:px-2 md:text-sm'
       },
       {
         label: (
           <span className="inline-flex items-center gap-1">
             {t('LabelRead')}
-            <HelpTooltipIcon text={t('LabelReadEbookWithoutProgress')} size="sm" />
+            <span className="hidden sm:inline-flex">
+              <HelpTooltipIcon text={t('LabelReadEbookWithoutProgress')} size="sm" />
+            </span>
           </span>
         ),
         accessor: (row: LibraryFile) => (
@@ -179,9 +171,8 @@ export default function EbookFilesTable({ libraryItem, keepOpen = false, expande
             auto_stories
           </IconBtn>
         ),
-        headerClassName: 'text-start w-24 min-w-24 px-2',
-        cellClassName: 'text-start py-1 px-2 align-middle',
-        minTableWidth: READ_MIN_TABLE_WIDTH
+        headerClassName: 'w-14 min-w-14 px-1 text-start sm:w-24 sm:min-w-24 sm:px-2',
+        cellClassName: 'w-14 min-w-14 px-1 py-1 text-start align-middle sm:w-24 sm:min-w-24 sm:px-2'
       },
       ...(showMoreColumn
         ? [
@@ -218,8 +209,8 @@ export default function EbookFilesTable({ libraryItem, keepOpen = false, expande
                   />
                 )
               },
-              headerClassName: 'w-12 min-w-11',
-              cellClassName: 'text-center py-1 align-middle'
+              headerClassName: 'w-11 min-w-11',
+              cellClassName: 'w-11 min-w-11 py-1 text-center align-middle'
             }
           ]
         : [])
@@ -276,7 +267,7 @@ export default function EbookFilesTable({ libraryItem, keepOpen = false, expande
         keepOpen={keepOpen}
         headerActions={headerActions}
       >
-        <SimpleDataTable data={ebookFiles} columns={columns} getRowKey={(row) => row.ino} />
+        <SimpleDataTable data={ebookFiles} columns={columns} getRowKey={(row) => row.ino} tableClassName="table-fixed" />
       </CollapsibleSection>
 
       <ConfirmDialog isOpen={!!fileToDelete} message={t('MessageConfirmDeleteFile')} onClose={() => setFileToDelete(null)} onConfirm={handleConfirmDelete} />

--- a/src/components/widgets/EbookFilesTable.tsx
+++ b/src/components/widgets/EbookFilesTable.tsx
@@ -2,7 +2,6 @@
 
 import { deleteLibraryFileAction } from '@/app/actions/audioFileActions'
 import { updateEbookFileStatusAction } from '@/app/actions/ebookActions'
-import Btn from '@/components/ui/Btn'
 import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
 import HelpTooltipIcon from '@/components/ui/HelpTooltipIcon'
 import IconBtn from '@/components/ui/IconBtn'
@@ -241,23 +240,27 @@ export default function EbookFilesTable({ libraryItem, keepOpen = false, expande
     ]
   )
 
-  const headerActions = useMemo(
-    () =>
-      userIsAdminOrUp ? (
-        <Btn
-          color={showFullPath ? 'bg-button-selected-bg' : ''}
-          size="small"
-          className="mr-2 hidden md:inline-flex"
-          onClick={(e) => {
-            e.stopPropagation()
-            toggleFullPath()
-          }}
-        >
-          {t('ButtonFullPath')}
-        </Btn>
-      ) : null,
-    [userIsAdminOrUp, showFullPath, toggleFullPath, t]
-  )
+  const headerActions = useMemo(() => {
+    const pathToggleLabel = showFullPath ? t('ButtonRelativePath') : t('ButtonFullPath')
+    return userIsAdminOrUp ? (
+      <Tooltip text={pathToggleLabel} position="top">
+        <span className="me-2 hidden md:inline-flex">
+          <IconBtn
+            size="small"
+            ariaLabel={pathToggleLabel}
+            aria-pressed={showFullPath}
+            className={showFullPath ? 'bg-button-selected-bg' : undefined}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggleFullPath()
+            }}
+          >
+            {showFullPath ? 'folder_off' : 'folder'}
+          </IconBtn>
+        </span>
+      </Tooltip>
+    ) : null
+  }, [userIsAdminOrUp, showFullPath, toggleFullPath, t])
 
   if (ebookFiles.length === 0) {
     return null

--- a/src/components/widgets/LibraryFilesTable.tsx
+++ b/src/components/widgets/LibraryFilesTable.tsx
@@ -2,9 +2,10 @@
 
 import { deleteLibraryFileAction } from '@/app/actions/audioFileActions'
 import AudioFileDataModal from '@/components/modals/AudioFileDataModal'
-import Btn from '@/components/ui/Btn'
 import ContextMenuDropdown, { ContextMenuDropdownItem } from '@/components/ui/ContextMenuDropdown'
+import IconBtn from '@/components/ui/IconBtn'
 import SimpleDataTable from '@/components/ui/SimpleDataTable'
+import Tooltip from '@/components/ui/Tooltip'
 import CollapsibleSection from '@/components/widgets/CollapsibleSection'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
@@ -179,23 +180,27 @@ export default function LibraryFilesTable({ libraryItem, keepOpen = false, inMod
     [t, showFullPath, userCanDownload, canDownloadItem, userCanDelete, userIsAdminOrUp, inModal, handleDeleteFile, downloadFile, showMoreInfo]
   )
 
-  const headerActions = useMemo(
-    () =>
-      userIsAdminOrUp ? (
-        <Btn
-          color={showFullPath ? 'bg-button-selected-bg' : ''}
-          size="small"
-          className="mr-2 hidden md:inline-flex"
-          onClick={(e) => {
-            e.stopPropagation()
-            toggleFullPath()
-          }}
-        >
-          {t('ButtonFullPath')}
-        </Btn>
-      ) : null,
-    [userIsAdminOrUp, showFullPath, toggleFullPath, t]
-  )
+  const headerActions = useMemo(() => {
+    const pathToggleLabel = showFullPath ? t('ButtonRelativePath') : t('ButtonFullPath')
+    return userIsAdminOrUp ? (
+      <Tooltip text={pathToggleLabel} position="top">
+        <span className="me-2 hidden md:inline-flex">
+          <IconBtn
+            size="small"
+            ariaLabel={pathToggleLabel}
+            aria-pressed={showFullPath}
+            className={showFullPath ? 'bg-button-selected-bg' : undefined}
+            onClick={(e) => {
+              e.stopPropagation()
+              toggleFullPath()
+            }}
+          >
+            {showFullPath ? 'folder_off' : 'folder'}
+          </IconBtn>
+        </span>
+      </Tooltip>
+    ) : null
+  }, [userIsAdminOrUp, showFullPath, toggleFullPath, t])
 
   return (
     <>

--- a/src/components/widgets/LibraryFilesTable.tsx
+++ b/src/components/widgets/LibraryFilesTable.tsx
@@ -16,27 +16,6 @@ import { AudioFile, BookLibraryItem, LibraryFile, PodcastLibraryItem } from '@/t
 import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import ConfirmDialog from './ConfirmDialog'
 
-// Minimum widths for columns (in pixels)
-// Actions: min-w-10 = 40px (w-10 = 2.5rem = 40px)
-// Size: min-w-12 = 48px (w-12 = 3rem = 48px)
-// Type: min-w-12 = 48px (w-12 = 3rem = 48px)
-// Path: flexible, can wrap
-const MIN_ACTIONS_WIDTH = 44
-const MIN_SIZE_WIDTH = 80
-const MIN_TYPE_WIDTH = 72
-const TABLE_BORDER = 2
-const PATH_MIN_WIDTH = 300
-
-// Calculate minTableWidth for columns
-// Path is always shown (base)
-const BASE_WIDTH = PATH_MIN_WIDTH + TABLE_BORDER + MIN_ACTIONS_WIDTH
-
-// Size requires base + size width
-const SIZE_MIN_TABLE_WIDTH = BASE_WIDTH + MIN_SIZE_WIDTH
-
-// Type requires base + size width + type width
-const TYPE_MIN_TABLE_WIDTH = SIZE_MIN_TABLE_WIDTH + MIN_TYPE_WIDTH
-
 interface LibraryFileWithAudio extends LibraryFile {
   audioFile?: AudioFile
 }
@@ -125,16 +104,20 @@ export default function LibraryFilesTable({ libraryItem, keepOpen = false, inMod
     () => [
       {
         label: t('LabelPath'),
-        accessor: (row: LibraryFileWithAudio) => <span className="break-all">{showFullPath ? row.metadata.path : row.metadata.relPath}</span>,
-        headerClassName: 'text-start px-2 md:px-4 min-w-[300px]',
-        cellClassName: 'text-start px-2 md:px-4 py-1 align-middle'
+        accessor: (row: LibraryFileWithAudio) => (
+          <>
+            <span className="break-all md:hidden">{row.metadata.relPath}</span>
+            <span className="hidden break-all md:inline">{showFullPath ? row.metadata.path : row.metadata.relPath}</span>
+          </>
+        ),
+        headerClassName: 'min-w-0 px-2 text-start md:px-4',
+        cellClassName: 'max-w-0 min-w-0 px-2 py-1 text-start align-middle md:px-4'
       },
       {
         label: t('LabelSize'),
         accessor: (row: LibraryFileWithAudio) => bytesPretty(row.metadata.size),
-        headerClassName: 'text-start w-22 min-w-20 px-2',
-        cellClassName: 'text-start py-1 text-xs md:text-sm whitespace-nowrap px-2 align-middle',
-        minTableWidth: SIZE_MIN_TABLE_WIDTH
+        headerClassName: 'w-16 min-w-16 px-1 text-start sm:w-20 sm:min-w-20 sm:px-2',
+        cellClassName: 'w-16 min-w-16 whitespace-nowrap px-1 py-1 text-start text-xs align-middle sm:w-20 sm:min-w-20 sm:px-2 md:text-sm'
       },
       {
         label: t('LabelType'),
@@ -143,9 +126,8 @@ export default function LibraryFilesTable({ libraryItem, keepOpen = false, inMod
             <p className="truncate">{row.fileType}</p>
           </div>
         ),
-        headerClassName: 'text-start w-22 min-w-18 px-2',
-        cellClassName: 'text-start text-xs py-1 whitespace-nowrap px-2 align-middle',
-        minTableWidth: TYPE_MIN_TABLE_WIDTH
+        headerClassName: 'w-14 min-w-14 px-1 text-start sm:w-20 sm:min-w-18 sm:px-2',
+        cellClassName: 'w-14 min-w-14 whitespace-nowrap px-1 py-1 text-start text-xs align-middle sm:w-20 sm:min-w-18 sm:px-2'
       },
       {
         label: '',
@@ -173,8 +155,8 @@ export default function LibraryFilesTable({ libraryItem, keepOpen = false, inMod
             />
           )
         },
-        headerClassName: 'w-12 min-w-11',
-        cellClassName: 'text-center py-1 align-middle'
+        headerClassName: 'w-11 min-w-11',
+        cellClassName: 'w-11 min-w-11 py-1 text-center align-middle'
       }
     ],
     [t, showFullPath, userCanDownload, canDownloadItem, userCanDelete, userIsAdminOrUp, inModal, handleDeleteFile, downloadFile, showMoreInfo]
@@ -212,7 +194,7 @@ export default function LibraryFilesTable({ libraryItem, keepOpen = false, inMod
         keepOpen={keepOpen}
         headerActions={headerActions}
       >
-        <SimpleDataTable data={filesWithAudioFile} columns={columns} getRowKey={(row) => row.ino} />
+        <SimpleDataTable data={filesWithAudioFile} columns={columns} getRowKey={(row) => row.ino} tableClassName="table-fixed" />
       </CollapsibleSection>
 
       {/* Single confirmation dialog for the table */}

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -501,6 +501,7 @@
   "LabelHoursPlural": "{count, plural, one {# hour} other {# hours}}",
   "LabelIcon": "Icon",
   "LabelIconOptions": "{label} options",
+  "LabelId": "Id",
   "LabelImageURLFromTheWeb": "Image URL from the web",
   "LabelInProgress": "In Progress",
   "LabelInclude": "Include",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -102,6 +102,7 @@
   "ButtonReadLess": "Read less",
   "ButtonReadMore": "Read more",
   "ButtonRefresh": "Refresh",
+  "ButtonRelativePath": "Relative Path",
   "ButtonRemove": "Remove",
   "ButtonRemoveAll": "Remove All",
   "ButtonRemoveAllLibraryItems": "Remove All Library Items",

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -501,7 +501,6 @@
   "LabelHoursPlural": "{count, plural, one {# hour} other {# hours}}",
   "LabelIcon": "Icon",
   "LabelIconOptions": "{label} options",
-  "LabelId": "Id",
   "LabelImageURLFromTheWeb": "Image URL from the web",
   "LabelInProgress": "In Progress",
   "LabelInclude": "Include",


### PR DESCRIPTION
This fixes the `redesign action buttons on book page tables` action item on #112 and also fixes #139

**Notable changes**
- Section actions (edit/add chapters, manage tracks, full path) use compact icon buttons so headers stay usable on small screens
- Chapters, tracks, and files tables fit narrow (~360px) widths without horizontal scroll; relative paths wrap and row menus stay visible
- Chapter Id and track `#` hide on the smallest screens; duration stays visible
- Full path toggle remains desktop-only; mobile always shows relative paths