### PR TITLE
Use Link for internal page navigation

### DIFF
--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -20,6 +20,7 @@ import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { mergeLibraryItemUpdate } from '@/lib/libraryItemUpdatedUtils'
 import { computeProgress } from '@/lib/mediaProgress'
 import { BookLibraryItem, BookMetadata, PodcastEpisode, PodcastLibraryItem, PodcastMetadata } from '@/types/api'
+import Link from 'next/link'
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import LibraryItemActionButtons from './LibraryItemActionButtons'
 import LibraryItemCover from './LibraryItemCover'
@@ -147,10 +148,10 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                     {bookSeries.map((series, index) => {
                       return (
                         <Fragment key={series.id}>
-                          <a href={`/library/${library.id}/series/${series.id}`} className="text-foreground-muted text-lg hover:underline">
+                          <Link href={`/library/${library.id}/series/${series.id}`} className="text-foreground-muted text-lg hover:underline">
                             {series.name}
                             {series.sequence && <span className="text-foreground-muted text-lg"> #{series.sequence}</span>}
-                          </a>
+                          </Link>
                           {index < bookSeries.length - 1 && <span className="text-foreground-muted text-lg">, </span>}
                         </Fragment>
                       )
@@ -164,9 +165,9 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                     {bookAuthors.map((author, index) => {
                       return (
                         <Fragment key={author.id}>
-                          <a href={`/library/${library.id}/authors/${author.id}`} className="text-foreground text-lg hover:underline md:text-xl">
+                          <Link href={`/library/${library.id}/authors/${author.id}`} className="text-foreground text-lg hover:underline md:text-xl">
                             {author.name}
-                          </a>
+                          </Link>
                           {index < bookAuthors.length - 1 && <span className="text-foreground text-lg md:text-xl">, </span>}
                         </Fragment>
                       )

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemDetails.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemDetails.tsx
@@ -5,6 +5,7 @@ import { filterEncode } from '@/lib/filterUtils'
 import { formatDuration } from '@/lib/formatDuration'
 import { bytesPretty } from '@/lib/string'
 import { BookLibraryItem, BookMetadata, PodcastLibraryItem, PodcastMetadata } from '@/types/api'
+import Link from 'next/link'
 import { Fragment } from 'react'
 
 interface LibraryItemDetailsProps {
@@ -27,17 +28,17 @@ function DetailRow({ label, value, filterKey, libraryId }: DetailRowProps) {
     if (Array.isArray(value)) {
       displayValue = (value as string[]).map((v, index) => (
         <Fragment key={v}>
-          <a href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(v)}`} className="text-foreground hover:underline">
+          <Link href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(v)}`} className="text-foreground hover:underline">
             {v}
-          </a>
+          </Link>
           {index < (value as string[]).length - 1 && <span className="text-foreground">, </span>}
         </Fragment>
       ))
     } else {
       displayValue = (
-        <a href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(value)}`} className="text-foreground hover:underline">
+        <Link href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(value)}`} className="text-foreground hover:underline">
           {value}
-        </a>
+        </Link>
       )
     }
   } else {

--- a/src/app/(main)/library/[library]/stats/StatsClient.tsx
+++ b/src/app/(main)/library/[library]/stats/StatsClient.tsx
@@ -7,6 +7,7 @@ import { formatDuration } from '@/lib/formatDuration'
 import { mergeClasses } from '@/lib/merge-classes'
 import { bytesPretty } from '@/lib/string'
 import { LibraryStatsResponse } from '@/types/api'
+import Link from 'next/link'
 import React from 'react'
 
 interface StatCardProps {
@@ -43,7 +44,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
     .map((stat) => ({
       label: stat.genre,
       percentage: Math.round((stat.count / stats.totalItems) * 100),
-      linkHref: `items?filter=genres.${filterEncode(stat.genre)}`
+      linkHref: `/library/${library.id}/items?filter=genres.${filterEncode(stat.genre)}`
     }))
 
   const topAuthors =
@@ -53,21 +54,21 @@ export default function StatsClient({ stats }: StatsClientProps) {
       .map((stat) => ({
         label: `${stat.name}`,
         numBooks: stat.count,
-        linkHref: `authors/${stat.id}`
+        linkHref: `/library/${library.id}/authors/${stat.id}`
       })) ?? []
 
   const longestItems = stats.longestItems
     .sort((a, b) => b.duration - a.duration)
     .map((stat) => ({
       label: stat.title,
-      linkHref: `item/${stat.id}`
+      linkHref: `/library/${library.id}/item/${stat.id}`
     }))
 
   const largestItems = stats.largestItems
     .sort((a, b) => b.size - a.size)
     .map((stat) => ({
       label: stat.title,
-      linkHref: `item/${stat.id}`,
+      linkHref: `/library/${library.id}/item/${stat.id}`,
       size: bytesPretty(stat.size)
     }))
 
@@ -100,9 +101,9 @@ export default function StatsClient({ stats }: StatsClientProps) {
               <div className="mb-1 flex items-end">
                 <p className="text-2xl font-bold">{`${stat.percentage}%`}</p>
                 <div className="grow"></div>
-                <a href={stat.linkHref} className="text-foreground-subdued ml-2 hover:underline">
+                <Link href={stat.linkHref} className="text-foreground-subdued ml-2 hover:underline">
                   {stat.label}
-                </a>
+                </Link>
               </div>
               <div className="bg-primary/50 h-3 w-full overflow-hidden rounded-full">
                 <div className="h-full rounded-full bg-yellow-400" style={{ width: `${stat.percentage}%` }}></div>
@@ -118,9 +119,9 @@ export default function StatsClient({ stats }: StatsClientProps) {
             {topAuthors.map((stat, index) => (
               <div key={index} className="mb-1 flex w-full items-center py-2 last:border-b-0">
                 <span className="text-foreground-subdued pr-1 text-sm">{`${index + 1}. `}</span>
-                <a href={stat.linkHref} className="text-foreground-subdued truncate pr-2 text-sm hover:underline">
+                <Link href={stat.linkHref} className="text-foreground-subdued truncate pr-2 text-sm hover:underline">
                   {stat.label}
-                </a>
+                </Link>
                 <div className="h-2.5 grow overflow-hidden rounded-full"></div>
                 <div className="ml-3 w-4">
                   <p className="text-sm font-bold">{Math.round(stat.numBooks)}</p>
@@ -139,9 +140,9 @@ export default function StatsClient({ stats }: StatsClientProps) {
           {longestItems.map((stat, index) => (
             <div key={index} className="mb-1 flex w-full items-center justify-between py-2 last:border-b-0">
               <span className="text-foreground-subdued pr-1 text-sm">{`${index + 1}. `}</span>
-              <a href={stat.linkHref} className="text-foreground-subdued w-3/4 truncate pr-2 text-sm hover:underline">
+              <Link href={stat.linkHref} className="text-foreground-subdued w-3/4 truncate pr-2 text-sm hover:underline">
                 {`${stat.label}`}
-              </a>
+              </Link>
               <div className="w-1/4 flex-shrink-0 text-right">
                 <p className="text-sm font-bold">{formatDuration(stats.longestItems[index].duration, t)}</p>
               </div>
@@ -155,9 +156,9 @@ export default function StatsClient({ stats }: StatsClientProps) {
           {largestItems.map((stat, index) => (
             <div key={index} className="mb-1 flex w-full items-center justify-between py-2 last:border-b-0">
               <span className="text-foreground-subdued pr-1 text-sm">{`${index + 1}. `}</span>
-              <a href={stat.linkHref} className="text-foreground-subdued w-3/4 truncate pr-2 text-sm hover:underline">
+              <Link href={stat.linkHref} className="text-foreground-subdued w-3/4 truncate pr-2 text-sm hover:underline">
                 {`${stat.label}`}
-              </a>
+              </Link>
               <div className="w-1/4 flex-shrink-0 text-right">
                 {/* Displaying the absolute size directly */}
                 <p className="text-sm font-bold whitespace-nowrap">{stat.size}</p>

--- a/src/components/ui/MetadataEditTable.tsx
+++ b/src/components/ui/MetadataEditTable.tsx
@@ -3,6 +3,7 @@
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { mergeClasses } from '@/lib/merge-classes'
 import { TranslationKey } from '@/types/translations'
+import Link from 'next/link'
 import { Fragment, useEffect, useRef, useState, useTransition } from 'react'
 import ConfirmDialog from '../widgets/ConfirmDialog'
 import IconBtn from './IconBtn'
@@ -171,9 +172,9 @@ export default function MetadataEditTable({ items, onItemEditSaveClick, onItemDe
     <tr className="group even:bg-primary/20 p-2">
       <td className="p-3.5">
         {showNumBooks ? (
-          <a className="text-foreground text-sm hover:underline md:text-base" title={item.name} href={narratorHref(item)}>
+          <Link className="text-foreground text-sm hover:underline md:text-base" title={item.name} href={narratorHref(item)}>
             {item.name}
-          </a>
+          </Link>
         ) : (
           <span className="text-foreground text-sm md:text-base" title={item.name}>
             {item.name}
@@ -183,9 +184,9 @@ export default function MetadataEditTable({ items, onItemEditSaveClick, onItemDe
       {showNumBooks && (
         <td className="w-1/6 md:table-cell">
           <div className="flex justify-center">
-            <a className="text-foreground text-sm hover:underline md:text-base" href={narratorHref(item)}>
+            <Link className="text-foreground text-sm hover:underline md:text-base" href={narratorHref(item)}>
               {item.numBooks}
-            </a>
+            </Link>
           </div>
         </td>
       )}


### PR DESCRIPTION
Fixes #227

Several internal links were plain hrefs, which trigger a full page load instead of client-side navigation. Because of this, the book that was playing stops.

Updated the item page (series, author, and the linked detail fields), the library stats page (top genres, top authors, longest items, largest items), and the narrator table to use Link.

The stats page links were also relative paths, which Link doesn't resolve the same way, so I made them absolute.

**Testing:**

- Played a book and confirmed it keeps playing when clicking links on the item, stats, and narrators pages
- Confirmed each link still lands on the right page with filters applied.