### PR TITLE
Allow selecting multiple files on the upload page

### DIFF
--- a/src/app/(main)/upload/UploadClient.tsx
+++ b/src/app/(main)/upload/UploadClient.tsx
@@ -340,7 +340,7 @@ export default function UploadClient({ libraries }: LibraryClientProps) {
             <p className="px-6 pt-6 text-2xl">{t('LabelUploaderDragAndDrop')}</p>
             <p className="p-6">{t('MessageOr')}</p>
             <div className="flex justify-center gap-4">
-              <FilePicker accept={supFileTypes} onFilesSelected={handleDialogFileSelected}>
+              <FilePicker accept={supFileTypes} multiple={true} onFilesSelected={handleDialogFileSelected}>
                 {t('ButtonChooseFiles')}
               </FilePicker>
               <FilePicker multiple={true} directory={true} onFilesSelected={handleDialogFileSelected}>


### PR DESCRIPTION
Fixes #229

The "Choose files" button on the upload page only allowed picking one file at a time. The file input now sets `multiple={true}`, matching the folder picker beside it and the Vue client.

**Testing:**

Confirmed multiple files can now be selected with "Choose files"