### PR TITLE
Add listened time alongside total duration on collection and playlist

### DIFF
--- a/src/hooks/useCollectionBooks.ts
+++ b/src/hooks/useCollectionBooks.ts
@@ -4,10 +4,11 @@ import { useLibrary } from '@/contexts/LibraryContext'
 import { useUser } from '@/contexts/UserContext'
 import { useLibraryItemUpdated } from '@/hooks/useLibraryItemUpdated'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { formatDuration } from '@/lib/formatDuration'
+import { getBookDuration } from '@/lib/book'
 import { applyLibraryItemUpdateToList } from '@/lib/libraryItemUpdatedUtils'
-import { getMediaItemProgress } from '@/lib/mediaProgress'
+import { getDurationSupplementLabel, getMediaItemProgress } from '@/lib/mediaProgress'
 import type { Collection, LibraryItem } from '@/types/api'
+import { isBookMedia } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
@@ -46,8 +47,7 @@ export function useCollectionBooks(collection: Collection) {
   const totalDurationSeconds = useMemo(() => {
     let sum = 0
     for (const book of orderedBooks) {
-      const d = book.media && 'duration' in book.media ? book.media.duration : 0
-      sum += typeof d === 'number' && Number.isFinite(d) ? d : 0
+      sum += book.media && isBookMedia(book.media) ? getBookDuration(book.media) : 0
     }
     return sum
   }, [orderedBooks])
@@ -55,22 +55,18 @@ export function useCollectionBooks(collection: Collection) {
   const totalListenedSeconds = useMemo(() => {
     let sum = 0
     for (const book of orderedBooks) {
-      const duration = book.media && 'duration' in book.media ? book.media.duration : 0
+      const duration = book.media && isBookMedia(book.media) ? getBookDuration(book.media) : 0
       const progress = getMediaItemProgress(user.mediaProgress, book.id)
       if (!progress) continue
-      sum += progress.isFinished ? typeof duration === 'number' ? duration : 0 : progress.currentTime || 0
+      sum += progress.isFinished ? duration : progress.currentTime || 0
     }
     return sum
   }, [orderedBooks, user.mediaProgress])
 
-  const totalDurationLabel = totalDurationSeconds > 0 ? formatDuration(totalDurationSeconds, t, { showDays: true }) : null
-  const totalListenedLabel = totalListenedSeconds > 0 ? formatDuration(totalListenedSeconds, t, { showDays: true }) : null
-
-  const itemCountSupplementLabel = useMemo(() => {
-    if (!totalDurationLabel) return null
-    if (totalListenedLabel) return ` (${totalListenedLabel} / ${totalDurationLabel} total)`
-    return ` (${totalDurationLabel})`
-  }, [totalDurationLabel, totalListenedLabel])
+  const itemCountSupplementLabel = useMemo(
+    () => getDurationSupplementLabel(totalDurationSeconds, totalListenedSeconds, t),
+    [totalDurationSeconds, totalListenedSeconds, t]
+  )
 
   useEffect(() => {
     setItemCount(totalEntities)

--- a/src/hooks/useCollectionBooks.ts
+++ b/src/hooks/useCollectionBooks.ts
@@ -1,10 +1,12 @@
 'use client'
 
 import { useLibrary } from '@/contexts/LibraryContext'
+import { useUser } from '@/contexts/UserContext'
 import { useLibraryItemUpdated } from '@/hooks/useLibraryItemUpdated'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatDuration } from '@/lib/formatDuration'
 import { applyLibraryItemUpdateToList } from '@/lib/libraryItemUpdatedUtils'
+import { getMediaItemProgress } from '@/lib/mediaProgress'
 import type { Collection, LibraryItem } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -13,6 +15,7 @@ export function useCollectionBooks(collection: Collection) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const { setItemCount, setItemCountSupplement } = useLibrary()
+  const { user } = useUser()
 
   const serverBookIds = useMemo(() => (collection.books ?? []).map((b) => b.id).join(','), [collection.books])
 
@@ -49,15 +52,33 @@ export function useCollectionBooks(collection: Collection) {
     return sum
   }, [orderedBooks])
 
+  const totalListenedSeconds = useMemo(() => {
+    let sum = 0
+    for (const book of orderedBooks) {
+      const duration = book.media && 'duration' in book.media ? book.media.duration : 0
+      const progress = getMediaItemProgress(user.mediaProgress, book.id)
+      if (!progress) continue
+      sum += progress.isFinished ? typeof duration === 'number' ? duration : 0 : progress.currentTime || 0
+    }
+    return sum
+  }, [orderedBooks, user.mediaProgress])
+
   const totalDurationLabel = totalDurationSeconds > 0 ? formatDuration(totalDurationSeconds, t, { showDays: true }) : null
+  const totalListenedLabel = totalListenedSeconds > 0 ? formatDuration(totalListenedSeconds, t, { showDays: true }) : null
+
+  const itemCountSupplementLabel = useMemo(() => {
+    if (!totalDurationLabel) return null
+    if (totalListenedLabel) return ` (${totalListenedLabel} / ${totalDurationLabel} total)`
+    return ` (${totalDurationLabel})`
+  }, [totalDurationLabel, totalListenedLabel])
 
   useEffect(() => {
     setItemCount(totalEntities)
-    setItemCountSupplement(totalDurationLabel ? ` (${totalDurationLabel})` : null)
+    setItemCountSupplement(itemCountSupplementLabel)
     return () => {
       setItemCount(null)
     }
-  }, [totalEntities, totalDurationLabel, setItemCount, setItemCountSupplement])
+  }, [totalEntities, itemCountSupplementLabel, setItemCount, setItemCountSupplement])
 
   return {
     orderedBooks,

--- a/src/hooks/usePlaylistItems.ts
+++ b/src/hooks/usePlaylistItems.ts
@@ -1,10 +1,12 @@
 'use client'
 
 import { useLibrary } from '@/contexts/LibraryContext'
+import { useUser } from '@/contexts/UserContext'
 import { useLibraryItemUpdated } from '@/hooks/useLibraryItemUpdated'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { formatDuration } from '@/lib/formatDuration'
 import { applyLibraryItemUpdateToPlaylistItems } from '@/lib/libraryItemUpdatedUtils'
+import { getMediaItemProgress } from '@/lib/mediaProgress'
 import { getPlaylistItemDuration, matchesPlaylistItem } from '@/lib/playlistItems'
 import type { Playlist, PlaylistItem } from '@/types/api'
 import { useRouter } from 'next/navigation'
@@ -14,6 +16,7 @@ export function usePlaylistItems(playlist: Playlist) {
   const t = useTypeSafeTranslations()
   const router = useRouter()
   const { setItemCount, setItemCountSupplement } = useLibrary()
+  const { user } = useUser()
 
   const serverItemKeys = useMemo(() => (playlist.items ?? []).map((i) => `${i.libraryItemId}:${i.episodeId ?? ''}`).join(','), [playlist.items])
 
@@ -51,7 +54,7 @@ export function usePlaylistItems(playlist: Playlist) {
 
   const totalEntities = orderedItems.length
 
-  const totalDurationSeconds = useMemo(() => {
+    const totalDurationSeconds = useMemo(() => {
     let sum = 0
     for (const item of orderedItems) {
       sum += getPlaylistItemDuration(item)
@@ -59,15 +62,33 @@ export function usePlaylistItems(playlist: Playlist) {
     return sum
   }, [orderedItems])
 
+  const totalListenedSeconds = useMemo(() => {
+    let sum = 0
+    for (const item of orderedItems) {
+      const duration = getPlaylistItemDuration(item)
+      const progress = getMediaItemProgress(user.mediaProgress, item.libraryItemId, item.episodeId)
+      if (!progress) continue
+      sum += progress.isFinished ? duration : progress.currentTime || 0
+    }
+    return sum
+  }, [orderedItems, user.mediaProgress])
+
   const totalDurationLabel = totalDurationSeconds > 0 ? formatDuration(totalDurationSeconds, t, { showDays: true }) : null
+  const totalListenedLabel = totalListenedSeconds > 0 ? formatDuration(totalListenedSeconds, t, { showDays: true }) : null
+
+  const itemCountSupplementLabel = useMemo(() => {
+    if (!totalDurationLabel) return null
+    if (totalListenedLabel) return ` (${totalListenedLabel} / ${totalDurationLabel} total)`
+    return ` (${totalDurationLabel})`
+  }, [totalDurationLabel, totalListenedLabel])
 
   useEffect(() => {
     setItemCount(totalEntities)
-    setItemCountSupplement(totalDurationLabel ? ` (${totalDurationLabel})` : null)
+    setItemCountSupplement(itemCountSupplementLabel)
     return () => {
       setItemCount(null)
     }
-  }, [totalEntities, totalDurationLabel, setItemCount, setItemCountSupplement])
+  }, [totalEntities, itemCountSupplementLabel, setItemCount, setItemCountSupplement])
 
   return {
     orderedItems,

--- a/src/hooks/usePlaylistItems.ts
+++ b/src/hooks/usePlaylistItems.ts
@@ -4,9 +4,8 @@ import { useLibrary } from '@/contexts/LibraryContext'
 import { useUser } from '@/contexts/UserContext'
 import { useLibraryItemUpdated } from '@/hooks/useLibraryItemUpdated'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { formatDuration } from '@/lib/formatDuration'
 import { applyLibraryItemUpdateToPlaylistItems } from '@/lib/libraryItemUpdatedUtils'
-import { getMediaItemProgress } from '@/lib/mediaProgress'
+import { getDurationSupplementLabel, getMediaItemProgress } from '@/lib/mediaProgress'
 import { getPlaylistItemDuration, matchesPlaylistItem } from '@/lib/playlistItems'
 import type { Playlist, PlaylistItem } from '@/types/api'
 import { useRouter } from 'next/navigation'
@@ -54,7 +53,7 @@ export function usePlaylistItems(playlist: Playlist) {
 
   const totalEntities = orderedItems.length
 
-    const totalDurationSeconds = useMemo(() => {
+  const totalDurationSeconds = useMemo(() => {
     let sum = 0
     for (const item of orderedItems) {
       sum += getPlaylistItemDuration(item)
@@ -73,14 +72,10 @@ export function usePlaylistItems(playlist: Playlist) {
     return sum
   }, [orderedItems, user.mediaProgress])
 
-  const totalDurationLabel = totalDurationSeconds > 0 ? formatDuration(totalDurationSeconds, t, { showDays: true }) : null
-  const totalListenedLabel = totalListenedSeconds > 0 ? formatDuration(totalListenedSeconds, t, { showDays: true }) : null
-
-  const itemCountSupplementLabel = useMemo(() => {
-    if (!totalDurationLabel) return null
-    if (totalListenedLabel) return ` (${totalListenedLabel} / ${totalDurationLabel} total)`
-    return ` (${totalDurationLabel})`
-  }, [totalDurationLabel, totalListenedLabel])
+  const itemCountSupplementLabel = useMemo(
+    () => getDurationSupplementLabel(totalDurationSeconds, totalListenedSeconds, t),
+    [totalDurationSeconds, totalListenedSeconds, t]
+  )
 
   useEffect(() => {
     setItemCount(totalEntities)

--- a/src/lib/mediaProgress.ts
+++ b/src/lib/mediaProgress.ts
@@ -1,4 +1,6 @@
 import type { MediaProgress } from '@/types/api'
+import { formatDuration } from '@/lib/formatDuration'
+import type { TypeSafeTranslations } from '@/types/translations'
 
 export function buildMediaItemProgressMap(mediaProgress: MediaProgress[]): Map<string, MediaProgress> {
   const map = new Map<string, MediaProgress>()
@@ -64,6 +66,15 @@ export function buildPodcastEpisodeProgressMap(podcastLibraryItemId: string, med
     map.set(key, p)
   }
   return map
+}
+
+export function getDurationSupplementLabel(totalDurationSeconds: number, totalListenedSeconds: number, t: TypeSafeTranslations): string | null {
+  const totalDurationLabel = totalDurationSeconds > 0 ? formatDuration(totalDurationSeconds, t, { showDays: true }) : null
+  const totalListenedLabel = totalListenedSeconds > 0 ? formatDuration(totalListenedSeconds, t, { showDays: true }) : null
+
+  if (!totalDurationLabel) return null
+  if (totalListenedLabel) return t('LabelDurationProgressSupplement', { listened: totalListenedLabel, total: totalDurationLabel })
+  return t('LabelDurationTotalSupplement', { total: totalDurationLabel })
 }
 
 export interface ProgressComputationOptions {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -411,6 +411,8 @@
   "LabelDurationComparisonLonger": "({0} longer)",
   "LabelDurationComparisonShorter": "({0} shorter)",
   "LabelDurationFound": "Duration found:",
+  "LabelDurationProgressSupplement": " ({listened} / {total})",
+  "LabelDurationTotalSupplement": " ({total})",
   "LabelDurationWithValue": "Duration: {0}",
   "LabelEbook": "Ebook",
   "LabelEbooks": "Ebooks",


### PR DESCRIPTION
Adds total listened time alongside the existing total duration shown on collection and playlist detail pages, addressing part of #189.

Both useCollectionBooks.ts and usePlaylistItems.ts already computed total duration client-side from data already loaded on the page. This adds a parallel calculation for listened time, using user.mediaProgress (already loaded app-wide) — summing each item's full duration if finished, or currentTime if still in progress.

No backend changes needed — both pages already load their full book/item list in one call, so this is purely a frontend calculation.

Tested locally:

Verified duration-only display still works correctly when nothing has been listened to.
Verified listened time updates correctly after playing a test book partway through, on both a collection and a playlist.

Collections Listened Time:

<img width="1902" height="961" alt="CollectionMins" src="https://github.com/user-attachments/assets/2ccb33e8-af87-4b2e-b219-32d008e95c6f" />

Playlist Listened Time:

<img width="1897" height="950" alt="PlaylistMins" src="https://github.com/user-attachments/assets/9e1001c2-8817-4788-877b-1cdcf7f017b8" />

AudioBook Used for testing :

<img width="1886" height="957" alt="testbook3" src="https://github.com/user-attachments/assets/ee1d488e-dc12-4908-955b-46836a4dfde8" />
