### PR TITLE
Add total duration and listened time to series page toolbar

### DIFF
--- a/src/app/(main)/library/[library]/(book)/series/[series]/SeriesClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/series/[series]/SeriesClient.tsx
@@ -10,6 +10,7 @@ import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { filterEncode } from '@/lib/filterUtils'
+import { formatDuration } from '@/lib/formatDuration'
 import { computeIsSeriesFinished } from '@/lib/mediaProgress'
 import { RssFeed, Series } from '@/types/api'
 import { useRouter } from 'next/navigation'
@@ -23,7 +24,7 @@ export default function SeriesClient({ series: seriesProp }: SeriesClientProps) 
   const router = useRouter()
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
-  const { library, collapseBookSeries, showSubtitles, updateSetting, setDetailToolbarTitle, setContextMenuItems, setContextMenuActionHandler } = useLibrary()
+  const { library, collapseBookSeries, showSubtitles, updateSetting, setDetailToolbarTitle, setItemCountSupplement, itemCount, setContextMenuItems, setContextMenuActionHandler } = useLibrary()
   const { user, userIsAdminOrUp } = useUser()
 
   const seriesBooksQuery = useMemo(() => {
@@ -49,7 +50,7 @@ export default function SeriesClient({ series: seriesProp }: SeriesClientProps) 
 
   const seriesLibraryItemIds = useMemo(() => series.progress?.libraryItemIds ?? [], [series.progress?.libraryItemIds])
   const isSeriesFinished = useMemo(() => computeIsSeriesFinished(user.mediaProgress, seriesLibraryItemIds), [seriesLibraryItemIds, user.mediaProgress])
-
+  
   const [rssFeed, setRssFeed] = useState<RssFeed | null>(series.rssFeed ?? null)
   const [rssFeedModalOpen, setRssFeedModalOpen] = useState(false)
 
@@ -82,6 +83,22 @@ export default function SeriesClient({ series: seriesProp }: SeriesClientProps) 
       setContextMenuItems([])
     }
   }, [series.name, setContextMenuItems, setDetailToolbarTitle])
+
+  const totalDurationLabel = series.totalDuration && series.totalDuration > 0 ? formatDuration(series.totalDuration, t, { showDays: true }) : null
+  const totalListenedLabel = series.progress?.totalListened && series.progress.totalListened > 0 ? formatDuration(series.progress.totalListened, t, { showDays: true }) : null
+
+  const itemCountSupplementLabel = useMemo(() => {
+    if (!totalDurationLabel) return null
+    if (totalListenedLabel) return ` (${totalListenedLabel} / ${totalDurationLabel} total)`
+    return ` (${totalDurationLabel})`
+  }, [totalDurationLabel, totalListenedLabel])
+   
+  useEffect(() => {
+    setItemCountSupplement(itemCountSupplementLabel)
+    return () => {
+      setItemCountSupplement(null)
+    }
+  }, [itemCountSupplementLabel, itemCount, setItemCountSupplement])
 
   const openRssModal = useCallback(() => {
     setRssFeedModalOpen(true)

--- a/src/app/(main)/library/[library]/Toolbar.tsx
+++ b/src/app/(main)/library/[library]/Toolbar.tsx
@@ -3,8 +3,8 @@
 import ContextMenuDropdown from '@/components/ui/ContextMenuDropdown'
 import { useBookshelfSelection } from '@/contexts/BookshelfSelectionContext'
 import { useLibrary } from '@/contexts/LibraryContext'
-import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { isLibraryIssuesPage } from '@/hooks/useLibraryRouteGuard'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { usePathname, useSearchParams } from 'next/navigation'
 
 // Pages that should show item count and toolbar extras
@@ -104,6 +104,7 @@ export default function Toolbar() {
               <p className="text-foreground truncate text-base" title={detailToolbarTitle ?? ''}>
                 <span>{detailToolbarTitle}</span>
                 <span className="text-foreground-muted"> {itemCount ? `(${itemCount})` : ''}</span>
+                {itemCountSupplement ? <span className="text-foreground-muted">{itemCountSupplement}</span> : null}
               </p>
             </div>
             <div

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -358,6 +358,7 @@ export interface SeriesProgress {
   libraryItemIds: string[]
   libraryItemIdsFinished: string[]
   isFinished: boolean
+  totalListened?: number
 }
 
 export interface Series {
@@ -383,6 +384,8 @@ export interface Series {
   progress?: SeriesProgress
   /** library items (author page endpoint only) */
   items?: LibraryItem[]
+  /** total duration in seconds of all books in the series */
+  totalDuration?: number
 }
 
 /**


### PR DESCRIPTION
Extends the pattern from #238  to the series detail page. Adds total duration and listened time next to the item count in the series toolbar (e.g. "Demo Series (3) (1m / 3m total)").

Backend: adds `totalDuration` and `progress.totalListened` to the existing `GET /libraries/:id/series/:seriesId` response in the paired `audiobookshelf` PR (advplyr/audiobookshelf#5502) — computed in-memory from the library items already fetched for that endpoint, so no new queries or network calls.

Frontend: reads the new fields in `SeriesClient.tsx` and renders them via the existing `itemCountSupplement` toolbar slot (same mechanism used for collections/playlists). Also fixes `Toolbar.tsx`, which was reading `itemCountSupplement` from context but never rendering it in the series-detail branch.

Tested locally against a Demo Series with 3 books, one with real listened progress — confirmed correct duration/listened math and that the toolbar updates live.

Part of #189.

SeriesPage:

<img width="1900" height="961" alt="SeriesPage" src="https://github.com/user-attachments/assets/668ec6ea-db22-4c78-aa6b-fb8de40f1d89" />
