### PR TITLE
Serve the Next client from a configurable base path without a rebuild

### DIFF
--- a/cypress/tests/lib/basePath.cy.ts
+++ b/cypress/tests/lib/basePath.cy.ts
@@ -1,4 +1,4 @@
-import { BASE_PATH_ATTRIBUTE, BASE_PATH_PLACEHOLDER, getClientBasePath, normalizeBasePath, replaceBasePathPlaceholder, withBasePath } from '@/lib/basePath'
+import { BASE_PATH_ATTRIBUTE, BASE_PATH_PLACEHOLDER, getBasePath, normalizeBasePath, replaceBasePathPlaceholder, withBasePath } from '@/lib/basePath'
 
 /** The browser reads the base path off the root element the server layout renders. */
 function serveFrom(basePath: string | null) {
@@ -29,17 +29,17 @@ describe('normalizeBasePath', () => {
   })
 })
 
-describe('getClientBasePath', () => {
+describe('getBasePath', () => {
   afterEach(() => serveFrom(null))
 
   it('is empty when the root element carries no base path', () => {
     serveFrom(null)
-    expect(getClientBasePath()).to.equal('')
+    expect(getBasePath()).to.equal('')
   })
 
-  it('normalizes whatever the layout rendered', () => {
-    serveFrom('/audiobookshelf/')
-    expect(getClientBasePath()).to.equal('/audiobookshelf')
+  it('returns the attribute the layout rendered', () => {
+    serveFrom('/audiobookshelf')
+    expect(getBasePath()).to.equal('/audiobookshelf')
   })
 })
 

--- a/cypress/tests/lib/basePath.cy.ts
+++ b/cypress/tests/lib/basePath.cy.ts
@@ -1,0 +1,126 @@
+import { BASE_PATH_ATTRIBUTE, BASE_PATH_PLACEHOLDER, getClientBasePath, normalizeBasePath, replaceBasePathPlaceholder, withBasePath } from '@/lib/basePath'
+
+/** The browser reads the base path off the root element the server layout renders. */
+function serveFrom(basePath: string | null) {
+  if (basePath === null) {
+    document.documentElement.removeAttribute(BASE_PATH_ATTRIBUTE)
+  } else {
+    document.documentElement.setAttribute(BASE_PATH_ATTRIBUTE, basePath)
+  }
+}
+
+describe('normalizeBasePath', () => {
+  it('treats empty, whitespace and "/" as a root deploy', () => {
+    expect(normalizeBasePath('')).to.equal('')
+    expect(normalizeBasePath('   ')).to.equal('')
+    expect(normalizeBasePath('/')).to.equal('')
+    expect(normalizeBasePath(null)).to.equal('')
+    expect(normalizeBasePath(undefined)).to.equal('')
+  })
+
+  it('adds the leading slash and drops the trailing one', () => {
+    expect(normalizeBasePath('audiobookshelf')).to.equal('/audiobookshelf')
+    expect(normalizeBasePath('/audiobookshelf/')).to.equal('/audiobookshelf')
+    expect(normalizeBasePath('  /audiobookshelf  ')).to.equal('/audiobookshelf')
+  })
+
+  it('keeps nested paths intact', () => {
+    expect(normalizeBasePath('/media/abs/')).to.equal('/media/abs')
+  })
+})
+
+describe('getClientBasePath', () => {
+  afterEach(() => serveFrom(null))
+
+  it('is empty when the root element carries no base path', () => {
+    serveFrom(null)
+    expect(getClientBasePath()).to.equal('')
+  })
+
+  it('normalizes whatever the layout rendered', () => {
+    serveFrom('/audiobookshelf/')
+    expect(getClientBasePath()).to.equal('/audiobookshelf')
+  })
+})
+
+describe('withBasePath', () => {
+  afterEach(() => serveFrom(null))
+
+  it('returns root-relative urls unchanged on a root deploy', () => {
+    serveFrom('')
+    expect(withBasePath('/api/items/123/cover')).to.equal('/api/items/123/cover')
+    expect(withBasePath('/login')).to.equal('/login')
+  })
+
+  it('prefixes root-relative urls on a subfolder deploy', () => {
+    serveFrom('/abs')
+    expect(withBasePath('/api/items/123/cover')).to.equal('/abs/api/items/123/cover')
+    expect(withBasePath('/socket.io')).to.equal('/abs/socket.io')
+    expect(withBasePath('/')).to.equal('/abs/')
+  })
+
+  it('keeps the query string and hash attached to the prefixed path', () => {
+    serveFrom('/abs')
+    expect(withBasePath('/library/1/items?filter=genres.abc#top')).to.equal('/abs/library/1/items?filter=genres.abc#top')
+  })
+
+  it('still prefixes a path that merely starts with the same characters', () => {
+    serveFrom('/abs')
+    expect(withBasePath('/absolute/path')).to.equal('/abs/absolute/path')
+  })
+
+  it('leaves absolute and protocol-relative urls alone', () => {
+    serveFrom('/abs')
+    expect(withBasePath('https://example.com/feed')).to.equal('https://example.com/feed')
+    expect(withBasePath('//cdn.example.com/img.png')).to.equal('//cdn.example.com/img.png')
+    expect(withBasePath('blob:https://example.com/1234')).to.equal('blob:https://example.com/1234')
+  })
+})
+
+/**
+ * These strings mirror the three shapes the placeholder takes in a production build: a plain
+ * literal in client chunks, a regex-escaped path in route matchers, and that same regex escaped
+ * again inside a JSON manifest.
+ */
+const PLAIN = `assetPrefix:"${BASE_PATH_PLACEHOLDER}"`
+const REGEX_ESCAPED = `/^\\${BASE_PATH_PLACEHOLDER}/library$/`
+const JSON_ESCAPED = `{"matcher":"^\\\\${BASE_PATH_PLACEHOLDER}/library$"}`
+
+describe('replaceBasePathPlaceholder', () => {
+  it('substitutes a nested path into a plain literal', () => {
+    expect(replaceBasePathPlaceholder(PLAIN, '/abs')).to.equal('assetPrefix:"/abs"')
+    expect(replaceBasePathPlaceholder(PLAIN, '/media/abs')).to.equal('assetPrefix:"/media/abs"')
+  })
+
+  it('removes the placeholder entirely for a root deploy', () => {
+    expect(replaceBasePathPlaceholder(PLAIN, '')).to.equal('assetPrefix:""')
+  })
+
+  it('keeps regex escaping on each path segment', () => {
+    expect(replaceBasePathPlaceholder(REGEX_ESCAPED, '/abs')).to.equal('/^\\/abs/library$/')
+    expect(replaceBasePathPlaceholder(REGEX_ESCAPED, '/media/abs')).to.equal('/^\\/media\\/abs/library$/')
+  })
+
+  it('keeps JSON-escaped regex escaping on each path segment', () => {
+    expect(replaceBasePathPlaceholder(JSON_ESCAPED, '/abs')).to.equal('{"matcher":"^\\\\/abs/library$"}')
+    expect(replaceBasePathPlaceholder(JSON_ESCAPED, '/media/abs')).to.equal('{"matcher":"^\\\\/media\\\\/abs/library$"}')
+  })
+
+  it('drops the escaping along with the token on a root deploy, leaving a valid pattern', () => {
+    // A stray backslash here is what produced "Unmatched )" errors from Next's route matcher.
+    expect(replaceBasePathPlaceholder(REGEX_ESCAPED, '')).to.equal('/^/library$/')
+    expect(replaceBasePathPlaceholder(JSON_ESCAPED, '')).to.equal('{"matcher":"^/library$"}')
+    expect(JSON.parse(replaceBasePathPlaceholder(JSON_ESCAPED, '')).matcher).to.equal('^/library$')
+  })
+
+  it('replaces every occurrence in a chunk', () => {
+    const chunk = `${BASE_PATH_PLACEHOLDER}/a|${BASE_PATH_PLACEHOLDER}/b|${BASE_PATH_PLACEHOLDER}/c`
+    expect(replaceBasePathPlaceholder(chunk, '/abs')).to.equal('/abs/a|/abs/b|/abs/c')
+    expect(replaceBasePathPlaceholder(chunk, '')).to.equal('/a|/b|/c')
+  })
+
+  it('leaves content without the placeholder untouched', () => {
+    const untouched = 'const basePath = "/audiobookshelf"'
+    expect(replaceBasePathPlaceholder(untouched, '/abs')).to.equal(untouched)
+  })
+})

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,25 @@
 import type { NextConfig } from 'next'
 import createNextIntlPlugin from 'next-intl/plugin'
+import { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD, PHASE_PRODUCTION_SERVER } from 'next/constants.js'
+import { createRequire } from 'node:module'
 import path from 'path'
 import { fileURLToPath } from 'url'
+
+const projectDir = process.env.REACT_CLIENT_PATH ? path.resolve(process.env.REACT_CLIENT_PATH) : path.dirname(fileURLToPath(import.meta.url))
+
+// Next compiles this file to CJS and evaluates it as a virtual module. Relative `import` then
+// resolves from Audiobookshelf's cwd, not this project. `createRequire` from the client package
+// fixes that. Explicit `.ts` works because Next's config loader registers a require hook for the
+// duration of this evaluation.
+const requireFromProject = createRequire(path.join(projectDir, 'package.json'))
+const { BASE_PATH_PLACEHOLDER, getConfiguredBasePath } = requireFromProject('./src/lib/basePath.ts')
+const { rewriteBuildBasePath } = requireFromProject('./src/lib/rewriteBuildBasePath.ts')
+
+type BasePathPhase = typeof PHASE_PRODUCTION_BUILD | typeof PHASE_PRODUCTION_SERVER | typeof PHASE_DEVELOPMENT_SERVER
+
+function isBasePathPhase(phase: string): phase is BasePathPhase {
+  return phase === PHASE_PRODUCTION_BUILD || phase === PHASE_PRODUCTION_SERVER || phase === PHASE_DEVELOPMENT_SERVER
+}
 
 /** Set via audiobookshelf dev.js `AllowedDevOrigins` → index.js sets ALLOWED_DEV_ORIGINS. */
 function allowedDevOriginsFromEnv(): string[] {
@@ -18,7 +36,6 @@ function allowedDevOriginsFromEnv(): string[] {
  * workaround: temporarily chdir so the check passes.
  */
 function runWithProjectCwd<T>(fn: () => T): T {
-  const projectDir = process.env.REACT_CLIENT_PATH ? path.resolve(process.env.REACT_CLIENT_PATH) : path.dirname(fileURLToPath(import.meta.url))
   const originalCwd = process.cwd()
   const shouldChdir = path.resolve(originalCwd) !== path.resolve(projectDir)
 
@@ -37,6 +54,38 @@ function runWithProjectCwd<T>(fn: () => T): T {
 
 const withNextIntl = createNextIntlPlugin('./src/lib/i18n.ts')
 
+/**
+ * Pick the Next `basePath` for the current phase.
+ *
+ * - Build: use a placeholder token. Production chunks bake `basePath` in, so we cannot change it
+ *   later without rewriting those files.
+ * - Production server start: rewrite the placeholder in `.next` to the configured path, then return
+ *   that path. Must happen here — once Next has loaded a chunk, its baked-in path is fixed.
+ * - Dev: return the configured path directly (no placeholder, no rewrite).
+ */
+function basePathForPhase(phase: BasePathPhase): string {
+  switch (phase) {
+    case PHASE_PRODUCTION_BUILD:
+      return BASE_PATH_PLACEHOLDER
+    case PHASE_PRODUCTION_SERVER: {
+      const basePath = getConfiguredBasePath()
+      rewriteBuildBasePath(path.join(projectDir, '.next'), basePath)
+      return basePath
+    }
+    case PHASE_DEVELOPMENT_SERVER:
+      return getConfiguredBasePath()
+  }
+}
+
+/**
+ * Next does not add the base path to the `url` parameter it sends to the image optimizer, but our
+ * image sources are prefixed (they are also used by plain `img` tags), so allow both forms.
+ */
+function localImagePatterns(basePath: string) {
+  const pathnames = ['/api/**', '/images/**']
+  return pathnames.flatMap((pathname) => (basePath ? [{ pathname }, { pathname: `${basePath}${pathname}` }] : [{ pathname }]))
+}
+
 const nextConfig: NextConfig = {
   devIndicators: false,
   allowedDevOrigins: allowedDevOriginsFromEnv(),
@@ -45,9 +94,6 @@ const nextConfig: NextConfig = {
     serverActions: {
       bodySizeLimit: '10mb'
     }
-  },
-  images: {
-    localPatterns: [{ pathname: '/api/**' }, { pathname: '/images/**' }]
   },
   async headers() {
     return [
@@ -60,4 +106,10 @@ const nextConfig: NextConfig = {
   }
 }
 
-export default runWithProjectCwd(() => withNextIntl(nextConfig))
+const configForPhase = (phase: string) => {
+  // Next also passes phases we do not care about (export, test, …); treat them like development.
+  const basePath = isBasePathPhase(phase) ? basePathForPhase(phase) : getConfiguredBasePath()
+  return runWithProjectCwd(() => withNextIntl({ ...nextConfig, basePath, images: { localPatterns: localImagePatterns(basePath) } }))
+}
+
+export default configForPhase

--- a/src/app/(blank)/layout.tsx
+++ b/src/app/(blank)/layout.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { getTypeSafeTranslations } from '@/lib/getTypeSafeTranslations'
 import type { Metadata } from 'next'
 import Image from 'next/image'
@@ -19,7 +20,7 @@ export default function BlankLayout({
   return (
     <div className="page-bg-gradient h-full">
       <div className="absolute top-0 left-0 flex h-16 w-full items-center justify-start px-2 md:px-6">
-        <Image src="/images/icon.svg" alt="" width={40} height={40} className="me-2 h-8 w-8 min-w-8 sm:me-4 sm:h-10 sm:w-10 sm:min-w-10" />
+        <Image src={withBasePath('/images/icon.svg')} alt="" width={40} height={40} className="me-2 h-8 w-8 min-w-8 sm:me-4 sm:h-10 sm:w-10 sm:min-w-10" />
         <p className="hidden text-xl lg:block">audiobookshelf</p>
       </div>
       <div className="h-screen w-full overflow-x-hidden overflow-y-auto">{children}</div>

--- a/src/app/(blank)/login/LoginForm.tsx
+++ b/src/app/(blank)/login/LoginForm.tsx
@@ -3,6 +3,7 @@
 import Btn from '@/components/ui/Btn'
 import TextInput from '@/components/ui/TextInput'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { getUserDefaultUrlPath } from '@/lib/userPermissions'
 import { AuthFormData } from '@/types/api'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -63,7 +64,7 @@ export default function LoginForm({ authMethods, authFormData, serverUrl }: Logi
       setError('')
       setLoading(true)
       try {
-        const res = await fetch('/internal-api/login', {
+        const res = await fetch(withBasePath('/internal-api/login'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ username, password })

--- a/src/app/(blank)/login/ServerInitForm.tsx
+++ b/src/app/(blank)/login/ServerInitForm.tsx
@@ -5,6 +5,7 @@ import TextInput from '@/components/ui/TextInput'
 import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import LanguageDropdown from '@/components/widgets/LanguageDropdown'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { useLocale } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useState, useTransition } from 'react'
@@ -33,7 +34,7 @@ export default function ServerInitForm() {
       setLanguage(newLanguage)
       startLanguageTransition(async () => {
         try {
-          const res = await fetch('/internal-api/set-language', {
+          const res = await fetch(withBasePath('/internal-api/set-language'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ language: newLanguage, scope: 'server' })
@@ -63,7 +64,7 @@ export default function ServerInitForm() {
             password
           }
         }
-        const res = await fetch('/init', {
+        const res = await fetch(withBasePath('/init'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -75,7 +76,7 @@ export default function ServerInitForm() {
         }
         // Navigate to login with a one-time redirect to library settings after first root login.
         // reload() would keep query params like ?error=Token+refresh+failed from a stale-session redirect before init.
-        window.location.replace('/login?redirect=/settings/libraries')
+        window.location.replace(withBasePath('/login?redirect=/settings/libraries'))
       } catch {
         setError(t('ErrorNetwork'))
       }

--- a/src/app/(main)/AppBar.tsx
+++ b/src/app/(main)/AppBar.tsx
@@ -9,6 +9,7 @@ import { useAppNavigation } from '@/contexts/AppNavigationContext'
 import { useUser } from '@/contexts/UserContext'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { resolveEffectiveLibrary } from '@/lib/libraries'
 import { mergeClasses } from '@/lib/merge-classes'
 import { Library } from '@/types/api'
@@ -69,7 +70,7 @@ export default function AppBar({ libraries, currentLibraryId }: AppBarProps) {
 
   const logoContent = (
     <>
-      <Image src="/images/icon.svg" alt="" width={40} height={40} priority className="h-8 w-8 min-w-8 sm:h-10 sm:w-10 sm:min-w-10" />
+      <Image src={withBasePath('/images/icon.svg')} alt="" width={40} height={40} priority className="h-8 w-8 min-w-8 sm:h-10 sm:w-10 sm:min-w-10" />
       <span className="hidden text-xl hover:underline lg:block">audiobookshelf</span>
     </>
   )

--- a/src/app/(main)/SideRailMobileDrawer.tsx
+++ b/src/app/(main)/SideRailMobileDrawer.tsx
@@ -5,6 +5,7 @@ import LibraryIcon from '@/components/ui/LibraryIcon'
 import { useAppNavigation } from '@/contexts/AppNavigationContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { resolveEffectiveLibrary } from '@/lib/libraries'
 import { Library } from '@/types/api'
 import Image from 'next/image'
@@ -69,7 +70,7 @@ export default function SideRailMobileDrawer({ isOpen, onClose, libraries, curre
       >
         <div className="border-primary/30 shrink-0 border-b px-4 py-3">
           <div className="text-foreground flex items-center gap-2 p-1">
-            <Image src="/images/icon.svg" alt="" width={40} height={40} className="h-8 w-8 min-w-8" />
+            <Image src={withBasePath('/images/icon.svg')} alt="" width={40} height={40} className="h-8 w-8 min-w-8" />
             <span className="text-xl">audiobookshelf</span>
           </div>
         </div>

--- a/src/app/(main)/account/ThemeSelector.tsx
+++ b/src/app/(main)/account/ThemeSelector.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import ThemeDropdown from '@/components/widgets/ThemeDropdown'
+import { withBasePath } from '@/lib/basePath'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
@@ -18,7 +19,7 @@ export default function ThemeSelector({ value, label }: ThemeSelectorProps) {
 
     setIsLoading(true)
     try {
-      const res = await fetch('/internal-api/set-theme', {
+      const res = await fetch(withBasePath('/internal-api/set-theme'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/app/(main)/account/UserLanguageSelector.tsx
+++ b/src/app/(main)/account/UserLanguageSelector.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import LanguageDropdown from '@/components/widgets/LanguageDropdown'
+import { withBasePath } from '@/lib/basePath'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
@@ -18,7 +19,7 @@ export default function UserLanguageSelector({ value, label }: UserLanguageSelec
 
     setIsLoading(true)
     try {
-      const res = await fetch('/internal-api/set-language', {
+      const res = await fetch(withBasePath('/internal-api/set-language'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/app/(main)/components_catalog/alerts/page.tsx
+++ b/src/app/(main)/components_catalog/alerts/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { AlertExamples } from '../examples/AlertExamples'
 import { ToastNotificationExamples } from '../examples/ToastNotificationExamples'
 import { TooltipExamples } from '../examples/TooltipExamples'
@@ -8,7 +9,7 @@ export default function AlertComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Alert, Toast & Tooltip Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the alert, toast, and tooltip components available in the audiobookshelf client.</p>
-        <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
         </a>
       </div>

--- a/src/app/(main)/components_catalog/alerts/page.tsx
+++ b/src/app/(main)/components_catalog/alerts/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { AlertExamples } from '../examples/AlertExamples'
 import { ToastNotificationExamples } from '../examples/ToastNotificationExamples'
 import { TooltipExamples } from '../examples/TooltipExamples'
@@ -9,9 +9,9 @@ export default function AlertComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Alert, Toast & Tooltip Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the alert, toast, and tooltip components available in the audiobookshelf client.</p>
-        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+        <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
-        </a>
+        </Link>
       </div>
 
       {/* Table of Contents */}

--- a/src/app/(main)/components_catalog/buttons/page.tsx
+++ b/src/app/(main)/components_catalog/buttons/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { BtnExamples } from '../examples/BtnExamples'
 import { ContextMenuDropdownExamples } from '../examples/ContextMenuDropdownExamples'
 import { IconBtnExamples } from '../examples/IconBtnExamples'
@@ -10,7 +11,7 @@ export default function ButtonComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Button Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the button components available in the audiobookshelf client.</p>
-        <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
         </a>
       </div>

--- a/src/app/(main)/components_catalog/buttons/page.tsx
+++ b/src/app/(main)/components_catalog/buttons/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { BtnExamples } from '../examples/BtnExamples'
 import { ContextMenuDropdownExamples } from '../examples/ContextMenuDropdownExamples'
 import { IconBtnExamples } from '../examples/IconBtnExamples'
@@ -11,9 +11,9 @@ export default function ButtonComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Button Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the button components available in the audiobookshelf client.</p>
-        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+        <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
-        </a>
+        </Link>
       </div>
 
       {/* Table of Contents */}

--- a/src/app/(main)/components_catalog/checkboxes/page.tsx
+++ b/src/app/(main)/components_catalog/checkboxes/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { CheckboxExamples } from '../examples/CheckboxExamples'
 import { ToggleSwitchExamples } from '../examples/ToggleSwitchExamples'
 
@@ -8,9 +8,9 @@ export default function CheckboxComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Checkbox & Switch Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the checkbox and switch components available in the audiobookshelf client.</p>
-        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+        <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
-        </a>
+        </Link>
       </div>
 
       {/* Table of Contents */}

--- a/src/app/(main)/components_catalog/checkboxes/page.tsx
+++ b/src/app/(main)/components_catalog/checkboxes/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { CheckboxExamples } from '../examples/CheckboxExamples'
 import { ToggleSwitchExamples } from '../examples/ToggleSwitchExamples'
 
@@ -7,7 +8,7 @@ export default function CheckboxComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Checkbox & Switch Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the checkbox and switch components available in the audiobookshelf client.</p>
-        <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
         </a>
       </div>

--- a/src/app/(main)/components_catalog/examples/PreviewCoverExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/PreviewCoverExamples.tsx
@@ -2,7 +2,7 @@
 
 import PreviewCover from '@/components/covers/PreviewCover'
 import CoverPreviewModal from '@/components/modals/CoverPreviewModal'
-import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
+import { getLibraryItemCoverUrl, getPlaceholderCoverUrl } from '@/lib/coverUtils'
 import { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
 import { useCallback, useState } from 'react'
 import { Code, ComponentExamples, ComponentInfo, Example, ExamplesBlock } from '../ComponentExamples'
@@ -136,7 +136,7 @@ export function PreviewCoverExamples({ selectedBook, selectedPodcast }: PreviewC
 
         <Example title="Invalid Cover Error State">
           <div className="flex flex-col items-center gap-4">
-            <PreviewCover src="/images/book_placeholder.jpg" width={120} forceErrorState={true} />
+            <PreviewCover src={getPlaceholderCoverUrl()} width={120} forceErrorState={true} />
             <p className="text-xs text-gray-400">Shows error state when image fails to load</p>
           </div>
         </Example>

--- a/src/app/(main)/components_catalog/icons/page.tsx
+++ b/src/app/(main)/components_catalog/icons/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { InlineIndicatorExamples } from '../examples/InlineIndicatorExamples'
 import { LibraryIconExamples } from '../examples/LibraryIconExamples'
 import { LoadingExamples } from '../examples/LoadingExamples'
@@ -10,9 +10,9 @@ export default function IconComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Icon & Indicator Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the icon and indicator components available in the audiobookshelf client.</p>
-        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+        <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
-        </a>
+        </Link>
       </div>
 
       {/* Table of Contents */}

--- a/src/app/(main)/components_catalog/icons/page.tsx
+++ b/src/app/(main)/components_catalog/icons/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { InlineIndicatorExamples } from '../examples/InlineIndicatorExamples'
 import { LibraryIconExamples } from '../examples/LibraryIconExamples'
 import { LoadingExamples } from '../examples/LoadingExamples'
@@ -9,7 +10,7 @@ export default function IconComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Icon & Indicator Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the icon and indicator components available in the audiobookshelf client.</p>
-        <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
         </a>
       </div>

--- a/src/app/(main)/components_catalog/inputs/page.tsx
+++ b/src/app/(main)/components_catalog/inputs/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { CronExpressionBuilderExamples } from '../examples/CronExpressionBuilderExamples'
 import { DropdownExamples } from '../examples/DropdownExamples'
 import { FileInputExamples } from '../examples/FileInputExamples'
@@ -18,9 +18,9 @@ export default function InputComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Input & Selection Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the input, dropdown, and selection components available in the audiobookshelf client.</p>
-        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+        <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
-        </a>
+        </Link>
       </div>
 
       {/* Table of Contents */}

--- a/src/app/(main)/components_catalog/inputs/page.tsx
+++ b/src/app/(main)/components_catalog/inputs/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { CronExpressionBuilderExamples } from '../examples/CronExpressionBuilderExamples'
 import { DropdownExamples } from '../examples/DropdownExamples'
 import { FileInputExamples } from '../examples/FileInputExamples'
@@ -17,7 +18,7 @@ export default function InputComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Input & Selection Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the input, dropdown, and selection components available in the audiobookshelf client.</p>
-        <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
         </a>
       </div>

--- a/src/app/(main)/components_catalog/items/page.tsx
+++ b/src/app/(main)/components_catalog/items/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import Dropdown from '@/components/ui/Dropdown'
-import { withBasePath } from '@/lib/basePath'
 import { useComponentsCatalog } from '@/contexts/ComponentsCatalogContext'
 import { LibraryProvider } from '@/contexts/LibraryContext'
 import { FlatResultItem } from '@/hooks/useGlobalSearchTransformer'
 import { Author, BookLibraryItem, Collection, LibraryItem, Playlist, PodcastLibraryItem, Series } from '@/types/api'
 import { useCallback, useState } from 'react'
+import Link from 'next/link'
 import GlobalSearchInput from '../../GlobalSearchInput'
 import { BookDetailsEditExamples } from '../examples/BookDetailsEditExamples'
 import { ChaptersExamples } from '../examples/ChaptersExamples'
@@ -94,9 +94,9 @@ export default function ItemDetailsExamplesPage() {
             This page showcases the item details editing components and cover management components for library items. Use the search box below to find and
             select books or podcasts to see the relevant components in action with real data.
           </p>
-          <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+          <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
             ← Back to Components Catalog
-          </a>
+          </Link>
         </div>
 
         {/* Search Section */}

--- a/src/app/(main)/components_catalog/items/page.tsx
+++ b/src/app/(main)/components_catalog/items/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Dropdown from '@/components/ui/Dropdown'
+import { withBasePath } from '@/lib/basePath'
 import { useComponentsCatalog } from '@/contexts/ComponentsCatalogContext'
 import { LibraryProvider } from '@/contexts/LibraryContext'
 import { FlatResultItem } from '@/hooks/useGlobalSearchTransformer'
@@ -93,7 +94,7 @@ export default function ItemDetailsExamplesPage() {
             This page showcases the item details editing components and cover management components for library items. Use the search box below to find and
             select books or podcasts to see the relevant components in action with real data.
           </p>
-          <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+          <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
             ← Back to Components Catalog
           </a>
         </div>

--- a/src/app/(main)/components_catalog/modals/page.tsx
+++ b/src/app/(main)/components_catalog/modals/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { AdvancedModalExamples } from '../examples/AdvancedModalExamples'
 import { ConfirmDialogExamples } from '../examples/ConfirmDialogExamples'
 import { ModalExamples } from '../examples/ModalExamples'
@@ -8,7 +9,7 @@ export default function ModalComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Modal Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the modal components available in the audiobookshelf client.</p>
-        <a href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
+        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
         </a>
       </div>

--- a/src/app/(main)/components_catalog/modals/page.tsx
+++ b/src/app/(main)/components_catalog/modals/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { AdvancedModalExamples } from '../examples/AdvancedModalExamples'
 import { ConfirmDialogExamples } from '../examples/ConfirmDialogExamples'
 import { ModalExamples } from '../examples/ModalExamples'
@@ -9,9 +9,9 @@ export default function ModalComponentsPage() {
       <div className="mb-8">
         <h1 className="mb-4 text-3xl font-bold">Modal Components</h1>
         <p className="mb-6 text-gray-300">This page showcases all the modal components available in the audiobookshelf client.</p>
-        <a href={withBasePath('/components_catalog')} className="text-blue-400 transition-colors hover:text-blue-300">
+        <Link href="/components_catalog" className="text-blue-400 transition-colors hover:text-blue-300">
           ← Back to Components Catalog
-        </a>
+        </Link>
       </div>
 
       {/* Table of Contents */}

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { CoverSizeWidgetExamples } from './examples/CoverSizeWidgetExamples'
 import { MetadataEditTableExamples } from './examples/MetadataEditTableExamples'
 import { SideBySideControlsExamples } from './examples/SideBySideControlsExamples'
@@ -16,7 +17,10 @@ export default function ComponentsCatalogPage() {
         <div className="rounded-lg bg-gray-800 p-6">
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/items" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/items')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Item Components
               </a>
@@ -25,7 +29,10 @@ export default function ComponentsCatalogPage() {
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/buttons" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/buttons')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Button Components
               </a>
@@ -34,7 +41,10 @@ export default function ComponentsCatalogPage() {
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/icons" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/icons')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Icon & Indicator Components
               </a>
@@ -43,7 +53,10 @@ export default function ComponentsCatalogPage() {
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/inputs" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/inputs')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Input & Selection Components
               </a>
@@ -52,7 +65,10 @@ export default function ComponentsCatalogPage() {
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/modals" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/modals')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Modal Components
               </a>
@@ -61,7 +77,10 @@ export default function ComponentsCatalogPage() {
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/checkboxes" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/checkboxes')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Checkbox & Switch Components
               </a>
@@ -70,7 +89,10 @@ export default function ComponentsCatalogPage() {
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a href="/components_catalog/alerts" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
+              <a
+                href={withBasePath('/components_catalog/alerts')}
+                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
+              >
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Alert, Toast & Tooltip Components
               </a>

--- a/src/app/(main)/components_catalog/page.tsx
+++ b/src/app/(main)/components_catalog/page.tsx
@@ -1,4 +1,4 @@
-import { withBasePath } from '@/lib/basePath'
+import Link from 'next/link'
 import { CoverSizeWidgetExamples } from './examples/CoverSizeWidgetExamples'
 import { MetadataEditTableExamples } from './examples/MetadataEditTableExamples'
 import { SideBySideControlsExamples } from './examples/SideBySideControlsExamples'
@@ -17,85 +17,64 @@ export default function ComponentsCatalogPage() {
         <div className="rounded-lg bg-gray-800 p-6">
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/items')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/items" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Item Components
-              </a>
+              </Link>
             </div>
           </div>
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/buttons')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/buttons" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Button Components
-              </a>
+              </Link>
             </div>
           </div>
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/icons')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/icons" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Icon & Indicator Components
-              </a>
+              </Link>
             </div>
           </div>
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/inputs')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/inputs" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Input & Selection Components
-              </a>
+              </Link>
             </div>
           </div>
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/modals')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/modals" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Modal Components
-              </a>
+              </Link>
             </div>
           </div>
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/checkboxes')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/checkboxes" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Checkbox & Switch Components
-              </a>
+              </Link>
             </div>
           </div>
 
           <div className="mb-6 border-gray-700">
             <div className="rounded-lg border border-blue-500/30 bg-blue-900/20 p-4">
-              <a
-                href={withBasePath('/components_catalog/alerts')}
-                className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300"
-              >
+              <Link href="/components_catalog/alerts" className="flex items-center gap-2 font-medium text-blue-400 transition-colors hover:text-blue-300">
                 <span className="material-symbols text-xl">arrow_forward</span>
                 Alert, Toast & Tooltip Components
-              </a>
+              </Link>
             </div>
           </div>
 

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemActionButtons.tsx
@@ -16,6 +16,7 @@ import { useMediaCardActions } from '@/components/widgets/media-card/useMediaCar
 import { useMediaContext } from '@/contexts/MediaContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { getEbookFormat } from '@/lib/ereader/ereaderEbook'
 import { PlayerState, type BookLibraryItem, type PodcastLibraryItem, type RssFeed } from '@/types/api'
 import { useCallback, useMemo } from 'react'
@@ -108,7 +109,7 @@ export default function LibraryItemActionButtons({
     isQueued,
     initialShare: libraryItem.mediaItemShare ?? null,
     onDeleteSuccess: () => {
-      window.location.href = `/library/${libraryItem.libraryId}`
+      window.location.href = withBasePath(`/library/${libraryItem.libraryId}`)
     },
     onOpenMatch,
     playerControls

--- a/src/app/(main)/settings/GeneralSettingsClient.tsx
+++ b/src/app/(main)/settings/GeneralSettingsClient.tsx
@@ -7,6 +7,7 @@ import LanguageDropdown from '@/components/widgets/LanguageDropdown'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { formatJsDate } from '@/lib/datefns'
 import { BookshelfView, ServerSettings } from '@/types/api'
 import { useRouter } from 'next/navigation'
@@ -115,7 +116,7 @@ export default function GeneralSettingsClient() {
       mergeServerSettings(response?.serverSettings)
 
       // Set the language cookie
-      await fetch('/internal-api/set-language', {
+      await fetch(withBasePath('/internal-api/set-language'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/src/app/(main)/settings/authentication/page.tsx
+++ b/src/app/(main)/settings/authentication/page.tsx
@@ -1,4 +1,5 @@
 import { getAuthSettings, getData } from '@/lib/api'
+import { getBasePath } from '@/lib/basePath'
 import { redirect } from 'next/navigation'
 import AuthenticationClient from './AuthenticationClient'
 
@@ -11,8 +12,5 @@ export default async function AuthenticationSettingsPage() {
     redirect('/settings/general')
   }
 
-  // TODO: Find a better way to handle subfolders with nextjs
-  const routerBasePath = process.env.ROUTER_BASE_PATH ?? ''
-
-  return <AuthenticationClient initialSettings={authSettings} routerBasePath={routerBasePath} />
+  return <AuthenticationClient initialSettings={authSettings} routerBasePath={getBasePath()} />
 }

--- a/src/app/(main)/settings/backups/BackupsClient.tsx
+++ b/src/app/(main)/settings/backups/BackupsClient.tsx
@@ -14,6 +14,7 @@ import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { ApiError } from '@/lib/apiErrors'
 import { uploadBackupArchive } from '@/lib/backupUpload'
+import { withBasePath } from '@/lib/basePath'
 import { formatJsDatetime } from '@/lib/datefns'
 import { downloadBackup } from '@/lib/download'
 import { bytesPretty } from '@/lib/string'
@@ -191,7 +192,7 @@ export default function BackupsClient({ backupResponse, appliedBackupToast = fal
       } catch {
         /* ignore */
       }
-      window.location.replace(`${window.location.origin}/settings/backups?backup=1`)
+      window.location.replace(`${window.location.origin}${withBasePath('/settings/backups?backup=1')}`)
     } catch (error) {
       console.error('Failed to apply backup', error)
       const message = error instanceof ApiError && error.message ? error.message : t('ToastBackupRestoreFailed')

--- a/src/app/(main)/settings/rss-feeds/RssFeedsTable.tsx
+++ b/src/app/(main)/settings/rss-feeds/RssFeedsTable.tsx
@@ -9,6 +9,7 @@ import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { formatJsDate, formatJsDatetime } from '@/lib/datefns'
 import { RssFeed } from '@/types/api'
 import { useCallback, useMemo, useRef, useState } from 'react'
@@ -102,12 +103,12 @@ export default function RssFeedsTable({ rssFeeds: initialFeeds }: RssFeedsTableP
           {rssFeed.coverPath ? (
             <>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={`/feed/${rssFeed.slug}/cover`} alt={t('LabelCover')} className="h-auto w-full" />
+              <img src={withBasePath(`/feed/${rssFeed.slug}/cover`)} alt={t('LabelCover')} className="h-auto w-full" />
             </>
           ) : (
             <>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/images/Logo.png" alt={t('LabelLogo')} className="h-auto w-full" />
+              <img src={withBasePath('/images/Logo.png')} alt={t('LabelLogo')} className="h-auto w-full" />
             </>
           )}
         </>

--- a/src/app/(public)/share/[slug]/SharePlayer.tsx
+++ b/src/app/(public)/share/[slug]/SharePlayer.tsx
@@ -5,7 +5,8 @@ import Tooltip from '@/components/ui/Tooltip'
 import LoadingSpinner from '@/components/widgets/LoadingSpinner'
 import { usePlayerSettings } from '@/hooks/usePlayerSettings'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
-import { getCoverAspectRatio } from '@/lib/coverUtils'
+import { withBasePath } from '@/lib/basePath'
+import { getCoverAspectRatio, getPlaceholderCoverUrl } from '@/lib/coverUtils'
 import { secondsToTimestamp } from '@/lib/datefns'
 import { AudioTrack } from '@/lib/player/AudioTrack'
 import { LocalAudioPlayer } from '@/lib/player/LocalAudioPlayer'
@@ -56,7 +57,7 @@ export default function SharePlayer({ slug, startTime: startTimeParam }: SharePl
 
     async function fetchShareData() {
       try {
-        let endpoint = `/public/share/${slug}`
+        let endpoint = withBasePath(`/public/share/${slug}`)
         if (startTimeParam != null) {
           endpoint += `?t=${startTimeParam}`
         }
@@ -103,9 +104,9 @@ export default function SharePlayer({ slug, startTime: startTimeParam }: SharePl
   const hasLoaded = playerState !== PlayerState.IDLE && playerState !== PlayerState.LOADING
   const coverAspectRatio = getCoverAspectRatio(playbackSession?.coverAspectRatio)
 
-  const coverUrl = playbackSession?.coverPath ? `/public/share/${slug}/cover` : '/images/book_placeholder.jpg'
+  const coverUrl = playbackSession?.coverPath ? withBasePath(`/public/share/${slug}/cover`) : getPlaceholderCoverUrl()
 
-  const downloadUrl = `/public/share/${slug}/download`
+  const downloadUrl = withBasePath(`/public/share/${slug}/download`)
 
   const audioTracks: AudioTrack[] = useMemo(() => {
     if (!playbackSession?.audioTracks) return []
@@ -142,7 +143,7 @@ export default function SharePlayer({ slug, startTime: startTimeParam }: SharePl
 
   const sendProgressSync = useCallback(
     (time: number) => {
-      fetch(`/public/share/${slug}/progress`, {
+      fetch(withBasePath(`/public/share/${slug}/progress`), {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ currentTime: time }),

--- a/src/app/internal-api/refresh/route.ts
+++ b/src/app/internal-api/refresh/route.ts
@@ -1,4 +1,5 @@
 import { getClientBaseUrlFromRequest, redirectToLogin, refreshSessionWithToken, setTokenCookies } from '@/lib/api'
+import { withBasePath } from '@/lib/basePath'
 import { getUserDefaultUrlPath } from '@/lib/userPermissions'
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
@@ -57,7 +58,8 @@ async function handleRefresh(request: Request) {
 
     // Get redirect URL from query parameters or default to user default path
     const redirectUrlPath = url.searchParams.get('redirect') || getUserDefaultUrlPath(session.userDefaultLibraryId)
-    const redirectUrl = new URL(redirectUrlPath, clientBaseUrl)
+    // A root-relative path would drop the base path from clientBaseUrl, so add it explicitly.
+    const redirectUrl = new URL(withBasePath(redirectUrlPath), clientBaseUrl)
 
     const response = NextResponse.redirect(redirectUrl)
     setTokenCookies(response, newAccessToken, newRefreshToken)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,10 +7,10 @@ import ServiceWorkerRegister from '../components/ServiceWorkerRegister'
 import GlobalToastContainer from '../components/widgets/GlobalToastContainer'
 import { CardSizeProvider } from '../contexts/CardSizeContext'
 import { ToastProvider } from '../contexts/ToastContext'
-import { getNextBasePath } from '../lib/nextBasePath'
+import { BASE_PATH_ATTRIBUTE, getBasePath } from '../lib/basePath'
 import { getTheme } from '../lib/theme'
 
-const basePath = getNextBasePath()
+const basePath = getBasePath()
 
 export const metadata: Metadata = {
   title: 'audiobookshelf', // i18n-ignore
@@ -41,12 +41,15 @@ export const viewport: Viewport = {
   themeColor: '#232323'
 }
 
+// Stylesheets cannot know the base path, so the one asset URL in CSS is overridden here.
+const rootStyle = { '--bookshelf-texture-img': `url(${basePath}/images/wood_default.jpg)` } as React.CSSProperties
+
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const locale = await getLocale()
   const theme = await getTheme()
 
   return (
-    <html lang={locale} className={`theme-${theme}`}>
+    <html lang={locale} className={`theme-${theme}`} style={rootStyle} {...{ [BASE_PATH_ATTRIBUTE]: basePath }}>
       <head>
         <link rel="manifest" href={`${basePath}/manifest.webmanifest`} />
       </head>

--- a/src/app/manifest.webmanifest/route.ts
+++ b/src/app/manifest.webmanifest/route.ts
@@ -1,4 +1,4 @@
-import { getNextBasePath } from '@/lib/nextBasePath'
+import { getBasePath } from '@/lib/basePath'
 import { buildManifest } from '@/lib/pwa/buildManifest'
 import { NextResponse } from 'next/server'
 
@@ -15,7 +15,7 @@ import { NextResponse } from 'next/server'
 export const dynamic = 'force-dynamic'
 
 export function GET() {
-  const base = getNextBasePath()
+  const base = getBasePath()
 
   return NextResponse.json(buildManifest(base), {
     headers: { 'Content-Type': 'application/manifest+json' }

--- a/src/components/covers/AuthorImage.tsx
+++ b/src/components/covers/AuthorImage.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { withBasePath } from '@/lib/basePath'
 import { mergeClasses } from '@/lib/merge-classes'
 import type { Author } from '@/types/api'
 import { useEffect, useState } from 'react'
@@ -16,7 +17,7 @@ export default function AuthorImage({ author, className }: AuthorImageProps) {
   const [imageError, setImageError] = useState(false)
   const [showCoverBg, setShowCoverBg] = useState(false)
 
-  const imageSrc = author.imagePath ? `/api/authors/${author.id}/image?ts=${author.updatedAt || Date.now()}` : null
+  const imageSrc = author.imagePath ? withBasePath(`/api/authors/${author.id}/image?ts=${author.updatedAt || Date.now()}`) : null
 
   // Reset state when author or image source changes
   useEffect(() => {

--- a/src/components/covers/PreviewCover.tsx
+++ b/src/components/covers/PreviewCover.tsx
@@ -2,6 +2,7 @@
 
 import { useBookCoverAspectRatio } from '@/contexts/LibraryContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { mergeClasses } from '@/lib/merge-classes'
 import Image from 'next/image'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -169,7 +170,9 @@ export default function PreviewCover({
       {imageFailed && (
         <div className="absolute start-0 end-0 top-0 bottom-0 h-full w-full bg-red-100" style={{ padding: `${placeholderCoverPadding}rem` }}>
           <div className="border-error flex h-full w-full flex-col items-center justify-center border-2">
-            {width > 100 && <Image src="/images/Logo.png" alt={t('LabelLogo')} width={40 * sizeMultiplier} height={40 * sizeMultiplier} className="mb-2" />}
+            {width > 100 && (
+              <Image src={withBasePath('/images/Logo.png')} alt={t('LabelLogo')} width={40 * sizeMultiplier} height={40 * sizeMultiplier} className="mb-2" />
+            )}
             <p className="text-error text-center" style={{ fontSize: `${invalidCoverFontSize}rem` }}>
               {t('MessageInvalidCover')}
             </p>

--- a/src/components/ereader/FoliateView.tsx
+++ b/src/components/ereader/FoliateView.tsx
@@ -21,6 +21,7 @@ import {
   usesPageBasedProgress,
   type EbookProgressUpdate
 } from '@/lib/ereader/ereaderEbook'
+import { withBasePath } from '@/lib/basePath'
 import { FixedLayoutZoomController, getFixedLayoutPageSize } from '@/lib/ereader/ereaderFixedLayoutZoom'
 import { attachEpubSecurity } from '@/lib/ereader/ereaderSecurity'
 import { applyEreaderSettingsToView, type EreaderSettings } from '@/lib/ereader/ereaderSettings'
@@ -380,7 +381,7 @@ const FoliateView = forwardRef<FoliateViewHandle, FoliateViewProps>(function Fol
           if (handleKeydown) document.removeEventListener('keydown', handleKeydown)
         }
 
-        const ebookUrl = fileId ? `/internal-api/items/${libraryItemId}/ebook/${fileId}` : `/internal-api/items/${libraryItemId}/ebook`
+        const ebookUrl = withBasePath(fileId ? `/internal-api/items/${libraryItemId}/ebook/${fileId}` : `/internal-api/items/${libraryItemId}/ebook`)
         const response = await fetch(ebookUrl, {
           credentials: 'include',
           headers: { Accept: 'application/json' }

--- a/src/components/modals/RssFeedOpenCloseModal.tsx
+++ b/src/components/modals/RssFeedOpenCloseModal.tsx
@@ -9,6 +9,7 @@ import TextInput from '@/components/ui/TextInput'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { getBasePath, withBasePath } from '@/lib/basePath'
 import { RssFeed } from '@/types/api'
 import { useCallback, useEffect, useState } from 'react'
 
@@ -54,7 +55,7 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
   const entityFeed = entity?.feed ?? null
   const hasEpisodesWithoutPubDate = entity?.hasEpisodesWithoutPubDate ?? false
   const isHttp = typeof window !== 'undefined' && window.location.origin.startsWith('http://')
-  const demoFeedUrl = typeof window !== 'undefined' ? `${window.location.origin}/feed/${newFeedSlug || entityId}` : ''
+  const demoFeedUrl = typeof window !== 'undefined' ? `${window.location.origin}${withBasePath(`/feed/${newFeedSlug || entityId}`)}` : ''
 
   useEffect(() => {
     if (isOpen && entity) {
@@ -78,7 +79,9 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
     setProcessing(true)
     try {
       const res = await openEntityRssFeed(entity.type, entityId, {
-        serverAddress: window.location.origin,
+        // The server stores this verbatim and builds absolute feed urls from it, so it has to
+        // carry the base path the listener will use.
+        serverAddress: `${window.location.origin}${getBasePath()}`,
         slug: sanitized,
         metadataDetails: {
           preventIndexing: metadataDetails.preventIndexing,
@@ -118,7 +121,7 @@ export default function RssFeedOpenCloseModal({ isOpen, onClose, entity, viewMod
 
   const outerContent = <ModalOuterContent title={entityName}>{entityName}</ModalOuterContent>
 
-  const fullFeedUrl = typeof window !== 'undefined' && currentFeed ? `${window.location.origin}${currentFeed.feedUrl}` : ''
+  const fullFeedUrl = typeof window !== 'undefined' && currentFeed ? `${window.location.origin}${withBasePath(currentFeed.feedUrl)}` : ''
   const meta = currentFeed?.meta
   const hasOwnerName = meta && meta.ownerName != null && String(meta.ownerName).trim() !== ''
   const hasOwnerEmail = meta && meta.ownerEmail != null && String(meta.ownerEmail).trim() !== ''

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -12,6 +12,7 @@ import ToggleSwitch from '@/components/ui/ToggleSwitch'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { ApiError } from '@/lib/apiErrors'
+import { withBasePath } from '@/lib/basePath'
 import { formatDuration } from '@/lib/formatDuration'
 import type { MediaItemShare } from '@/types/api'
 import { useLocale } from 'next-intl'
@@ -97,12 +98,12 @@ export default function ShareModal({ isOpen, onClose, mediaItemId, mediaItemShar
 
   const demoShareUrl = useMemo(() => {
     if (typeof window === 'undefined') return ''
-    return `${window.location.origin}/share/${newShareSlug}`
+    return `${window.location.origin}${withBasePath(`/share/${newShareSlug}`)}`
   }, [newShareSlug])
 
   const currentShareUrl = useMemo(() => {
     if (!currentShare || typeof window === 'undefined') return ''
-    return `${window.location.origin}/share/${currentShare.slug}`
+    return `${window.location.origin}${withBasePath(`/share/${currentShare.slug}`)}`
   }, [currentShare])
 
   const currentShareTimeRemaining = useMemo(() => {

--- a/src/contexts/SocketContext.tsx
+++ b/src/contexts/SocketContext.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { withBasePath } from '@/lib/basePath'
 import { OnlineUser } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { ReactNode, createContext, useCallback, useContext, useEffect, useState } from 'react'
@@ -47,7 +48,8 @@ export function SocketProvider({ children, accessToken }: SocketProviderProps) {
   const [usersOnline, setUsersOnline] = useState<OnlineUser[]>([])
 
   useEffect(() => {
-    const socketInstance = io()
+    // Socket.IO attaches to the raw HTTP server, so the base path is not applied for us.
+    const socketInstance = io({ path: withBasePath('/socket.io') })
     setSocket(socketInstance)
 
     const handleConnect = () => {
@@ -85,7 +87,7 @@ export function SocketProvider({ children, accessToken }: SocketProviderProps) {
     const handleAuthFailed = async () => {
       console.log('Socket auth failed. Attempting silent token refresh.')
       try {
-        const res = await fetch('/internal-api/refresh', {
+        const res = await fetch(withBasePath('/internal-api/refresh'), {
           headers: {
             Accept: 'application/json'
           }

--- a/src/hooks/useChapterPreviewAudio.ts
+++ b/src/hooks/useChapterPreviewAudio.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { AudioTrack } from '@/types/api'
+import { withBasePath } from '@/lib/basePath'
 import { getAudioTrackForTime } from '@/lib/chapters/chapterEditorUtils'
 
 interface UseChapterPreviewAudioOptions {
@@ -65,7 +66,7 @@ export function useChapterPreviewAudio({ tracks, token }: UseChapterPreviewAudio
       }
 
       const audioEl = document.createElement('audio')
-      audioEl.src = `${audioTrack.contentUrl}?token=${token}`
+      audioEl.src = `${withBasePath(audioTrack.contentUrl)}?token=${token}`
       audioEl.id = 'chapter-audio'
       document.body.appendChild(audioEl)
       audioElRef.current = audioEl

--- a/src/hooks/useGlobalSearchTransformer.ts
+++ b/src/hooks/useGlobalSearchTransformer.ts
@@ -1,4 +1,5 @@
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { withBasePath } from '@/lib/basePath'
 import { getLibraryItemCoverSrc, getPlaceholderCoverUrl } from '@/lib/coverUtils'
 import { filterEncode } from '@/lib/filterUtils'
 import { SearchLibraryResponse } from '@/types/api'
@@ -143,7 +144,7 @@ export function useGlobalSearchTransformer({
       // Use series cover or fallback to first book cover
       let imageSrc = ''
       if (item.series.coverPath) {
-        imageSrc = `/api/series/${item.series.id}/cover?ts=${item.series.updatedAt || 0}`
+        imageSrc = withBasePath(`/api/series/${item.series.id}/cover?ts=${item.series.updatedAt || 0}`)
       } else if (item.books.length > 0) {
         imageSrc = getLibraryItemCoverSrc(item.books[0], getPlaceholderCoverUrl())
       }

--- a/src/hooks/useLogout.ts
+++ b/src/hooks/useLogout.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { withBasePath } from '@/lib/basePath'
 import type { ServerLogoutResponse } from '@/types/api'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
@@ -9,14 +10,14 @@ export function useLogout() {
   const router = useRouter()
 
   return useCallback(async () => {
-    const res = await fetch('/internal-api/logout', { method: 'POST' })
+    const res = await fetch(withBasePath('/internal-api/logout'), { method: 'POST' })
     if (!res.ok) {
       throw new Error(`Logout failed: ${res.status} ${res.statusText}`)
     }
 
     const data = (await res.json()) as ServerLogoutResponse
     if (data.redirect_url) {
-      window.location.href = data.redirect_url
+      window.location.href = withBasePath(data.redirect_url)
     } else {
       router.replace('/login')
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -99,6 +99,7 @@ import {
 } from '../types/api'
 
 import { ApiError, NetworkError, UnauthorizedError } from './apiErrors'
+import { getBasePath, withBasePath } from './basePath'
 import { isNextRedirectError } from './nextErrors'
 import { getUserDefaultUrlPath } from './userPermissions'
 
@@ -134,8 +135,7 @@ export function getClientBaseUrlFromRequest(request: Request): string {
  * Parallels the server's getRequestOrigin() plus global.RouterBasePath (see OidcAuthStrategy).
  */
 export function getClientBaseUrlFromHeaders(headerStore: { get(name: string): string | null }): string {
-  const routerBasePath = process.env.ROUTER_BASE_PATH ?? ''
-  return `${getClientOriginFromHeaders(headerStore)}${routerBasePath}`
+  return `${getClientOriginFromHeaders(headerStore)}${getBasePath()}`
 }
 
 export async function getClientBaseUrl(): Promise<string> {
@@ -160,7 +160,8 @@ export function clearSessionCookies(response: NextResponse) {
  * would otherwise bounce /login → /library forever.
  */
 export function redirectToLogin(request: Request, errorMessage: string): NextResponse {
-  const login = new URL('/login', getClientBaseUrlFromRequest(request))
+  // Route handler redirects are sent verbatim, so the base path has to be added here.
+  const login = new URL(withBasePath('/login'), getClientBaseUrlFromRequest(request))
   login.searchParams.set('error', errorMessage)
   const response = NextResponse.redirect(login)
   clearSessionCookies(response)

--- a/src/lib/backupUpload.ts
+++ b/src/lib/backupUpload.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { parseUploadErrorMessage } from '@/lib/uploadErrors'
 import type { UploadProgressInfo } from '@/types/upload'
 
@@ -11,7 +12,7 @@ export async function uploadBackupArchive(file: File, onProgress?: (progress: Up
 
   await new Promise<void>((resolve, reject) => {
     const xhr = new XMLHttpRequest()
-    xhr.open('POST', '/internal-api/backups/upload', true)
+    xhr.open('POST', withBasePath('/internal-api/backups/upload'), true)
 
     xhr.upload.onprogress = (event) => {
       if (event.lengthComputable && onProgress) {

--- a/src/lib/basePath.ts
+++ b/src/lib/basePath.ts
@@ -48,9 +48,9 @@ export function getConfiguredBasePath(): string {
  */
 export const BASE_PATH_ATTRIBUTE = 'data-base-path'
 
-export function getClientBasePath(): string {
+export function getBasePath(): string {
   if (typeof document !== 'undefined') {
-    return normalizeBasePath(document.documentElement.getAttribute(BASE_PATH_ATTRIBUTE))
+    return document.documentElement.getAttribute(BASE_PATH_ATTRIBUTE) ?? ''
   }
   return getConfiguredBasePath()
 }
@@ -61,7 +61,7 @@ export function getClientBasePath(): string {
  */
 export function withBasePath(url: string): string {
   if (!url.startsWith('/') || url.startsWith('//')) return url
-  return `${getClientBasePath()}${url}`
+  return `${getBasePath()}${url}`
 }
 
 /**

--- a/src/lib/basePath.ts
+++ b/src/lib/basePath.ts
@@ -1,0 +1,82 @@
+/**
+ * Token compiled into the client bundle as Next's `basePath` during `next build`.
+ *
+ * Next inlines `basePath` into production chunks, so the deployed path cannot change without a
+ * rebuild. Building with this token instead lets the server swap in the configured path at startup
+ * (see `rewriteBuildBasePath`). It must never appear anywhere else in the app source.
+ */
+export const BASE_PATH_PLACEHOLDER = '/__ABS_BASE_PATH__'
+
+/** Normalize to '' (root) or '/segment' with no trailing slash. */
+export function normalizeBasePath(basePath: string | null | undefined): string {
+  if (!basePath) return ''
+
+  const trimmed = basePath.trim()
+  if (!trimmed || trimmed === '/') return ''
+
+  const withLeadingSlash = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+  return withLeadingSlash.endsWith('/') ? withLeadingSlash.slice(0, -1) : withLeadingSlash
+}
+
+declare global {
+  /** Set by Audiobookshelf before it starts Next. */
+  var RouterBasePath: string | undefined
+}
+
+/**
+ * The path the browser sees, resolved at process start.
+ *
+ * Audiobookshelf sets `global.RouterBasePath` from `ROUTER_BASE_PATH` before starting Next, so
+ * both processes agree. Standalone `next dev` falls back to the env var.
+ */
+export function getConfiguredBasePath(): string {
+  if (typeof globalThis.RouterBasePath === 'string') {
+    return normalizeBasePath(globalThis.RouterBasePath)
+  }
+  return normalizeBasePath(process.env.ROUTER_BASE_PATH)
+}
+
+/**
+ * The subfolder the client is served from, '' when served from the root.
+ *
+ * Next already prefixes `Link`, `useRouter`, `redirect`, and its own assets. It does not prefix
+ * `next/image` `src`, `fetch`, Socket.IO, `window.location`, or raw API URLs — use these helpers
+ * for those.
+ *
+ * On the server the value comes from the audiobookshelf global; in the browser it is read from the
+ * attribute the root layout renders, since the value is only known at server start.
+ */
+export const BASE_PATH_ATTRIBUTE = 'data-base-path'
+
+export function getClientBasePath(): string {
+  if (typeof document !== 'undefined') {
+    return normalizeBasePath(document.documentElement.getAttribute(BASE_PATH_ATTRIBUTE))
+  }
+  return getConfiguredBasePath()
+}
+
+/**
+ * Prefix a root-relative URL. Absolute and protocol-relative URLs are returned unchanged (OIDC
+ * logout can pass an IdP URL through the same helper).
+ */
+export function withBasePath(url: string): string {
+  if (!url.startsWith('/') || url.startsWith('//')) return url
+  return `${getClientBasePath()}${url}`
+}
+
+/**
+ * Matches the placeholder together with any backslashes escaping its leading slash.
+ *
+ * Route matchers embed the base path as a regex (`\/__ABS_BASE_PATH__`), and the JSON manifests
+ * escape that again (`\\/__ABS_BASE_PATH__`). Leaving those backslashes in place would produce an
+ * invalid pattern on a root deploy, so the replacement reuses whatever run it captured.
+ */
+const PLACEHOLDER_PATTERN = new RegExp(`(\\\\*)${BASE_PATH_PLACEHOLDER}`, 'g')
+
+/**
+ * Swap every placeholder occurrence for `basePath`, keeping each occurrence's escaping depth.
+ * A root deploy ('') removes the slash and its backslashes along with the token.
+ */
+export function replaceBasePathPlaceholder(content: string, basePath: string): string {
+  return content.replace(PLACEHOLDER_PATTERN, (_match, backslashes: string) => basePath.split('/').join(`${backslashes}/`))
+}

--- a/src/lib/coverUpload.ts
+++ b/src/lib/coverUpload.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { parseUploadErrorMessage } from '@/lib/uploadErrors'
 import { UploadCoverResponse } from '@/types/api'
 
@@ -9,7 +10,7 @@ export async function uploadCoverFile(libraryItemId: string, file: File): Promis
   const form = new FormData()
   form.set('cover', file, file.name)
 
-  const response = await fetch(`/internal-api/items/${libraryItemId}/cover`, {
+  const response = await fetch(withBasePath(`/internal-api/items/${libraryItemId}/cover`), {
     method: 'POST',
     body: form
   })

--- a/src/lib/coverUtils.ts
+++ b/src/lib/coverUtils.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import type { LibraryItem } from '@/types/api'
 
 /**
@@ -13,7 +14,7 @@ export function getLibraryItemCoverUrl(libraryItemId: string, timestamp?: number
   if (raw) {
     params.set('raw', '1')
   }
-  return `/api/items/${libraryItemId}/cover?${params.toString()}`
+  return withBasePath(`/api/items/${libraryItemId}/cover?${params.toString()}`)
 }
 
 /**
@@ -33,14 +34,14 @@ export function getLibraryFileUrl(libraryItemId: string, fileIno: string, timest
   if (timestamp) {
     params.set('ts', String(timestamp))
   }
-  return `/internal-api/items/${libraryItemId}/file/${fileIno}?${params.toString()}`
+  return withBasePath(`/internal-api/items/${libraryItemId}/file/${fileIno}?${params.toString()}`)
 }
 
 /**
  * Get placeholder cover image URL
  */
 export function getPlaceholderCoverUrl(): string {
-  return '/images/book_placeholder.jpg'
+  return withBasePath('/images/book_placeholder.jpg')
 }
 
 /**

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,3 +1,5 @@
+import { withBasePath } from '@/lib/basePath'
+
 interface DownloadByUrlOptions {
   filename?: string
   openInNewTab?: boolean
@@ -6,7 +8,7 @@ interface DownloadByUrlOptions {
 export function downloadByUrl(url: string, { filename, openInNewTab = false }: DownloadByUrlOptions = {}) {
   const link = document.createElement('a')
   link.style.display = 'none'
-  link.href = url
+  link.href = withBasePath(url)
 
   if (filename != null) {
     link.download = filename

--- a/src/lib/libraryItemUpload.ts
+++ b/src/lib/libraryItemUpload.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import { parseUploadErrorMessage } from '@/lib/uploadErrors'
 import type { Library } from '@/types/api'
 import type { UploadProgressInfo } from '@/types/upload'
@@ -36,7 +37,7 @@ export async function uploadLibraryItem(
 
   await new Promise<void>((resolve, reject) => {
     const xhr = new XMLHttpRequest()
-    xhr.open('POST', '/internal-api/items/upload', true)
+    xhr.open('POST', withBasePath('/internal-api/items/upload'), true)
 
     xhr.upload.onprogress = (event) => {
       if (event.lengthComputable && onProgress) {

--- a/src/lib/nextBasePath.ts
+++ b/src/lib/nextBasePath.ts
@@ -1,7 +1,0 @@
-/**
- * Next.js app base path from NEXT_PUBLIC_BASE_PATH (empty for root).
- * Marker for future Next `basePath` support; currently unused.
- */
-export function getNextBasePath(): string {
-  return process.env.NEXT_PUBLIC_BASE_PATH ?? ''
-}

--- a/src/lib/player/AudioTrack.ts
+++ b/src/lib/player/AudioTrack.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/lib/basePath'
 import type { AudioTrackData } from '@/types/api'
 
 /**
@@ -26,10 +27,12 @@ export class AudioTrack {
 
     this.sessionId = sessionId
 
+    // Track URLs come from the server without the base path, and the browser requests them
+    // directly rather than through Next.
     if (this.contentUrl?.startsWith('/hls') || !sessionId) {
-      this.sessionTrackUrl = this.contentUrl
+      this.sessionTrackUrl = withBasePath(this.contentUrl)
     } else {
-      this.sessionTrackUrl = `/public/session/${sessionId}/track/${this.index}`
+      this.sessionTrackUrl = withBasePath(`/public/session/${sessionId}/track/${this.index}`)
     }
   }
 

--- a/src/lib/rewriteBuildBasePath.ts
+++ b/src/lib/rewriteBuildBasePath.ts
@@ -108,11 +108,17 @@ export function rewriteBuildBasePath(distDir: string, basePath: string): boolean
 
   const state = readJsonFile<AppliedState>(stateFile)
   const isUpToDate = state?.version === REWRITE_VERSION && state.buildId === buildId && state.basePath === basePath
-  if (isUpToDate && existsSync(snapshotDir)) return false
+  // Same path/build/version: live files are already correct. Do not rebuild the snapshot (even if missing snapshot dir)
+  if (isUpToDate) return false
 
   let manifest = readJsonFile<SnapshotManifest>(path.join(snapshotDir, SNAPSHOT_MANIFEST_NAME))
-  if (manifest?.buildId !== buildId) {
+  if (manifest?.buildId !== buildId || !manifest.files.length) {
     manifest = createSnapshot(distDir, snapshotDir, buildId)
+  }
+  if (!manifest.files.length) {
+    throw new Error(
+      `Cannot apply base path "${basePath || '/'}" to the client build at ${distDir}. The original placeholder files are gone (missing or empty snapshot). Run a new production build.`
+    )
   }
 
   try {

--- a/src/lib/rewriteBuildBasePath.ts
+++ b/src/lib/rewriteBuildBasePath.ts
@@ -1,0 +1,131 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+
+import { BASE_PATH_PLACEHOLDER, replaceBasePathPlaceholder } from './basePath.ts'
+
+/**
+ * Swap the compiled-in base path placeholder for the configured path.
+ *
+ * Next inlines `basePath` into production chunks, so this is what makes the path configurable
+ * without a rebuild. The pristine placeholder files are snapshotted on first run, and every later
+ * change restores from that snapshot before replacing — reversing a real path like '/abs' in place
+ * would corrupt unrelated strings that happen to start with it.
+ *
+ * Must run before Next loads any build chunk, otherwise already-required modules keep the
+ * placeholder. `next.config.ts` is the earliest hook available for that.
+ *
+ * Kept in this file (not `basePath.ts`) because it uses Node `fs`. Client components import
+ * `withBasePath` from `basePath.ts`; a top-level `node:fs` import there would break the browser bundle.
+ */
+
+const SNAPSHOT_DIR_NAME = 'abs-base-path-snapshot'
+const SNAPSHOT_MANIFEST_NAME = 'snapshot-manifest.json'
+const STATE_FILE_NAME = 'abs-base-path.json'
+
+/** Bumped when the replacement logic changes, so an existing build is rewritten from scratch. */
+const REWRITE_VERSION = 2
+
+/** Build output that is regenerated or irrelevant at runtime. */
+const IGNORED_DIRECTORIES = ['cache', SNAPSHOT_DIR_NAME]
+
+/** Text formats the placeholder can appear in. Anything else risks corrupting binary output. */
+const REWRITABLE_EXTENSIONS = ['.js', '.cjs', '.mjs', '.json', '.html', '.rsc', '.txt', '.css']
+
+interface SnapshotManifest {
+  buildId: string
+  files: string[]
+}
+
+interface AppliedState {
+  version: number
+  buildId: string
+  basePath: string
+}
+
+function readBuildId(distDir: string): string {
+  return readFileSync(path.join(distDir, 'BUILD_ID'), 'utf8').trim()
+}
+
+function readJsonFile<T>(filePath: string): T | null {
+  if (!existsSync(filePath)) return null
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8')) as T
+  } catch {
+    return null
+  }
+}
+
+function collectPlaceholderFiles(distDir: string, relativeDir = ''): string[] {
+  const absoluteDir = path.join(distDir, relativeDir)
+  const found: string[] = []
+
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath = path.join(relativeDir, entry.name)
+
+    if (entry.isDirectory()) {
+      if (relativeDir === '' && IGNORED_DIRECTORIES.includes(entry.name)) continue
+      found.push(...collectPlaceholderFiles(distDir, relativePath))
+      continue
+    }
+
+    if (!entry.isFile() || !REWRITABLE_EXTENSIONS.includes(path.extname(entry.name))) continue
+
+    if (readFileSync(path.join(distDir, relativePath), 'utf8').includes(BASE_PATH_PLACEHOLDER)) {
+      found.push(relativePath)
+    }
+  }
+
+  return found
+}
+
+function createSnapshot(distDir: string, snapshotDir: string, buildId: string): SnapshotManifest {
+  rmSync(snapshotDir, { recursive: true, force: true })
+
+  const manifest: SnapshotManifest = { buildId, files: collectPlaceholderFiles(distDir) }
+
+  for (const relativePath of manifest.files) {
+    const destination = path.join(snapshotDir, relativePath)
+    mkdirSync(path.dirname(destination), { recursive: true })
+    copyFileSync(path.join(distDir, relativePath), destination)
+  }
+
+  mkdirSync(snapshotDir, { recursive: true })
+  writeFileSync(path.join(snapshotDir, SNAPSHOT_MANIFEST_NAME), JSON.stringify(manifest))
+  return manifest
+}
+
+/**
+ * @param distDir absolute path to the `.next` directory
+ * @param basePath normalized base path ('' for root)
+ * @returns true when files were rewritten, false when the build already matches
+ */
+export function rewriteBuildBasePath(distDir: string, basePath: string): boolean {
+  if (!existsSync(path.join(distDir, 'BUILD_ID'))) return false
+
+  const buildId = readBuildId(distDir)
+  const snapshotDir = path.join(distDir, SNAPSHOT_DIR_NAME)
+  const stateFile = path.join(distDir, STATE_FILE_NAME)
+
+  const state = readJsonFile<AppliedState>(stateFile)
+  const isUpToDate = state?.version === REWRITE_VERSION && state.buildId === buildId && state.basePath === basePath
+  if (isUpToDate && existsSync(snapshotDir)) return false
+
+  let manifest = readJsonFile<SnapshotManifest>(path.join(snapshotDir, SNAPSHOT_MANIFEST_NAME))
+  if (manifest?.buildId !== buildId) {
+    manifest = createSnapshot(distDir, snapshotDir, buildId)
+  }
+
+  try {
+    for (const relativePath of manifest.files) {
+      const pristine = readFileSync(path.join(snapshotDir, relativePath), 'utf8')
+      writeFileSync(path.join(distDir, relativePath), replaceBasePathPlaceholder(pristine, basePath))
+    }
+    writeFileSync(stateFile, JSON.stringify({ version: REWRITE_VERSION, buildId, basePath } satisfies AppliedState))
+  } catch (error) {
+    throw new Error(
+      `Failed to apply base path "${basePath || '/'}" to the client build at ${distDir}. The directory must be writable. Cause: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+
+  return true
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { clearSessionCookies, getServerStatus } from './lib/api'
+import { withBasePath } from './lib/basePath'
 import { isSessionTokenValid } from './lib/jwt'
 import { matchAcceptLanguage } from './lib/languages'
 import Logger from './lib/Logger'
@@ -31,17 +32,19 @@ export async function proxy(request: NextRequest) {
   }
 
   // Helper to create URLs with correct host/port from request headers.
-  // nextUrl/url don't always containt the right host/port,
+  // nextUrl/url don't always contain the right host/port,
   // but nextjs populates the x-forwarded-host and x-forwarded-proto headers correctly.
+  // Middleware redirects are sent verbatim, so the base path has to be added here.
   const createUrl = (path: string) => {
+    const absolutePath = withBasePath(path)
     try {
       const host = request.headers.get('x-forwarded-host') || request.headers.get('host') || request.nextUrl.host
       const protocol = request.headers.get('x-forwarded-proto') || (host.includes('localhost') || host.includes('127.0.0.1') ? 'http' : 'https')
-      return new URL(path, `${protocol}://${host}`)
+      return new URL(absolutePath, `${protocol}://${host}`)
     } catch (error) {
       Logger.error('[proxy] failed to create URL:', { path, error })
       // Fallback: use the current request's URL as base
-      return new URL(path, request.nextUrl.origin)
+      return new URL(absolutePath, request.nextUrl.origin)
     }
   }
 
@@ -176,8 +179,11 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
+  // '/' is listed separately: the catch-all below does not match the origin-root path, which is
+  // what the browser hits for both `https://host/` and `https://host/abs/` (Next strips basePath
+  // before matching). Without it the home URL 404s instead of redirecting to /library.
   // PWA files (sw.js, manifest.webmanifest) are excluded so they stay publicly fetchable:
   // otherwise the auth redirect would serve a /login HTML page in their place, breaking
   // service-worker registration and install from the login screen.
-  matcher: ['/((?!api|internal-api|_next/static|_next/image|sw\\.js|manifest\\.webmanifest|.*\\.png|.*\\.ico|.*\\.svg|.*\\.json).*)']
+  matcher: ['/', '/((?!api|internal-api|_next/static|_next/image|sw\\.js|manifest\\.webmanifest|.*\\.png|.*\\.ico|.*\\.svg|.*\\.json).*)']
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,


### PR DESCRIPTION
Fixes #217

Next inlines `basePath` into production chunks, so a simple `bastPath` deployment would have required a rebuild to change it.

This PR builds with a placeholder basePath, rewrites `.next` at server start from `RouterBasePath`, and prefixes the URLs Next does not prefix automatically (`fetch`, `next/image` `src`, Socket.IO, uploads, `window.location`). 

Root deployments keep `basePath` empty and behave as before.

This depends on [server PR #5507](https://github.com/advplyr/audiobookshelf/pull/5507) (restore the Express mount prefix when handing requests to Next).

## Testing
Run `pnpm build`

Run tests with 'npm run start-dev` (which loads a prebuilt next, proving that this doesn't require a rebuild)

Test with different values for `RouterBasePath` in `dev.js`, including empty string, and unset. 
Restart the server after each `RouterBasePath` change.
- Verify that when RouterBasePath is unset client is served under `/audiobookshelf` (similar to Vue)
- Verify that when `RouterBasePath == ''` client is served under `/`
- Verify that when `RouterBasePath == '/abs'` client is served under `/abs`
