### PR TITLE
Make MediaSession respect chapter track setting

### DIFF
--- a/src/app/(public)/share/[slug]/SharePlayer.tsx
+++ b/src/app/(public)/share/[slug]/SharePlayer.tsx
@@ -23,6 +23,7 @@ const PROGRESS_SYNC_INTERVAL = 30 // seconds
 
 export default function SharePlayer({ slug, startTime: startTimeParam }: SharePlayerProps) {
   const t = useTypeSafeTranslations()
+  const unknownLabel = t('LabelUnknown')
   // Share data
   const [shareData, setShareData] = useState<MediaItemShareResponse | null>(null)
   const [fetchError, setFetchError] = useState<string | null>(null)
@@ -310,9 +311,14 @@ export default function SharePlayer({ slug, startTime: startTimeParam }: SharePl
   useEffect(() => {
     if (!playbackSession || !('mediaSession' in navigator)) return
 
+    const bookTitle = playbackSession.displayTitle || unknownLabel
+    const chapterTitle = currentChapter?.title
+    const title = chapterTitle ? t('LabelMediaSessionTitleWithChapter', { title: bookTitle, chapter: chapterTitle }) : bookTitle
+    const artist = playbackSession.displayAuthor || unknownLabel
+
     navigator.mediaSession.metadata = new MediaMetadata({
-      title: playbackSession.displayTitle || 'No title',
-      artist: playbackSession.displayAuthor || 'Unknown',
+      title,
+      artist,
       artwork: playbackSession.coverPath ? [{ src: coverUrl }] : []
     })
 
@@ -326,7 +332,7 @@ export default function SharePlayer({ slug, startTime: startTimeParam }: SharePl
     })
     navigator.mediaSession.setActionHandler('previoustrack', jumpBackward)
     navigator.mediaSession.setActionHandler('nexttrack', jumpForward)
-  }, [playbackSession, coverUrl, play, pause, jumpBackward, jumpForward, seek])
+  }, [playbackSession, coverUrl, play, pause, jumpBackward, jumpForward, seek, currentChapter, unknownLabel, t])
 
   // Update media session playback state
   useEffect(() => {

--- a/src/components/player/MediaPlayerContainer.tsx
+++ b/src/components/player/MediaPlayerContainer.tsx
@@ -4,10 +4,9 @@ import { useBookCoverAspectRatio } from '@/contexts/LibraryContext'
 import { useMediaContext, usePlayerState } from '@/contexts/MediaContext'
 import { useAudioPlayerHotkeys } from '@/hooks/useAudioPlayerHotkeys'
 import { useCoverAccentColor } from '@/hooks/useCoverAccentColor'
-import { useMediaSession } from '@/hooks/useMediaSession'
-import { usePlayerChapterQueueNavigation } from '@/hooks/usePlayerChapterQueueNavigation'
-import type { PlayerHandler } from '@/hooks/usePlayerHandler'
 import { useMediaQuery } from '@/hooks/useMediaQuery'
+import { useMediaSession } from '@/hooks/useMediaSession'
+import type { PlayerHandler } from '@/hooks/usePlayerHandler'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { secondsToTimestamp } from '@/lib/datefns'
@@ -49,13 +48,9 @@ export default function MediaPlayerContainer() {
 
   useAudioPlayerHotkeys(playerHandler.state, playerHandler.controls, !!streamLibraryItem, clearStreamMedia)
 
-  const { handleNext, handlePrevious } = usePlayerChapterQueueNavigation(playerHandler, streamLibraryItem)
-
   useMediaSession({
     libraryItem: streamLibraryItem,
     playerHandler,
-    onPreviousTrack: handlePrevious,
-    onNextTrack: handleNext,
     enabled: !!streamLibraryItem
   })
 

--- a/src/hooks/useMediaSession.ts
+++ b/src/hooks/useMediaSession.ts
@@ -30,16 +30,8 @@ function buildChapterInfo(chapters: Chapter[]) {
   }))
 }
 
-function buildMediaMetadata(
-  libraryItem: LibraryItem,
-  displayTitle: string | null,
-  displayAuthor: string | null,
-  chapters: Chapter[],
-  unknownLabel: string
-): MediaMetadata {
+function buildMediaMetadata(libraryItem: LibraryItem, title: string, artist: string, chapters: Chapter[]): MediaMetadata {
   const metadata = libraryItem.media.metadata
-  const title = displayTitle || metadata.title || unknownLabel
-  const artist = displayAuthor || (isBookMetadata(metadata) ? metadata.authorName : undefined) || unknownLabel
   const album = isBookMetadata(metadata) ? (metadata.seriesName ?? '') : ''
   const coverUrl = getLibraryItemCoverUrl(libraryItem.id, libraryItem.updatedAt, true)
   const chapterInfo = buildChapterInfo(chapters)
@@ -53,27 +45,6 @@ function buildMediaMetadata(
   }
 
   return new MediaMetadata(init)
-}
-
-function buildChapterMediaMetadata(
-  libraryItem: LibraryItem,
-  displayTitle: string | null,
-  displayAuthor: string | null,
-  currentChapter: Chapter,
-  unknownLabel: string
-): MediaMetadata {
-  const metadata = libraryItem.media.metadata
-  const bookTitle = displayTitle || metadata.title || unknownLabel
-  const author = displayAuthor || (isBookMetadata(metadata) ? metadata.authorName : undefined) || unknownLabel
-  const coverUrl = getLibraryItemCoverUrl(libraryItem.id, libraryItem.updatedAt, true)
-
-  // Audible-style lock screen: book title primary, chapter name secondary; author in album (expanded views).
-  return new MediaMetadata({
-    title: bookTitle,
-    artist: currentChapter.title || unknownLabel,
-    album: author,
-    artwork: [{ src: coverUrl }]
-  })
 }
 
 function getMediaSessionPositionState({
@@ -155,16 +126,17 @@ export function useMediaSession({ libraryItem, playerHandler, enabled = true }: 
   useEffect(() => {
     if (!enabled || !libraryItem || !('mediaSession' in navigator)) return
 
-    if (useChapterTrack && currentChapter) {
-      navigator.mediaSession.metadata = buildChapterMediaMetadata(libraryItem, displayTitle, displayAuthor, currentChapter, unknownLabel)
-    } else {
-      navigator.mediaSession.metadata = buildMediaMetadata(libraryItem, displayTitle, displayAuthor, chapters, unknownLabel)
-    }
+    const bookTitle = displayTitle || libraryItem.media.metadata.title || unknownLabel
+    const chapterTitle = currentChapter?.title
+    const title = chapterTitle ? t('LabelMediaSessionTitleWithChapter', { title: bookTitle, chapter: chapterTitle }) : bookTitle
+    const artist = displayAuthor || (isBookMetadata(libraryItem.media.metadata) ? libraryItem.media.metadata.authorName : undefined) || unknownLabel
+
+    navigator.mediaSession.metadata = buildMediaMetadata(libraryItem, title, artist, chapters)
 
     return () => {
       navigator.mediaSession.metadata = null
     }
-  }, [enabled, libraryItem, displayAuthor, displayTitle, chapters, useChapterTrack, currentChapter, unknownLabel])
+  }, [enabled, libraryItem, displayAuthor, displayTitle, chapters, currentChapter, unknownLabel, t])
 
   // Action handlers use refs so seek/jump callbacks changing with currentTime do not reset metadata.
   useEffect(() => {

--- a/src/hooks/useMediaSession.ts
+++ b/src/hooks/useMediaSession.ts
@@ -1,5 +1,7 @@
 import type { PlayerHandler } from '@/hooks/usePlayerHandler'
+import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
+import { getPlayerProgress, subscribePlayerProgress } from '@/lib/player/playerProgressStore'
 import { isBookMetadata, PlayerState, type Chapter, type LibraryItem } from '@/types/api'
 import { useEffect, useRef } from 'react'
 
@@ -13,6 +15,14 @@ interface UseMediaSessionOptions {
   enabled?: boolean
 }
 
+interface MediaSessionPositionInput {
+  useChapterTrack: boolean
+  currentChapter: Chapter | null
+  currentTime: number
+  duration: number
+  playbackRate: number
+}
+
 function buildChapterInfo(chapters: Chapter[]) {
   if (!chapters.length) return undefined
 
@@ -22,10 +32,16 @@ function buildChapterInfo(chapters: Chapter[]) {
   }))
 }
 
-function buildMediaMetadata(libraryItem: LibraryItem, displayTitle: string | null, displayAuthor: string | null, chapters: Chapter[]): MediaMetadata {
+function buildMediaMetadata(
+  libraryItem: LibraryItem,
+  displayTitle: string | null,
+  displayAuthor: string | null,
+  chapters: Chapter[],
+  unknownLabel: string
+): MediaMetadata {
   const metadata = libraryItem.media.metadata
-  const title = displayTitle || metadata.title || 'Unknown'
-  const artist = displayAuthor || (isBookMetadata(metadata) ? metadata.authorName : undefined) || 'Unknown'
+  const title = displayTitle || metadata.title || unknownLabel
+  const artist = displayAuthor || (isBookMetadata(metadata) ? metadata.authorName : undefined) || unknownLabel
   const album = isBookMetadata(metadata) ? (metadata.seriesName ?? '') : ''
   const coverUrl = getLibraryItemCoverUrl(libraryItem.id, libraryItem.updatedAt, true)
   const chapterInfo = buildChapterInfo(chapters)
@@ -41,8 +57,78 @@ function buildMediaMetadata(libraryItem: LibraryItem, displayTitle: string | nul
   return new MediaMetadata(init)
 }
 
+function buildChapterMediaMetadata(
+  libraryItem: LibraryItem,
+  displayTitle: string | null,
+  displayAuthor: string | null,
+  currentChapter: Chapter,
+  unknownLabel: string
+): MediaMetadata {
+  const metadata = libraryItem.media.metadata
+  const bookTitle = displayTitle || metadata.title || unknownLabel
+  const author = displayAuthor || (isBookMetadata(metadata) ? metadata.authorName : undefined) || unknownLabel
+  const coverUrl = getLibraryItemCoverUrl(libraryItem.id, libraryItem.updatedAt, true)
+
+  // Audible-style lock screen: book title primary, chapter name secondary; author in album (expanded views).
+  return new MediaMetadata({
+    title: bookTitle,
+    artist: currentChapter.title || unknownLabel,
+    album: author,
+    artwork: [{ src: coverUrl }]
+  })
+}
+
+function getMediaSessionPositionState({
+  useChapterTrack,
+  currentChapter,
+  currentTime,
+  duration,
+  playbackRate
+}: MediaSessionPositionInput): MediaPositionState | null {
+  if (useChapterTrack && currentChapter) {
+    const chapterStart = currentChapter.start
+    const chapterEnd = currentChapter.end
+    const chapterDuration = chapterEnd - chapterStart
+
+    let chapterPosition = currentTime - chapterStart
+    chapterPosition = Math.max(0, Math.min(chapterPosition, chapterDuration))
+
+    if (Number.isNaN(chapterDuration) || chapterDuration <= 0 || Number.isNaN(chapterPosition)) {
+      return null
+    }
+
+    return { duration: chapterDuration, position: chapterPosition, playbackRate }
+  }
+
+  if (duration > 0) {
+    const position = Math.max(0, Math.min(currentTime, duration))
+
+    if (Number.isNaN(duration) || Number.isNaN(position)) {
+      return null
+    }
+
+    return { duration, position, playbackRate }
+  }
+
+  return null
+}
+
+function setMediaSessionPositionState(positionState: MediaPositionState | null) {
+  if (!('mediaSession' in navigator) || !navigator.mediaSession.setPositionState) return
+  if (!positionState) return
+
+  try {
+    navigator.mediaSession.setPositionState(positionState)
+  } catch (error) {
+    console.error('Error setting media session position state:', error)
+  }
+}
+
 /** Wire lock-screen / OS media controls via the Media Session API (parity with Vue MediaPlayerContainer). */
 export function useMediaSession({ libraryItem, playerHandler, onPreviousTrack, onNextTrack, enabled = true }: UseMediaSessionOptions) {
+  const t = useTypeSafeTranslations()
+  const unknownLabel = t('LabelUnknown')
+
   const onPreviousTrackRef = useRef(onPreviousTrack)
   onPreviousTrackRef.current = onPreviousTrack
   const onNextTrackRef = useRef(onNextTrack)
@@ -51,19 +137,41 @@ export function useMediaSession({ libraryItem, playerHandler, onPreviousTrack, o
   const controlsRef = useRef(playerHandler.controls)
   controlsRef.current = playerHandler.controls
 
-  const { playerState, displayTitle, displayAuthor, chapters } = playerHandler.state
+  const { playerState, displayTitle, displayAuthor, chapters, currentChapter, duration, settings } = playerHandler.state
   const isPlaying = playerState === PlayerState.PLAYING
+  const useChapterTrack = settings.useChapterTrack && chapters.length > 0
 
-  // Metadata only when track identity changes — not on every playback tick (Cast dialog reads this).
+  const useChapterTrackRef = useRef(useChapterTrack)
+  useChapterTrackRef.current = useChapterTrack
+  const currentChapterRef = useRef(currentChapter)
+  currentChapterRef.current = currentChapter
+  const positionInputRef = useRef({
+    useChapterTrack,
+    currentChapter,
+    duration,
+    playbackRate: settings.playbackRate
+  })
+  positionInputRef.current = {
+    useChapterTrack,
+    currentChapter,
+    duration,
+    playbackRate: settings.playbackRate
+  }
+
+  // Metadata when track identity or chapter changes — not on every playback tick (Cast dialog reads this).
   useEffect(() => {
     if (!enabled || !libraryItem || !('mediaSession' in navigator)) return
 
-    navigator.mediaSession.metadata = buildMediaMetadata(libraryItem, displayTitle, displayAuthor, chapters)
+    if (useChapterTrack && currentChapter) {
+      navigator.mediaSession.metadata = buildChapterMediaMetadata(libraryItem, displayTitle, displayAuthor, currentChapter, unknownLabel)
+    } else {
+      navigator.mediaSession.metadata = buildMediaMetadata(libraryItem, displayTitle, displayAuthor, chapters, unknownLabel)
+    }
 
     return () => {
       navigator.mediaSession.metadata = null
     }
-  }, [enabled, libraryItem, displayAuthor, displayTitle, chapters])
+  }, [enabled, libraryItem, displayAuthor, displayTitle, chapters, useChapterTrack, currentChapter, unknownLabel])
 
   // Action handlers use refs so seek/jump callbacks changing with currentTime do not reset metadata.
   useEffect(() => {
@@ -75,9 +183,17 @@ export function useMediaSession({ libraryItem, playerHandler, onPreviousTrack, o
     navigator.mediaSession.setActionHandler('seekbackward', () => controlsRef.current.jumpBackward())
     navigator.mediaSession.setActionHandler('seekforward', () => controlsRef.current.jumpForward())
     navigator.mediaSession.setActionHandler('seekto', (details) => {
-      if (details.seekTime != null && !Number.isNaN(details.seekTime)) {
-        controlsRef.current.seek(details.seekTime)
+      if (details.seekTime == null || Number.isNaN(details.seekTime)) return
+
+      const chapter = currentChapterRef.current
+      if (useChapterTrackRef.current && chapter) {
+        const chapterDuration = chapter.end - chapter.start
+        const clampedSeekTime = Math.max(0, Math.min(details.seekTime, chapterDuration))
+        controlsRef.current.seek(chapter.start + clampedSeekTime)
+        return
       }
+
+      controlsRef.current.seek(details.seekTime)
     })
     navigator.mediaSession.setActionHandler('previoustrack', () => onPreviousTrackRef.current?.())
     navigator.mediaSession.setActionHandler('nexttrack', () => onNextTrackRef.current?.())
@@ -97,4 +213,27 @@ export function useMediaSession({ libraryItem, playerHandler, onPreviousTrack, o
     if (!enabled || !('mediaSession' in navigator)) return
     navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused'
   }, [enabled, isPlaying])
+
+  // Position state: subscribe to progress store directly so playback ticks do not re-render the player shell.
+  useEffect(() => {
+    if (!enabled || !('mediaSession' in navigator)) return
+
+    const updatePositionState = () => {
+      const { currentTime } = getPlayerProgress()
+      const { useChapterTrack, currentChapter, duration, playbackRate } = positionInputRef.current
+
+      setMediaSessionPositionState(
+        getMediaSessionPositionState({
+          useChapterTrack,
+          currentChapter,
+          currentTime,
+          duration,
+          playbackRate
+        })
+      )
+    }
+
+    updatePositionState()
+    return subscribePlayerProgress(updatePositionState)
+  }, [enabled, useChapterTrack, currentChapter, duration, settings.playbackRate])
 }

--- a/src/hooks/useMediaSession.ts
+++ b/src/hooks/useMediaSession.ts
@@ -10,8 +10,6 @@ const MEDIA_SESSION_ACTIONS = ['play', 'pause', 'stop', 'seekbackward', 'seekfor
 interface UseMediaSessionOptions {
   libraryItem: LibraryItem | null
   playerHandler: PlayerHandler
-  onPreviousTrack?: () => void
-  onNextTrack?: () => void
   enabled?: boolean
 }
 
@@ -125,14 +123,9 @@ function setMediaSessionPositionState(positionState: MediaPositionState | null) 
 }
 
 /** Wire lock-screen / OS media controls via the Media Session API (parity with Vue MediaPlayerContainer). */
-export function useMediaSession({ libraryItem, playerHandler, onPreviousTrack, onNextTrack, enabled = true }: UseMediaSessionOptions) {
+export function useMediaSession({ libraryItem, playerHandler, enabled = true }: UseMediaSessionOptions) {
   const t = useTypeSafeTranslations()
   const unknownLabel = t('LabelUnknown')
-
-  const onPreviousTrackRef = useRef(onPreviousTrack)
-  onPreviousTrackRef.current = onPreviousTrack
-  const onNextTrackRef = useRef(onNextTrack)
-  onNextTrackRef.current = onNextTrack
 
   const controlsRef = useRef(playerHandler.controls)
   controlsRef.current = playerHandler.controls
@@ -195,8 +188,9 @@ export function useMediaSession({ libraryItem, playerHandler, onPreviousTrack, o
 
       controlsRef.current.seek(details.seekTime)
     })
-    navigator.mediaSession.setActionHandler('previoustrack', () => onPreviousTrackRef.current?.())
-    navigator.mediaSession.setActionHandler('nexttrack', () => onNextTrackRef.current?.())
+    // Vue parity: prev/next track also jump (compact lock-screen UIs usually show seek OR track buttons, not both).
+    navigator.mediaSession.setActionHandler('previoustrack', () => controlsRef.current.jumpBackward())
+    navigator.mediaSession.setActionHandler('nexttrack', () => controlsRef.current.jumpForward())
 
     return () => {
       for (const action of MEDIA_SESSION_ACTIONS) {

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -592,6 +592,7 @@
   "LabelMaxEpisodesToKeep": "Max # of episodes to keep",
   "LabelMaxEpisodesToKeepHelp": "Value of 0 sets no max limit. After a new episode is auto-fetched this will delete the oldest episode if you have more than X episodes. This will only delete 1 episode per new fetch.",
   "LabelMediaPlayer": "Media Player",
+  "LabelMediaSessionTitleWithChapter": "{title}: {chapter}",
   "LabelMediaType": "Media Type",
   "LabelMetaTag": "Meta Tag",
   "LabelMetaTags": "Meta Tags",


### PR DESCRIPTION
Fixes #191 - when "Use chapter track" is enabled, the Media Session API reports chapter-relative duration/position so OS lock screen and notification scrubbers span only the current chapter. 

### Notable changes from Vue
- Lock screen metadata in chapter-track mode uses Audible-style layout: book title primary, chapter name secondary, author in album (Vue uses book title as primary, author as secondary, no chapter title)
- Position updates subscribe to the progress store directly so playback ticks do not re-render `MediaPlayerContainer`

### Not yet implemented
- Share player chapter-track Media Session support
  - Currently Share player is not identical to Vue and doesn't show the Settings button that lets you control "Use chapter track"
    - **Should we add a Settings button on the Share player**
- Always showing chapter name on lock screen when chapter track is off
  - When "Use chapter track" is off, we show title and author on the lock screen. 
    - **Shouldn't we show title and chapter (if chapters exist) even when "Use chapter track" is off? Audible does it, and I think it makes more sense. There's not much info gain in showing the author**