### PR TITLE
Underline inline links when hover is unavailable

### DIFF
--- a/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
+++ b/src/app/(main)/library/[library]/(book)/authors/[author]/AuthorClient.tsx
@@ -107,11 +107,11 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
         <div className="mt-8e -ms-2e">
           <ItemSlider
             title={
-              <Link href={`/library/${library.id}/items?filter=authors.${filterEncode(author.id)}`} className="transition-colors hover:underline">
+              <Link href={`/library/${library.id}/items?filter=authors.${filterEncode(author.id)}`} className="link-underline transition-colors">
                 {t('LabelXBooks', { count: libraryItems.length })}
               </Link>
             }
-            className="!ps-0"
+            className="ps-0!"
           >
             {libraryItems.map((libraryItem, entityIndex) => {
               const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
@@ -141,7 +141,7 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
       {series.map((bookSeries) => {
         const seriesTitle = (
           <>
-            <Link href={`/library/${library.id}/series/${bookSeries.id}`} className="transition-colors hover:underline">
+            <Link href={`/library/${library.id}/series/${bookSeries.id}`} className="link-underline transition-colors">
               {bookSeries.name}
             </Link>
             <span className="text-foreground-subdued ps-2e">{t('LabelSeries')}</span>
@@ -149,7 +149,7 @@ export default function AuthorClient({ author: authorProp }: AuthorClientProps) 
         )
         return (
           <div key={bookSeries.id} className="-ms-2e shrink-0">
-            <ItemSlider title={seriesTitle} className="!ps-0">
+            <ItemSlider title={seriesTitle} className="ps-0!">
               {bookSeries.items?.map((libraryItem, entityIndex) => {
                 const mediaProgress = libraryItem.media?.id ? getMediaItemProgress(libraryItem.media.id) : undefined
                 const seriesItems = bookSeries.items ?? []

--- a/src/app/(main)/library/[library]/(podcast)/add-podcast/AddPodcastClient.tsx
+++ b/src/app/(main)/library/[library]/(podcast)/add-podcast/AddPodcastClient.tsx
@@ -274,7 +274,7 @@ export default function AddPodcastClient() {
                   {podcast.pageUrl ? (
                     <a
                       href={podcast.pageUrl}
-                      className="text-foreground hover:text-foreground-muted text-base hover:underline md:text-lg"
+                      className="text-foreground hover:text-foreground-muted link-underline text-base md:text-lg"
                       target="_blank"
                       rel="noopener noreferrer"
                       onClick={(e) => e.stopPropagation()}

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -129,10 +129,10 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
       {accentRgb !== null ? (
         <div aria-hidden className="library-item-cover-accent-backdrop pointer-events-none absolute inset-0 z-0 h-[calc(100vh-var(--header-height))]" />
       ) : null}
-      <div className="relative z-[1] p-6 sm:p-8">
+      <div className="relative z-1 p-6 sm:p-8">
         <div className="mx-auto w-full max-w-6xl">
           <div className="flex flex-col gap-6 md:flex-row md:gap-8">
-            <div className="mx-auto flex w-full max-w-72 flex-shrink-0 items-start justify-center md:w-52 md:max-w-52 md:justify-start">
+            <div className="mx-auto flex w-full max-w-72 shrink-0 items-start justify-center md:w-52 md:max-w-52 md:justify-start">
               <LibraryItemCover
                 libraryItem={libraryItem}
                 canUpdate={userCanUpdate}
@@ -153,7 +153,7 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                     {bookSeries.map((series, index) => {
                       return (
                         <Fragment key={series.id}>
-                          <Link href={`/library/${library.id}/series/${series.id}`} className="text-foreground-muted text-lg hover:underline">
+                          <Link href={`/library/${library.id}/series/${series.id}`} className="text-foreground-muted link-underline text-lg">
                             {series.name}
                             {series.sequence && <span className="text-foreground-muted text-lg"> #{series.sequence}</span>}
                           </Link>
@@ -170,7 +170,7 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
                     {bookAuthors.map((author, index) => {
                       return (
                         <Fragment key={author.id}>
-                          <Link href={`/library/${library.id}/authors/${author.id}`} className="text-foreground text-lg hover:underline md:text-xl">
+                          <Link href={`/library/${library.id}/authors/${author.id}`} className="text-foreground link-underline text-lg md:text-xl">
                             {author.name}
                           </Link>
                           {index < bookAuthors.length - 1 && <span className="text-foreground text-lg md:text-xl">, </span>}

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemDetails.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemDetails.tsx
@@ -28,7 +28,7 @@ function DetailRow({ label, value, filterKey, libraryId }: DetailRowProps) {
     if (Array.isArray(value)) {
       displayValue = (value as string[]).map((v, index) => (
         <Fragment key={v}>
-          <Link href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(v)}`} className="text-foreground hover:underline">
+          <Link href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(v)}`} className="text-foreground link-underline">
             {v}
           </Link>
           {index < (value as string[]).length - 1 && <span className="text-foreground">, </span>}
@@ -36,7 +36,7 @@ function DetailRow({ label, value, filterKey, libraryId }: DetailRowProps) {
       ))
     } else {
       displayValue = (
-        <Link href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(value)}`} className="text-foreground hover:underline">
+        <Link href={`/library/${libraryId}/items?filter=${filterKey}.${filterEncode(value)}`} className="text-foreground link-underline">
           {value}
         </Link>
       )

--- a/src/app/(main)/library/[library]/stats/StatsClient.tsx
+++ b/src/app/(main)/library/[library]/stats/StatsClient.tsx
@@ -101,7 +101,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
               <div className="mb-1 flex items-end">
                 <p className="text-2xl font-bold">{`${stat.percentage}%`}</p>
                 <div className="grow"></div>
-                <Link href={stat.linkHref} className="text-foreground-subdued ml-2 hover:underline">
+                <Link href={stat.linkHref} className="text-foreground-subdued link-underline ml-2">
                   {stat.label}
                 </Link>
               </div>
@@ -119,7 +119,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
             {topAuthors.map((stat, index) => (
               <div key={index} className="mb-1 flex w-full items-center py-2 last:border-b-0">
                 <span className="text-foreground-subdued pr-1 text-sm">{`${index + 1}. `}</span>
-                <Link href={stat.linkHref} className="text-foreground-subdued truncate pr-2 text-sm hover:underline">
+                <Link href={stat.linkHref} className="text-foreground-subdued link-underline truncate pr-2 text-sm">
                   {stat.label}
                 </Link>
                 <div className="h-2.5 grow overflow-hidden rounded-full"></div>
@@ -140,7 +140,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
           {longestItems.map((stat, index) => (
             <div key={index} className="mb-1 flex w-full items-center justify-between py-2 last:border-b-0">
               <span className="text-foreground-subdued pr-1 text-sm">{`${index + 1}. `}</span>
-              <Link href={stat.linkHref} className="text-foreground-subdued w-3/4 truncate pr-2 text-sm hover:underline">
+              <Link href={stat.linkHref} className="text-foreground-subdued link-underline w-3/4 truncate pr-2 text-sm">
                 {`${stat.label}`}
               </Link>
               <div className="w-1/4 flex-shrink-0 text-right">
@@ -156,7 +156,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
           {largestItems.map((stat, index) => (
             <div key={index} className="mb-1 flex w-full items-center justify-between py-2 last:border-b-0">
               <span className="text-foreground-subdued pr-1 text-sm">{`${index + 1}. `}</span>
-              <Link href={stat.linkHref} className="text-foreground-subdued w-3/4 truncate pr-2 text-sm hover:underline">
+              <Link href={stat.linkHref} className="text-foreground-subdued link-underline w-3/4 truncate pr-2 text-sm">
                 {`${stat.label}`}
               </Link>
               <div className="w-1/4 flex-shrink-0 text-right">

--- a/src/app/(main)/library/[library]/stats/StatsClient.tsx
+++ b/src/app/(main)/library/[library]/stats/StatsClient.tsx
@@ -143,7 +143,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
               <Link href={stat.linkHref} className="text-foreground-subdued link-underline w-3/4 truncate pr-2 text-sm">
                 {`${stat.label}`}
               </Link>
-              <div className="w-1/4 flex-shrink-0 text-right">
+              <div className="w-1/4 shrink-0 text-right">
                 <p className="text-sm font-bold">{formatDuration(stats.longestItems[index].duration, t)}</p>
               </div>
             </div>
@@ -159,7 +159,7 @@ export default function StatsClient({ stats }: StatsClientProps) {
               <Link href={stat.linkHref} className="text-foreground-subdued link-underline w-3/4 truncate pr-2 text-sm">
                 {`${stat.label}`}
               </Link>
-              <div className="w-1/4 flex-shrink-0 text-right">
+              <div className="w-1/4 shrink-0 text-right">
                 {/* Displaying the absolute size directly */}
                 <p className="text-sm font-bold whitespace-nowrap">{stat.size}</p>
               </div>

--- a/src/app/(main)/settings/api-keys/ApiKeysTable.tsx
+++ b/src/app/(main)/settings/api-keys/ApiKeysTable.tsx
@@ -67,7 +67,7 @@ export default function ApiKeysTable({ apiKeys, onEditClick }: ApiKeysTableProps
     {
       label: t('LabelApiKeyUser'),
       accessor: (apiKey) => (
-        <Link href={`/settings/users/${apiKey.user.id}`} className="text-foreground hover:underline">
+        <Link href={`/settings/users/${apiKey.user.id}`} className="text-foreground link-underline">
           {apiKey.user.username}
         </Link>
       )

--- a/src/app/(main)/settings/libraries/LibrariesListRow.tsx
+++ b/src/app/(main)/settings/libraries/LibrariesListRow.tsx
@@ -80,7 +80,7 @@ export default function LibrariesListRow({ item, handleDeleteLibrary, handleEdit
   return (
     <div className="hover:bg-primary/20 text-foreground/50 hover:text-foreground flex items-center gap-4 px-4 py-1">
       {isLibraryTaskRunning ? <LoadingSpinner /> : <LibraryIcon icon={item.icon} />}
-      <Link className="text-foreground py-2 hover:underline" href={`/library/${item.id}`}>
+      <Link className="text-foreground link-underline py-2" href={`/library/${item.id}`}>
         {item.name}
       </Link>
       <div className="grow" />

--- a/src/app/(main)/settings/listening-sessions/ListeningSessionModal.tsx
+++ b/src/app/(main)/settings/listening-sessions/ListeningSessionModal.tsx
@@ -108,7 +108,7 @@ export default function ListeningSessionModal({ isOpen, session, onClose, onSess
         isOpen={isOpen}
         processing={isProcessing}
         onClose={onClose}
-        className="w-[calc(100vw-1rem)] md:max-w-[700px]"
+        className="w-[calc(100vw-1rem)] md:max-w-175"
         outerContent={<ModalOuterContent title={sessionTitle}>{sessionTitle}</ModalOuterContent>}
       >
         {currentSession && (

--- a/src/app/(main)/settings/listening-sessions/ListeningSessionModal.tsx
+++ b/src/app/(main)/settings/listening-sessions/ListeningSessionModal.tsx
@@ -118,7 +118,7 @@ export default function ListeningSessionModal({ isOpen, session, onClose, onSess
                 {currentSession.libraryId && currentSession.libraryItemId ? (
                   <Link
                     href={`/library/${currentSession.libraryId}/item/${currentSession.libraryItemId}`}
-                    className="text-foreground text-base hover:underline"
+                    className="text-foreground link-underline text-base"
                     onClick={onClose}
                   >
                     {currentSession.displayTitle}

--- a/src/app/(main)/settings/listening-sessions/ListeningSessionsTable.tsx
+++ b/src/app/(main)/settings/listening-sessions/ListeningSessionsTable.tsx
@@ -371,7 +371,7 @@ export default function ListeningSessionsTable({ users, sessionsResponse, openSe
         accessor: (session) => (
           <button
             type="button"
-            className="w-full cursor-pointer text-center font-mono text-xs hover:underline"
+            className="link-underline w-full cursor-pointer text-center font-mono text-xs"
             onClick={(e) => {
               e.stopPropagation()
               handlePromptResumePlayback(session)
@@ -596,7 +596,7 @@ function SessionListTable({
         accessor: (session) => (
           <button
             type="button"
-            className="w-full cursor-pointer text-center font-mono text-xs hover:underline"
+            className="link-underline w-full cursor-pointer text-center font-mono text-xs"
             onClick={(e) => {
               e.stopPropagation()
               onPromptResumePlayback(session)

--- a/src/app/(main)/settings/notifications/NotificationsClient.tsx
+++ b/src/app/(main)/settings/notifications/NotificationsClient.tsx
@@ -28,7 +28,7 @@ function toAppriseSettingsPatch(appriseApiUrl: string, maxNotificationQueue: str
 
 const appriseDescriptionTags = {
   appriseLink: (chunks: React.ReactNode) => (
-    <a href="https://github.com/caronc/apprise-api" target="_blank" className="text-blue-400 hover:text-blue-300 hover:underline" rel="noopener noreferrer">
+    <a href="https://github.com/caronc/apprise-api" target="_blank" className="link-underline text-blue-400 hover:text-blue-300" rel="noopener noreferrer">
       {chunks}
     </a>
   ),

--- a/src/app/(main)/settings/users/[user]/UserClient.tsx
+++ b/src/app/(main)/settings/users/[user]/UserClient.tsx
@@ -22,7 +22,7 @@ import UserListeningStatsSkeleton from './UserListeningStatsSkeleton'
 
 const legacyTokenTags = {
   apiKeysLink: (chunks: React.ReactNode) => (
-    <Link href="/settings/api-keys" className="text-blue-400 hover:text-blue-300 hover:underline">
+    <Link href="/settings/api-keys" className="link-underline text-blue-400 hover:text-blue-300">
       {chunks}
     </Link>
   )

--- a/src/assets/defaultStyles.css
+++ b/src/assets/defaultStyles.css
@@ -14,8 +14,14 @@
 }
 
 .default-style a {
-  text-decoration: none;
   color: #5985ff;
+  text-decoration-line: underline;
+}
+
+@media (hover: hover) {
+  .default-style a:not(:hover) {
+    text-decoration-line: none;
+  }
 }
 
 .default-style ul {

--- a/src/assets/globals.css
+++ b/src/assets/globals.css
@@ -150,11 +150,22 @@ body {
   outline-color: var(--heatmap-outline-fill);
 }
 
+/* Underline when hover is unavailable; underline on hover when it is (issue #219). */
+@utility link-underline {
+  text-decoration-line: underline;
+
+  @media (hover: hover) {
+    &:not(:hover) {
+      text-decoration-line: none;
+    }
+  }
+}
+
 /* SortableList: vertical-axis modifier can leave the pointer off the handle while dragging; keep grabbing cursor (see DND_POINTER_DRAG_HTML_CLASS). */
 @layer utilities {
   html.abs-dnd-pointer-dragging,
   html.abs-dnd-pointer-dragging * {
-    @apply !cursor-grabbing;
+    @apply cursor-grabbing!;
   }
 }
 

--- a/src/components/app/VersionFooter.tsx
+++ b/src/components/app/VersionFooter.tsx
@@ -35,7 +35,7 @@ export default function VersionFooter({ serverVersion, installSource, variant = 
             <p className="text-xxs text-foreground-subdued text-center italic">{installSource}</p>
           </div>
           {hasUpdate && githubTagUrl ? (
-            <a href={githubTagUrl} target="_blank" rel="noopener noreferrer" className="text-warning text-xs hover:underline">
+            <a href={githubTagUrl} target="_blank" rel="noopener noreferrer" className="text-warning link-underline text-xs">
               {t('LabelLatestVersionWithValue', { 0: versionData.latestVersion })}
             </a>
           ) : null}
@@ -56,7 +56,7 @@ export default function VersionFooter({ serverVersion, installSource, variant = 
         v{serverVersion}
       </button>
       {hasUpdate && githubTagUrl ? (
-        <a href={githubTagUrl} target="_blank" rel="noopener noreferrer" className="text-warning text-xxs block text-center leading-3 hover:underline">
+        <a href={githubTagUrl} target="_blank" rel="noopener noreferrer" className="text-warning link-underline text-xxs block text-center leading-3">
           {t('ButtonUpdate')}
         </a>
       ) : (

--- a/src/components/modals/AddToCollectionModal.tsx
+++ b/src/components/modals/AddToCollectionModal.tsx
@@ -55,12 +55,10 @@ export default function AddToCollectionModal({ isOpen, onClose, libraryId, libra
 
   const sortedCollections = useMemo((): CollectionRow[] => {
     return [...collections]
-      .map(
-        (collection): CollectionRow => ({
-          ...collection,
-          allBooksIncluded: collectionIncludesAllBooks(collection, libraryItemIds)
-        })
-      )
+      .map((collection): CollectionRow => ({
+        ...collection,
+        allBooksIncluded: collectionIncludesAllBooks(collection, libraryItemIds)
+      }))
       .sort((a, b) => {
         if (a.allBooksIncluded !== b.allBooksIncluded) {
           return a.allBooksIncluded ? -1 : 1
@@ -215,7 +213,7 @@ export default function AddToCollectionModal({ isOpen, onClose, libraryId, libra
                       <div className="min-w-0 flex-1 overflow-hidden px-2">
                         <Link
                           href={`/library/${libraryId}/collection/${collection.id}`}
-                          className="cursor-pointer truncate ps-2 pe-2 hover:underline"
+                          className="link-underline cursor-pointer truncate ps-2 pe-2"
                           onClick={() => onClose()}
                         >
                           {collection.name}

--- a/src/components/modals/AddToCollectionModal.tsx
+++ b/src/components/modals/AddToCollectionModal.tsx
@@ -7,8 +7,8 @@ import Modal from '@/components/modals/Modal'
 import ModalOuterContent from '@/components/modals/ModalOuterContent'
 import Btn from '@/components/ui/Btn'
 import IconBtn from '@/components/ui/IconBtn'
-import TextInput from '@/components/ui/TextInput'
 import MoreInfoIcon from '@/components/ui/MoreInfoIcon'
+import TextInput from '@/components/ui/TextInput'
 import CollectionGroupCover from '@/components/widgets/media-card/CollectionGroupCover'
 import { useBookCoverAspectRatio } from '@/contexts/LibraryContext'
 import { useGlobalToast } from '@/contexts/ToastContext'
@@ -206,7 +206,7 @@ export default function AddToCollectionModal({ isOpen, onClose, libraryId, libra
                   const books = collection.books ?? []
                   return (
                     <div key={collection.id} className="hover:bg-dropdown-item-hover relative flex items-center justify-start px-4 py-2">
-                      {included && <div className="bg-success absolute start-0 top-0 z-10 h-full w-1" aria-hidden />}
+                      {included && <div className="bg-success absolute inset-s-0 top-0 z-10 h-full w-1" aria-hidden />}
                       <div className="w-20 max-w-20 shrink-0 text-center">
                         <CollectionGroupCover books={books} width={coverWidth} height={coverHeight} />
                       </div>

--- a/src/components/modals/AddToPlaylistModal.tsx
+++ b/src/components/modals/AddToPlaylistModal.tsx
@@ -57,12 +57,10 @@ export default function AddToPlaylistModal({ isOpen, onClose, libraryId, items, 
 
   const sortedPlaylists = useMemo((): PlaylistRow[] => {
     return [...playlists]
-      .map(
-        (playlist): PlaylistRow => ({
-          ...playlist,
-          allItemsIncluded: playlistIncludesAllItems(playlist, items)
-        })
-      )
+      .map((playlist): PlaylistRow => ({
+        ...playlist,
+        allItemsIncluded: playlistIncludesAllItems(playlist, items)
+      }))
       .sort((a, b) => {
         if (a.allItemsIncluded !== b.allItemsIncluded) {
           return a.allItemsIncluded ? -1 : 1
@@ -219,7 +217,7 @@ export default function AddToPlaylistModal({ isOpen, onClose, libraryId, items, 
                       <div className="min-w-0 flex-1 overflow-hidden px-2">
                         <Link
                           href={`/library/${libraryId}/playlist/${playlist.id}`}
-                          className="cursor-pointer truncate ps-2 pe-2 hover:underline"
+                          className="link-underline cursor-pointer truncate ps-2 pe-2"
                           onClick={() => onClose()}
                         >
                           {playlist.name}

--- a/src/components/modals/AddToPlaylistModal.tsx
+++ b/src/components/modals/AddToPlaylistModal.tsx
@@ -6,8 +6,8 @@ import Modal from '@/components/modals/Modal'
 import ModalOuterContent from '@/components/modals/ModalOuterContent'
 import Btn from '@/components/ui/Btn'
 import IconBtn from '@/components/ui/IconBtn'
-import TextInput from '@/components/ui/TextInput'
 import MoreInfoIcon from '@/components/ui/MoreInfoIcon'
+import TextInput from '@/components/ui/TextInput'
 import PlaylistGroupCover from '@/components/widgets/media-card/PlaylistGroupCover'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
@@ -210,7 +210,7 @@ export default function AddToPlaylistModal({ isOpen, onClose, libraryId, items, 
                   const playlistItems = playlist.items ?? []
                   return (
                     <div key={playlist.id} className="hover:bg-dropdown-item-hover relative flex items-center justify-start px-4 py-2">
-                      {included && <div className="bg-success absolute start-0 top-0 z-10 h-full w-1" aria-hidden />}
+                      {included && <div className="bg-success absolute inset-s-0 top-0 z-10 h-full w-1" aria-hidden />}
                       <div className="w-20 max-w-20 shrink-0 text-center">
                         <PlaylistGroupCover items={playlistItems} width={coverWidth} height={coverHeight} />
                       </div>

--- a/src/components/modals/ViewEpisodeModal.tsx
+++ b/src/components/modals/ViewEpisodeModal.tsx
@@ -111,7 +111,7 @@ function ViewEpisodeModalBody({ onClose }: ViewEpisodeModalBodyProps) {
         <div className="min-w-0 grow px-2">
           <Link
             href={podcastHref}
-            className="focus-visible:outline-foreground-muted mb-1 inline-block max-w-full rounded-sm text-base underline focus-visible:outline-1 focus-visible:outline-offset-2 md:no-underline md:hover:underline"
+            className="focus-visible:outline-foreground-muted link-underline mb-1 inline-block max-w-full rounded-sm text-base focus-visible:outline-1 focus-visible:outline-offset-2"
             onClick={onClose}
           >
             <span className="block truncate">{podcastTitle}</span>

--- a/src/components/modals/ViewEpisodeModal.tsx
+++ b/src/components/modals/ViewEpisodeModal.tsx
@@ -92,7 +92,7 @@ function ViewEpisodeModalBody({ onClose }: ViewEpisodeModalBodyProps) {
 
   if (fetchPending && !episode) {
     return (
-      <div className="flex min-h-[200px] items-center justify-center">
+      <div className="flex min-h-50 items-center justify-center">
         <LoadingIndicator variant="inline" />
       </div>
     )
@@ -105,7 +105,7 @@ function ViewEpisodeModalBody({ onClose }: ViewEpisodeModalBodyProps) {
   return (
     <>
       <div className="mb-4 flex">
-        <div className="relative h-12 w-12 flex-shrink-0">
+        <div className="relative h-12 w-12 shrink-0">
           <PreviewCover src={coverUrl} fill bookCoverAspectRatio={1} showResolution={false} />
         </div>
         <div className="min-w-0 grow px-2">
@@ -127,7 +127,7 @@ function ViewEpisodeModalBody({ onClose }: ViewEpisodeModalBodyProps) {
       {parsedDescription ? (
         <div
           dir="auto"
-          className="default-style less-spacing break-words"
+          className="default-style less-spacing wrap-break-word"
           onClick={handleDescriptionClick}
           dangerouslySetInnerHTML={{ __html: parsedDescription }}
         />
@@ -170,7 +170,7 @@ export default function ViewEpisodeModal(props: ViewEpisodeModalProps) {
       isOpen={isOpen}
       onClose={onClose}
       {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem, episode: props.episode })}
-      className="bg-bg relative max-h-[80vh] w-[calc(100vw-1rem)] overflow-y-auto rounded-lg p-4 text-sm shadow-lg sm:w-[600px] md:w-[700px] lg:w-[800px]"
+      className="bg-bg relative max-h-[80vh] w-[calc(100vw-1rem)] overflow-y-auto rounded-lg p-4 text-sm shadow-lg sm:w-150 md:w-175 lg:w-200"
     >
       <ViewEpisodeModalBody onClose={onClose} />
     </EpisodeModal>

--- a/src/components/player/PlayerMetadataBlock.tsx
+++ b/src/components/player/PlayerMetadataBlock.tsx
@@ -38,9 +38,7 @@ export default function PlayerMetadataBlock({ streamLibraryItem, metadata, cover
         <Link
           href={`/library/${streamLibraryItem.libraryId}/item/${streamLibraryItem.id}`}
           className={
-            compact
-              ? 'text-foreground block truncate text-sm font-medium hover:underline'
-              : 'text-foreground block truncate text-lg font-medium hover:underline'
+            compact ? 'text-foreground link-underline block truncate text-sm font-medium' : 'text-foreground link-underline block truncate text-lg font-medium'
           }
         >
           {displayTitle}
@@ -53,7 +51,7 @@ export default function PlayerMetadataBlock({ streamLibraryItem, metadata, cover
             <div className="truncate ps-1">
               {bookAuthors.map((author, index) => (
                 <span key={author.id}>
-                  <Link href={`/library/${streamLibraryItem.libraryId}/authors/${author.id}`} className="text-foreground-muted hover:underline">
+                  <Link href={`/library/${streamLibraryItem.libraryId}/authors/${author.id}`} className="text-foreground-muted link-underline">
                     {author.name}
                   </Link>
                   {index < bookAuthors.length - 1 && <span className="text-foreground-muted">, </span>}

--- a/src/components/player/QueueItemsModal.tsx
+++ b/src/components/player/QueueItemsModal.tsx
@@ -94,7 +94,7 @@ export default function QueueItemsModal({ isOpen, onClose }: QueueItemsModalProp
   const renderQueueItemText = useCallback(
     (item: PlayerQueueItem) => {
       const title = item.title || ''
-      const titleClassName = 'text-foreground text-sm hover:underline'
+      const titleClassName = 'text-foreground link-underline text-sm'
       const titleFocusClassName = 'rounded-sm focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-2'
       const titleWrapperClassName = mergeClasses('block w-fit max-w-full min-w-0 px-0.5 text-start', titleFocusClassName)
 

--- a/src/components/player/QueueItemsModal.tsx
+++ b/src/components/player/QueueItemsModal.tsx
@@ -189,7 +189,7 @@ export default function QueueItemsModal({ isOpen, onClose }: QueueItemsModalProp
           <p className="text-foreground-subdued text-sm whitespace-nowrap transition-opacity group-focus-within:opacity-0 group-hover:opacity-0">
             {durationLabel}
           </p>
-          <div className="absolute inset-y-0 end-0 flex items-center justify-end opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+          <div className="absolute inset-y-0 inset-e-0 flex items-center justify-end opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
             {actionButtons}
           </div>
         </div>
@@ -215,7 +215,7 @@ export default function QueueItemsModal({ isOpen, onClose }: QueueItemsModalProp
   const outerContent = <ModalOuterContent>{t('HeaderPlayerQueue')}</ModalOuterContent>
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} outerContent={outerContent} className="sm:max-w-[800px] md:max-w-[800px] lg:max-w-[800px]">
+    <Modal isOpen={isOpen} onClose={onClose} outerContent={outerContent} className="sm:max-w-200 md:max-w-200 lg:max-w-200">
       <div className="max-h-[80vh] w-full min-w-0 overflow-x-hidden overflow-y-auto py-4">
         <div className="flex items-center px-4 pb-4">
           <p className="text-foreground-muted shrink-0 text-base">{queueCountLabel}</p>

--- a/src/components/ui/MetadataEditTable.tsx
+++ b/src/components/ui/MetadataEditTable.tsx
@@ -172,7 +172,7 @@ export default function MetadataEditTable({ items, onItemEditSaveClick, onItemDe
     <tr className="group even:bg-primary/20 p-2">
       <td className="p-3.5">
         {showNumBooks ? (
-          <Link className="text-foreground text-sm hover:underline md:text-base" title={item.name} href={narratorHref(item)}>
+          <Link className="text-foreground link-underline text-sm md:text-base" title={item.name} href={narratorHref(item)}>
             {item.name}
           </Link>
         ) : (
@@ -184,7 +184,7 @@ export default function MetadataEditTable({ items, onItemEditSaveClick, onItemDe
       {showNumBooks && (
         <td className="w-1/6 md:table-cell">
           <div className="flex justify-center">
-            <Link className="text-foreground text-sm hover:underline md:text-base" href={narratorHref(item)}>
+            <Link className="text-foreground link-underline text-sm md:text-base" href={narratorHref(item)}>
               {item.numBooks}
             </Link>
           </div>
@@ -225,7 +225,7 @@ export default function MetadataEditTable({ items, onItemEditSaveClick, onItemDe
         {showNumBooks && (
           <td className="w-1/6 md:table-cell">
             <div className="flex justify-center">
-              <a className="text-sm hover:underline md:text-base">{item.numBooks}</a>
+              <a className="link-underline text-sm md:text-base">{item.numBooks}</a>
             </div>
           </td>
         )}

--- a/src/components/ui/slate/constants.ts
+++ b/src/components/ui/slate/constants.ts
@@ -14,6 +14,6 @@ export const slateElementStyles = mergeClasses(
   '[&_ul]:list-disc [&_ul]:list-outside',
   '[&_ol]:list-decimal [&_ol]:list-outside',
   '[&_li]:text-start [&_li]:ms-4',
-  '[&_a]:text-blue-500 [&_a]:hover:underline [&_a]:hover:text-blue-400',
+  '[&_a]:text-blue-500 [&_a]:link-underline [&_a]:hover:text-blue-400',
   '[&>*:not(:last-child)]:mb-1.5'
 )

--- a/src/components/widgets/ChaptersTable.tsx
+++ b/src/components/widgets/ChaptersTable.tsx
@@ -48,7 +48,7 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
           return onGoToTimestamp ? (
             <button
               type="button"
-              className="cursor-pointer bg-transparent p-0 font-mono hover:underline"
+              className="link-underline cursor-pointer bg-transparent p-0 font-mono"
               onClick={(e) => {
                 e.stopPropagation()
                 onGoToTimestamp(row.start)

--- a/src/components/widgets/ChaptersTable.tsx
+++ b/src/components/widgets/ChaptersTable.tsx
@@ -35,7 +35,7 @@ export default function ChaptersTable({ libraryItem, keepOpen = false, expanded:
     () => [
       {
         label: t('LabelTitle'),
-        accessor: (row: Chapter) => <span className="break-words">{row.title}</span>,
+        accessor: (row: Chapter) => <span className="wrap-break-word">{row.title}</span>,
         headerClassName: 'min-w-0 px-2 text-start md:px-4',
         cellClassName: 'max-w-0 min-w-0 px-2 md:px-4'
       },

--- a/src/components/widgets/CurrentDownloadRow.tsx
+++ b/src/components/widgets/CurrentDownloadRow.tsx
@@ -34,7 +34,7 @@ export default function CurrentDownloadRow({ episode }: CurrentDownloadRowProps)
           <PreviewCover src={coverSrc} width={48} bookCoverAspectRatio={bookCoverAspectRatio} showResolution={false} />
           <div className="grow px-2">
             <div className="flex items-center">
-              <Link href={itemHref} className="text-foreground-muted hover:text-foreground text-sm hover:underline">
+              <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline text-sm">
                 {episode.podcastTitle}
               </Link>
               {episode.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}
@@ -45,7 +45,7 @@ export default function CurrentDownloadRow({ episode }: CurrentDownloadRowProps)
 
         <div className="hidden md:block">
           <div className="flex items-center">
-            <Link href={itemHref} className="text-foreground-muted hover:text-foreground text-sm hover:underline">
+            <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline text-sm">
               {episode.podcastTitle}
             </Link>
             {episode.podcastExplicit && <ExplicitIndicator className="ms-1 shrink-0" />}

--- a/src/components/widgets/LibraryItemSubpageHeader.tsx
+++ b/src/components/widgets/LibraryItemSubpageHeader.tsx
@@ -35,7 +35,7 @@ export default function LibraryItemSubpageHeader({ libraryItem, libraryId, itemI
           <div className="me-3 shrink-0">
             <PreviewCover src={coverSrc} width={COVER_HEIGHT / bookCoverAspectRatio} showResolution={false} />
           </div>
-          <Link href={`/library/${libraryId}/item/${itemId}`} className="hover:underline">
+          <Link href={`/library/${libraryId}/item/${itemId}`} className="link-underline">
             <h1 className="text-lg lg:text-xl">{title}</h1>
           </Link>
           <IconBtn ariaLabel={t('ButtonEdit')} borderless size="small" className="ml-2" onClick={onEditClick}>

--- a/src/components/widgets/PodcastDownloadQueueTable.tsx
+++ b/src/components/widgets/PodcastDownloadQueueTable.tsx
@@ -68,7 +68,7 @@ export default function PodcastDownloadQueueTable({ queue }: PodcastDownloadQueu
           <div className="flex items-center">
             <Link
               href={`/library/${library.id}/item/${item.libraryItemId}`}
-              className="text-foreground-muted hover:text-foreground text-start text-sm hover:underline"
+              className="text-foreground-muted hover:text-foreground link-underline text-start text-sm"
             >
               {item.podcastTitle}
             </Link>

--- a/src/components/widgets/RecentEpisodeRow.tsx
+++ b/src/components/widgets/RecentEpisodeRow.tsx
@@ -125,7 +125,7 @@ export default function RecentEpisodeRow({ episode, episodeIndex, episodes }: Re
           <PreviewCover src={coverSrc} width={48} bookCoverAspectRatio={bookCoverAspectRatio} showResolution={false} />
           <div className="min-w-0 flex-1 px-2">
             <div className="flex min-w-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-              <Link href={itemHref} className="text-foreground-muted hover:text-foreground min-w-0 flex-1 text-sm break-words hover:underline">
+              <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline min-w-0 flex-1 text-sm break-words">
                 {podcastTitle}
               </Link>
               {isExplicit && <ExplicitIndicator className="shrink-0" />}
@@ -136,7 +136,7 @@ export default function RecentEpisodeRow({ episode, episodeIndex, episodes }: Re
 
         <div className="hidden md:block">
           <div className="flex min-w-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-            <Link href={itemHref} className="text-foreground-muted hover:text-foreground min-w-0 text-sm break-words hover:underline">
+            <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline min-w-0 text-sm break-words">
               {podcastTitle}
             </Link>
             {isExplicit && <ExplicitIndicator className="shrink-0" />}

--- a/src/components/widgets/RecentEpisodeRow.tsx
+++ b/src/components/widgets/RecentEpisodeRow.tsx
@@ -125,7 +125,7 @@ export default function RecentEpisodeRow({ episode, episodeIndex, episodes }: Re
           <PreviewCover src={coverSrc} width={48} bookCoverAspectRatio={bookCoverAspectRatio} showResolution={false} />
           <div className="min-w-0 flex-1 px-2">
             <div className="flex min-w-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-              <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline min-w-0 flex-1 text-sm break-words">
+              <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline min-w-0 flex-1 text-sm wrap-break-word">
                 {podcastTitle}
               </Link>
               {isExplicit && <ExplicitIndicator className="shrink-0" />}
@@ -136,7 +136,7 @@ export default function RecentEpisodeRow({ episode, episodeIndex, episodes }: Re
 
         <div className="hidden md:block">
           <div className="flex min-w-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-            <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline min-w-0 text-sm break-words">
+            <Link href={itemHref} className="text-foreground-muted hover:text-foreground link-underline min-w-0 text-sm wrap-break-word">
               {podcastTitle}
             </Link>
             {isExplicit && <ExplicitIndicator className="shrink-0" />}
@@ -156,7 +156,7 @@ export default function RecentEpisodeRow({ episode, episodeIndex, episodes }: Re
           <button
             type="button"
             disabled={isPending}
-            className="focus-visible:outline-foreground-muted min-w-0 flex-1 cursor-pointer rounded-sm text-start text-sm font-semibold break-words focus-visible:outline-1 focus-visible:outline-offset-4 md:text-base"
+            className="focus-visible:outline-foreground-muted min-w-0 flex-1 cursor-pointer rounded-sm text-start text-sm font-semibold wrap-break-word focus-visible:outline-1 focus-visible:outline-offset-4 md:text-base"
             onClick={(e) => {
               e.stopPropagation()
               handleRowClick()
@@ -171,7 +171,7 @@ export default function RecentEpisodeRow({ episode, episodeIndex, episodes }: Re
         {descriptionHtml && (
           <div
             dir="auto"
-            className="text-foreground-muted mb-4 line-clamp-4 min-w-0 text-sm break-words [&_*]:break-words"
+            className="text-foreground-muted mb-4 line-clamp-4 min-w-0 text-sm wrap-break-word **:wrap-break-word"
             dangerouslySetInnerHTML={{ __html: descriptionHtml }}
             onClick={(e) => {
               if ((e.target as HTMLElement).tagName.toLowerCase() === 'a') {

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -39,7 +39,9 @@ import { isBookMedia, isBookMetadata, isPodcastLibraryItem, isPodcastMedia } fro
 import Link from 'next/link'
 import { useCallback, useMemo, useState, useTransition } from 'react'
 
-const COMPILATION_ROW_LINK_FOCUS = 'rounded-sm px-1e py-0.5e focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-0'
+// z-[2] sits above the mobile full-row hit target (z-[1]) so series/author taps are not captured.
+const COMPILATION_ROW_LINK_FOCUS =
+  'relative z-2 rounded-sm px-1e py-0.5e focus-visible:outline-1 focus-visible:outline-foreground-muted focus-visible:outline-offset-0'
 
 export type CompilationItemListRowContext = { kind: 'collection'; collectionId: string } | { kind: 'playlist'; playlistId: string }
 
@@ -306,7 +308,7 @@ function CompilationItemListRowBody({
                 type="button"
                 onClick={handleViewEpisode}
                 className={mergeClasses(
-                  'focus-visible:outline-foreground-muted absolute inset-0 z-[1] cursor-pointer rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
+                  'focus-visible:outline-foreground-muted absolute inset-0 z-1 cursor-pointer rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
                   isDragging && 'pointer-events-none'
                 )}
                 aria-label={itemTitle}
@@ -315,7 +317,7 @@ function CompilationItemListRowBody({
               <Link
                 href={itemHref}
                 className={mergeClasses(
-                  'focus-visible:outline-foreground-muted absolute inset-0 z-[1] rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
+                  'focus-visible:outline-foreground-muted absolute inset-0 z-1 rounded-sm focus-visible:outline-1 focus-visible:outline-offset-0 md:hidden',
                   isDragging && 'pointer-events-none'
                 )}
                 aria-label={itemTitle}
@@ -416,7 +418,7 @@ function CompilationItemListRowBody({
         </div>
 
         {showMobilePlayBtn && (
-          <div className="pe-1e relative z-[2] flex shrink-0 items-center">
+          <div className="pe-1e relative z-2 flex shrink-0 items-center">
             <IconBtn borderless size="custom" className={EPISODE_ROW_ACTION_BTN_CLASS} ariaLabel={t('ButtonPlay')} onClick={handlePlayClick}>
               play_arrow
             </IconBtn>

--- a/src/components/widgets/compilation/CompilationItemListRow.tsx
+++ b/src/components/widgets/compilation/CompilationItemListRow.tsx
@@ -348,7 +348,7 @@ function CompilationItemListRowBody({
                     type="button"
                     onClick={handleViewEpisode}
                     className={mergeClasses(
-                      'text-foreground inline-block w-fit max-w-full cursor-pointer text-start text-[0.875em] hover:underline md:text-[1em]',
+                      'text-foreground link-underline inline-block w-fit max-w-full cursor-pointer text-start text-[0.875em] md:text-[1em]',
                       COMPILATION_ROW_LINK_FOCUS
                     )}
                     title={itemTitle}
@@ -359,7 +359,7 @@ function CompilationItemListRowBody({
                   <Link
                     href={itemHref}
                     className={mergeClasses(
-                      'text-foreground inline-block w-fit max-w-full text-[0.875em] hover:underline md:text-[1em]',
+                      'text-foreground link-underline inline-block w-fit max-w-full text-[0.875em] md:text-[1em]',
                       COMPILATION_ROW_LINK_FOCUS
                     )}
                     title={itemTitle}
@@ -374,13 +374,9 @@ function CompilationItemListRowBody({
               )}
               {episode && mediaMetadata?.title && (
                 <div className="text-foreground-muted min-w-0 text-[0.75em] md:text-[0.875em]">
-                  {isMdUp ? (
-                    <Link href={itemHref} className={mergeClasses('inline-block hover:underline', COMPILATION_ROW_LINK_FOCUS)}>
-                      {mediaMetadata.title}
-                    </Link>
-                  ) : (
-                    <span className="inline-block">{mediaMetadata.title}</span>
-                  )}
+                  <Link href={itemHref} className={mergeClasses('link-underline inline-block', COMPILATION_ROW_LINK_FOCUS)}>
+                    {mediaMetadata.title}
+                  </Link>
                 </div>
               )}
               {bookSeries.length > 0 && (
@@ -388,20 +384,13 @@ function CompilationItemListRowBody({
                   {bookSeries.map((series, idx) => (
                     <span key={series.id}>
                       {idx > 0 && ' '}
-                      {isMdUp ? (
-                        <Link
-                          href={`/library/${libraryItem.libraryId}/series/${series.id}`}
-                          className={mergeClasses('inline-block font-sans hover:underline', COMPILATION_ROW_LINK_FOCUS)}
-                        >
-                          {series.name}
-                          {series.sequence && ` #${series.sequence}`}
-                        </Link>
-                      ) : (
-                        <span className="inline-block font-sans">
-                          {series.name}
-                          {series.sequence && ` #${series.sequence}`}
-                        </span>
-                      )}
+                      <Link
+                        href={`/library/${libraryItem.libraryId}/series/${series.id}`}
+                        className={mergeClasses('link-underline inline-block font-sans', COMPILATION_ROW_LINK_FOCUS)}
+                      >
+                        {series.name}
+                        {series.sequence && ` #${series.sequence}`}
+                      </Link>
                     </span>
                   ))}
                 </div>
@@ -410,16 +399,12 @@ function CompilationItemListRowBody({
                 <div className="text-foreground-muted min-w-0 text-[0.75em] md:text-[0.875em]">
                   {bookAuthors.map((author, index) => (
                     <span key={author.id}>
-                      {isMdUp ? (
-                        <Link
-                          href={`/library/${libraryItem.libraryId}/authors/${author.id}`}
-                          className={mergeClasses('inline-block hover:underline', COMPILATION_ROW_LINK_FOCUS)}
-                        >
-                          {author.name}
-                        </Link>
-                      ) : (
-                        <span className="inline-block">{author.name}</span>
-                      )}
+                      <Link
+                        href={`/library/${libraryItem.libraryId}/authors/${author.id}`}
+                        className={mergeClasses('link-underline inline-block', COMPILATION_ROW_LINK_FOCUS)}
+                      >
+                        {author.name}
+                      </Link>
                       {index < bookAuthors.length - 1 && <>,&nbsp;</>}
                     </span>
                   ))}

--- a/src/components/widgets/match/MultiSelectMatchFieldEditor.tsx
+++ b/src/components/widgets/match/MultiSelectMatchFieldEditor.tsx
@@ -55,7 +55,7 @@ function MultiSelectMatchFieldEditor({
     ? t.rich('MessageCurrentlyWithLink', {
         0: format.list(currentValue, { type: 'unit' }),
         link: (chunks) => (
-          <a title={t('LabelClickToUseCurrentValue')} className="cursor-pointer hover:underline" onClick={handleUseCurrentValue}>
+          <a title={t('LabelClickToUseCurrentValue')} className="link-underline cursor-pointer" onClick={handleUseCurrentValue}>
             {chunks}
           </a>
         )

--- a/src/components/widgets/match/SlateEditorMatchFieldEditor.tsx
+++ b/src/components/widgets/match/SlateEditorMatchFieldEditor.tsx
@@ -32,7 +32,7 @@ function SlateEditorMatchFieldEditor({ usageChecked, onUsageChange, value, onCha
     ? t.rich('MessageCurrentlyWithLink', {
         0: formattedValue,
         link: (chunks) => (
-          <a title={t('LabelClickToUseCurrentValue')} className="cursor-pointer hover:underline" onClick={handleUseCurrentValue}>
+          <a title={t('LabelClickToUseCurrentValue')} className="link-underline cursor-pointer" onClick={handleUseCurrentValue}>
             {chunks}
           </a>
         )

--- a/src/components/widgets/match/TextInputMatchFieldEditor.tsx
+++ b/src/components/widgets/match/TextInputMatchFieldEditor.tsx
@@ -44,7 +44,7 @@ function TextInputMatchFieldEditor({
     ? t.rich('MessageCurrentlyWithLink', {
         0: String(currentValue),
         link: (chunks) => (
-          <a title={t('LabelClickToUseCurrentValue')} className="cursor-pointer hover:underline" onClick={handleUseCurrentValue}>
+          <a title={t('LabelClickToUseCurrentValue')} className="link-underline cursor-pointer" onClick={handleUseCurrentValue}>
             {chunks}
           </a>
         )

--- a/src/components/widgets/match/TwoStageMultiSelectMatchFieldEditor.tsx
+++ b/src/components/widgets/match/TwoStageMultiSelectMatchFieldEditor.tsx
@@ -67,7 +67,7 @@ function TwoStageMultiSelectMatchFieldEditor({
     ? t.rich('MessageCurrentlyWithLink', {
         0: formattedValue,
         link: (chunks) => (
-          <a title={t('LabelClickToUseCurrentValue')} className="cursor-pointer hover:underline" onClick={handleUseCurrentValue}>
+          <a title={t('LabelClickToUseCurrentValue')} className="link-underline cursor-pointer" onClick={handleUseCurrentValue}>
             {chunks}
           </a>
         )


### PR DESCRIPTION
fixes #219

## Notable changes
- Add a `link-underline` utility
   - always underlines when hover is unavailable
   - underlines on hover when it is (`@media (hover: hover)`).
- Apply it to inline `<Link>` / `<a>` text (and similar clickable table cells)

Card/row/menu surfaces, icon-only links, and already-permanent underlines (e.g. settings footer) are unchanged.

## Testing
- Mobile: author, series, stats, player metadata, and similar inline links are underlined at rest
- Desktop with a mouse: those links have no underline at rest and underline on hover
- Collection/playlist list view on mobile: series, author, and episode subtitle are tappable links
- Cover cards, search results, notification task rows, and help icons still have no underline