### PR TITLE
Distinguish dropdown selected state from focus and hover

### DIFF
--- a/cypress/tests/components/app/UserAppBarNav.cy.tsx
+++ b/cypress/tests/components/app/UserAppBarNav.cy.tsx
@@ -1,8 +1,8 @@
 import UserAppBarNav from '@/app/(main)/UserAppBarNav'
 import { UserContext, type UserContextType } from '@/contexts/UserContext'
 import { User } from '@/types/api'
-import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { AppRouterContext } from 'next/dist/shared/lib/app-router-context.shared-runtime'
 import * as navigation from 'next/navigation'
 import { ReactNode } from 'react'
 
@@ -79,7 +79,7 @@ function mountUserAppBarNav(props: { username?: string } = {}, options?: { align
   const ui: ReactNode = (
     <UserContext.Provider value={createMockUserContextValue(user)}>
       <AppRouterContext.Provider value={router}>
-        {options?.alignEnd ? <div className="absolute end-0">{userAppBarNav}</div> : userAppBarNav}
+        {options?.alignEnd ? <div className="absolute inset-e-0">{userAppBarNav}</div> : userAppBarNav}
       </AppRouterContext.Provider>
     </UserContext.Provider>
   )
@@ -107,12 +107,12 @@ describe('<UserAppBarNav /> desktop keyboard navigation', () => {
     mountUserAppBarNav()
     desktopMenuTrigger().focus().type('{enter}')
     desktopMenuTrigger().should('have.focus')
-    cy.get('[role="menuitem"]').eq(0).should('have.class', 'bg-dropdown-item-selected')
+    cy.get('[role="menuitem"]').eq(0).should('have.class', 'bg-dropdown-item-focused')
     desktopMenuTrigger().type('{downarrow}')
-    cy.get('[role="menuitem"]').eq(1).should('have.class', 'bg-dropdown-item-selected')
+    cy.get('[role="menuitem"]').eq(1).should('have.class', 'bg-dropdown-item-focused')
     desktopMenuTrigger().should('have.focus')
     desktopMenuTrigger().type('{uparrow}')
-    cy.get('[role="menuitem"]').eq(0).should('have.class', 'bg-dropdown-item-selected')
+    cy.get('[role="menuitem"]').eq(0).should('have.class', 'bg-dropdown-item-focused')
   })
 
   it('closes the menu with Escape and returns focus to the trigger', () => {
@@ -128,9 +128,9 @@ describe('<UserAppBarNav /> desktop keyboard navigation', () => {
     mountUserAppBarNav()
     desktopMenuTrigger().focus().type('{enter}')
     desktopMenuTrigger().type('{end}')
-    cy.get('[role="menuitem"]').last().should('have.class', 'bg-dropdown-item-selected')
+    cy.get('[role="menuitem"]').last().should('have.class', 'bg-dropdown-item-focused')
     desktopMenuTrigger().type('{home}')
-    cy.get('[role="menuitem"]').first().should('have.class', 'bg-dropdown-item-selected')
+    cy.get('[role="menuitem"]').first().should('have.class', 'bg-dropdown-item-focused')
     desktopMenuTrigger().should('have.focus')
   })
 

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -203,13 +203,14 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
-    it('moves visual focus to the hovered item without losing the selected highlight', () => {
+    it('does not move keyboard focus when an item is hovered', () => {
       cy.mount(<Dropdown items={mockItems} value="option1" />)
       cy.get('button').click()
-      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-focused')
+      cy.realType('{downarrow}')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
       cy.get('[role="listbox"] > li').eq(2).trigger('mouseover')
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-focused')
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'bg-dropdown-item-focused')
       cy.get('[role="listbox"] > li').first().should('have.class', 'text-dropdown-item-selected')
       cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'text-dropdown-item-selected')
     })

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -177,7 +177,7 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"] > li').each(($el) => {
         cy.wrap($el).should('not.have.class', 'bg-dropdown-item-selected')
       })
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-dropdown-item-highlight')
     })
 
     it('focuses the first item when opened with ArrowDown', () => {
@@ -186,7 +186,7 @@ describe('<Dropdown />', () => {
       cy.get('button').type('{downarrow}')
       cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
       cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-dropdown-item-highlight')
     })
 
     it('focuses the first item when opened with Enter', () => {
@@ -210,8 +210,8 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"] > li').eq(2).trigger('mouseover')
       cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-selected')
       cy.get('[role="listbox"] > li').first().should('not.have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'text-yellow-400')
-      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('keeps selected highlight distinct from keyboard focus', () => {
@@ -220,8 +220,8 @@ describe('<Dropdown />', () => {
       cy.realType('{downarrow}')
       cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
       cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('navigates through menu items with ArrowDown', () => {
@@ -507,11 +507,11 @@ describe('<Dropdown />', () => {
     it('highlights the selected subitem and its parent', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} value="sub2" />)
       cy.get('button').click()
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
       cy.get('[role="listbox"] > li').eq(1).trigger('mouseover')
-      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-yellow-400')
-      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('selects subitem on click', () => {
@@ -777,24 +777,24 @@ describe('<Dropdown />', () => {
     it('highlights selected item by default', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" />)
       cy.get('button').click()
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('highlights selected item when highlightSelected is true', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" highlightSelected={true} />)
       cy.get('button').click()
       // The selected item (option2, index 1) should have yellow text
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
       // Other items should not have yellow text
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('does not highlight selected item when highlightSelected is false', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" highlightSelected={false} />)
       cy.get('button').click()
       // The selected item should not have yellow text
-      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('does not highlight when no value is selected', () => {
@@ -802,7 +802,7 @@ describe('<Dropdown />', () => {
       cy.get('button').click()
       // No items should have yellow text
       cy.get('[role="listbox"] > li').each(($el) => {
-        cy.wrap($el).should('not.have.class', 'text-yellow-400')
+        cy.wrap($el).should('not.have.class', 'text-dropdown-item-highlight')
       })
     })
   })

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -170,11 +170,58 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"]').should('be.visible')
     })
 
-    it('has visual focus on the first item when menu is open', () => {
-      cy.mount(<Dropdown items={mockItems} />)
+    it('does not focus a menu item when opened by click', () => {
+      cy.mount(<Dropdown items={mockItems} value="option3" />)
       cy.get('button').click()
       cy.get('[role="listbox"]').should('be.visible')
+      cy.get('[role="listbox"] > li').each(($el) => {
+        cy.wrap($el).should('not.have.class', 'bg-dropdown-item-selected')
+      })
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-yellow-400')
+    })
+
+    it('focuses the first item when opened with ArrowDown', () => {
+      cy.mount(<Dropdown items={mockItems} value="option3" />)
+      cy.get('button').focus()
+      cy.get('button').type('{downarrow}')
       cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-yellow-400')
+    })
+
+    it('focuses the first item when opened with Enter', () => {
+      cy.mount(<Dropdown items={mockItems} />)
+      cy.get('button').focus()
+      cy.get('button').type('{enter}')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+    })
+
+    it('focuses the last item when ArrowUp is pressed after opening by click', () => {
+      cy.mount(<Dropdown items={mockItems} />)
+      cy.get('button').click()
+      cy.realType('{uparrow}')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+    })
+
+    it('moves visual focus to the hovered item without losing the selected highlight', () => {
+      cy.mount(<Dropdown items={mockItems} value="option1" />)
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(2).trigger('mouseover')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'text-yellow-400')
+    })
+
+    it('keeps selected highlight distinct from keyboard focus', () => {
+      cy.mount(<Dropdown items={mockItems} value="option2" />)
+      cy.get('button').click()
+      cy.realType('{downarrow}')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-yellow-400')
     })
 
     it('navigates through menu items with ArrowDown', () => {
@@ -182,7 +229,9 @@ describe('<Dropdown />', () => {
       cy.get('button').click()
       cy.get('[role="listbox"]').should('be.visible')
 
-      // First item should be focused
+      // Click-open has no focused item; first ArrowDown focuses the first item
+      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-selected')
+      cy.realType('{downarrow}')
       cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
 
       // Navigate to second item
@@ -373,9 +422,11 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"]').should('have.attr', 'id')
     })
 
-    it('has proper ARIA active descendant', () => {
+    it('has no ARIA active descendant until an item is focused', () => {
       cy.mount(<Dropdown items={mockItems} />)
       cy.get('button').click()
+      cy.get('button').should('not.have.attr', 'aria-activedescendant')
+      cy.realType('{downarrow}')
       cy.get('button').should('have.attr', 'aria-activedescendant')
     })
   })
@@ -485,7 +536,8 @@ describe('<Dropdown />', () => {
     it('navigates to submenu with ArrowRight key', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} />)
       cy.get('button').click()
-      // Navigate to item with subitems
+      // Click-open has no focused item; move to the submenu parent
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       // Open submenu with right arrow
       cy.realType('{rightarrow}')
@@ -499,6 +551,7 @@ describe('<Dropdown />', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} />)
       cy.get('button').click()
       cy.realType('{downarrow}')
+      cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       cy.get('[role="menu"]').should('exist')
       cy.realType('{leftarrow}')
@@ -508,6 +561,7 @@ describe('<Dropdown />', () => {
     it('navigates within submenu with ArrowUp/ArrowDown', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} />)
       cy.get('button').click()
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // First subitem focused
@@ -525,6 +579,7 @@ describe('<Dropdown />', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} onChange={onChangeSpy} />)
       cy.get('button').click()
       cy.realType('{downarrow}')
+      cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       cy.realType('{enter}')
       cy.get('@onChangeSpy').should('have.been.calledWith', 'sub1')
@@ -534,6 +589,7 @@ describe('<Dropdown />', () => {
     it('closes submenu with Escape without closing main menu', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} />)
       cy.get('button').click()
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       cy.get('[role="menu"]').should('exist')
@@ -572,7 +628,8 @@ describe('<Dropdown />', () => {
     it('filters submenu items when typing characters', () => {
       cy.mount(<Dropdown items={itemsWithLargeSubmenu} />)
       cy.get('button').click()
-      // Navigate to item with submenu
+      // Click-open has no focused item; move to the submenu parent
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       // Open submenu
       cy.realType('{rightarrow}')
@@ -585,6 +642,7 @@ describe('<Dropdown />', () => {
     it('shows filter text indicator in submenu', () => {
       cy.mount(<Dropdown items={itemsWithLargeSubmenu} />)
       cy.get('button').click()
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // Type 'ban' to filter
@@ -599,6 +657,7 @@ describe('<Dropdown />', () => {
     it('clears filter with Backspace key', () => {
       cy.mount(<Dropdown items={itemsWithLargeSubmenu} />)
       cy.get('button').click()
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // Type 'ch' to filter to Cherry only
@@ -618,6 +677,7 @@ describe('<Dropdown />', () => {
       cy.mount(<Dropdown items={itemsWithLargeSubmenu} />)
       cy.get('button').click()
       cy.realType('{downarrow}')
+      cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // Type 'xyz' which matches nothing
       cy.realType('xyz')
@@ -630,6 +690,7 @@ describe('<Dropdown />', () => {
       cy.mount(<Dropdown items={itemsWithLargeSubmenu} onChange={onChangeSpy} />)
       cy.get('button').click()
       cy.realType('{downarrow}')
+      cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // Type 'ban' to filter to Banana
       cy.realType('ban')
@@ -641,6 +702,7 @@ describe('<Dropdown />', () => {
     it('clears filter when closing submenu', () => {
       cy.mount(<Dropdown items={itemsWithLargeSubmenu} />)
       cy.get('button').click()
+      cy.realType('{downarrow}')
       cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // Type 'ch' to filter
@@ -702,6 +764,13 @@ describe('<Dropdown />', () => {
     })
   })
   describe('highlightSelected Prop', () => {
+    it('highlights selected item by default', () => {
+      cy.mount(<Dropdown items={mockItems} value="option2" />)
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-yellow-400')
+    })
+
     it('highlights selected item when highlightSelected is true', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" highlightSelected={true} />)
       cy.get('button').click()

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -824,6 +824,7 @@ describe('<Dropdown />', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" onClear={onClear} onChange={onChange} />)
       cy.get('button').click()
       cy.get('[role="listbox"] > li').first().should('contain.text', 'Option 2').and('have.attr', 'aria-label', 'Clear Filter')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'text-dropdown-item-selected')
       cy.get('[role="listbox"] > li').first().find('.material-symbols').should('contain', 'close')
       cy.get('[role="listbox"] > li').first().click()
       cy.get('@onClear').should('have.been.calledOnce')

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -175,53 +175,53 @@ describe('<Dropdown />', () => {
       cy.get('button').click()
       cy.get('[role="listbox"]').should('be.visible')
       cy.get('[role="listbox"] > li').each(($el) => {
-        cy.wrap($el).should('not.have.class', 'bg-dropdown-item-selected')
+        cy.wrap($el).should('not.have.class', 'bg-dropdown-item-focused')
       })
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-dropdown-item-selected')
     })
 
     it('focuses the first item when opened with ArrowDown', () => {
       cy.mount(<Dropdown items={mockItems} value="option3" />)
       cy.get('button').focus()
       cy.get('button').type('{downarrow}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'text-dropdown-item-selected')
     })
 
     it('focuses the first item when opened with Enter', () => {
       cy.mount(<Dropdown items={mockItems} />)
       cy.get('button').focus()
       cy.get('button').type('{enter}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('focuses the last item when ArrowUp is pressed after opening by click', () => {
       cy.mount(<Dropdown items={mockItems} />)
       cy.get('button').click()
       cy.realType('{uparrow}')
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('moves visual focus to the hovered item without losing the selected highlight', () => {
       cy.mount(<Dropdown items={mockItems} value="option1" />)
       cy.get('button').click()
-      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-focused')
       cy.get('[role="listbox"] > li').eq(2).trigger('mouseover')
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('keeps selected highlight distinct from keyboard focus', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" />)
       cy.get('button').click()
       cy.realType('{downarrow}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('navigates through menu items with ArrowDown', () => {
@@ -230,21 +230,21 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"]').should('be.visible')
 
       // Click-open has no focused item; first ArrowDown focuses the first item
-      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-focused')
       cy.realType('{downarrow}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
 
       // Navigate to second item
       cy.realType('{downarrow}')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-focused')
 
       // Navigate to third item
       cy.realType('{downarrow}')
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-focused')
 
       // Should stay on last item when pressing down again
       cy.realType('{downarrow}')
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('navigates through menu items with ArrowUp', () => {
@@ -254,23 +254,23 @@ describe('<Dropdown />', () => {
       cy.get('[role="listbox"]').should('be.visible')
 
       // Last item should be focused when opening with up arrow
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
 
       // Navigate to third item
       cy.realType('{uparrow}')
-      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(2).should('have.class', 'bg-dropdown-item-focused')
 
       // Navigate to second item
       cy.realType('{uparrow}')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-focused')
 
       // Navigate to first item
       cy.realType('{uparrow}')
-      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-focused')
 
       // Should stay on first item when pressing up again
       cy.realType('{uparrow}')
-      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('activates menu item with Enter', () => {
@@ -304,7 +304,7 @@ describe('<Dropdown />', () => {
       cy.get('button').type('{downarrow}') // Navigate to second item
       cy.get('button').type('{home}') // Go to first item
 
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('navigates to last item with End key', () => {
@@ -313,7 +313,7 @@ describe('<Dropdown />', () => {
       cy.get('button').type('{downarrow}') // Open menu
       cy.get('button').type('{end}') // Go to last item
 
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('closes menu with Escape key', () => {
@@ -507,11 +507,11 @@ describe('<Dropdown />', () => {
     it('highlights the selected subitem and its parent', () => {
       cy.mount(<Dropdown items={itemsWithSubmenus} value="sub2" />)
       cy.get('button').click()
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-selected')
       cy.get('[role="listbox"] > li').eq(1).trigger('mouseover')
-      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('selects subitem on click', () => {
@@ -554,7 +554,7 @@ describe('<Dropdown />', () => {
       // Submenu should be visible
       cy.get('[role="menu"]').should('exist')
       // First subitem should be focused
-      cy.get('[role="menu"] li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="menu"] li').first().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('closes submenu with ArrowLeft key', () => {
@@ -575,13 +575,13 @@ describe('<Dropdown />', () => {
       cy.realType('{downarrow}')
       cy.realType('{rightarrow}')
       // First subitem focused
-      cy.get('[role="menu"] li').eq(0).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="menu"] li').eq(0).should('have.class', 'bg-dropdown-item-focused')
       // Navigate down
       cy.realType('{downarrow}')
-      cy.get('[role="menu"] li').eq(1).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="menu"] li').eq(1).should('have.class', 'bg-dropdown-item-focused')
       // Navigate up
       cy.realType('{uparrow}')
-      cy.get('[role="menu"] li').eq(0).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="menu"] li').eq(0).should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('selects subitem with Enter key', () => {
@@ -777,24 +777,24 @@ describe('<Dropdown />', () => {
     it('highlights selected item by default', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" />)
       cy.get('button').click()
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('highlights selected item when highlightSelected is true', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" highlightSelected={true} />)
       cy.get('button').click()
       // The selected item (option2, index 1) should have yellow text
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-selected')
       // Other items should not have yellow text
-      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').first().should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('does not highlight selected item when highlightSelected is false', () => {
       cy.mount(<Dropdown items={mockItems} value="option2" highlightSelected={false} />)
       cy.get('button').click()
       // The selected item should not have yellow text
-      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('does not highlight when no value is selected', () => {
@@ -802,7 +802,7 @@ describe('<Dropdown />', () => {
       cy.get('button').click()
       // No items should have yellow text
       cy.get('[role="listbox"] > li').each(($el) => {
-        cy.wrap($el).should('not.have.class', 'text-dropdown-item-highlight')
+        cy.wrap($el).should('not.have.class', 'text-dropdown-item-selected')
       })
     })
   })

--- a/cypress/tests/components/ui/Dropdown.cy.tsx
+++ b/cypress/tests/components/ui/Dropdown.cy.tsx
@@ -504,6 +504,16 @@ describe('<Dropdown />', () => {
       cy.get('[role="menu"] li').should('have.length', 3)
     })
 
+    it('highlights the selected subitem and its parent', () => {
+      cy.mount(<Dropdown items={itemsWithSubmenus} value="sub2" />)
+      cy.get('button').click()
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).trigger('mouseover')
+      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-yellow-400')
+    })
+
     it('selects subitem on click', () => {
       const onChangeSpy = cy.spy().as('onChangeSpy')
       cy.mount(<Dropdown items={itemsWithSubmenus} onChange={onChangeSpy} />)

--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -133,6 +133,22 @@ describe('<DropdownMenu />', () => {
       cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'bg-dropdown-item-selected')
     })
 
+    it('calls onItemMouseOver when an item is hovered', () => {
+      const onItemMouseOver = cy.stub().as('onItemMouseOver')
+      cy.mount(<DropdownMenu {...defaultProps} onItemMouseOver={onItemMouseOver} />)
+      cy.get('[role="listbox"] > li').eq(2).trigger('mouseover')
+      cy.get('@onItemMouseOver').should('have.been.calledWith', 2)
+    })
+
+    it('applies selected highlight independently of focused styling', () => {
+      const isItemSelected = (item: DropdownMenuItem) => item.value === 'option2'
+      cy.mount(<DropdownMenu {...defaultProps} focusedIndex={0} highlightSelected isItemSelected={isItemSelected} />)
+      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
+    })
+
     it('scrolls focused item into view', () => {
       // This test verifies the useEffect behavior for scrolling
       cy.mount(<DropdownMenu {...defaultProps} focusedIndex={3} />)

--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -145,8 +145,8 @@ describe('<DropdownMenu />', () => {
       const isItemSelected = (item: DropdownMenuItem) => item.value === 'option2'
       cy.mount(<DropdownMenu {...defaultProps} focusedIndex={0} highlightSelected isItemSelected={isItemSelected} />)
       cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
       cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
     })
 
@@ -166,10 +166,10 @@ describe('<DropdownMenu />', () => {
       cy.mount(
         <DropdownMenu {...defaultProps} items={itemsWithSubmenu} focusedIndex={-1} openSubmenuIndex={1} highlightSelected isItemSelected={isItemSelected} />
       )
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
-      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-yellow-400')
-      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
     })
 
     it('scrolls focused item into view', () => {
@@ -183,7 +183,7 @@ describe('<DropdownMenu />', () => {
       const isItemSelected = (item: DropdownMenuItem) => item.value === 'option2'
       cy.mount(<DropdownMenu {...defaultProps} showSelectedIndicator={true} isItemSelected={isItemSelected} />)
       cy.get('[role="listbox"] > li').eq(1).find('.material-symbols').should('contain.text', 'check')
-      cy.get('[role="listbox"] > li').eq(1).find('.material-symbols').should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(1).find('.material-symbols').should('have.class', 'text-dropdown-item-highlight')
     })
 
     it('does not show selected indicator when showSelectedIndicator is false', () => {

--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -8,6 +8,7 @@ interface DropdownMenuItem {
   value: string | number
   subtext?: string
   leftIcon?: React.ReactNode
+  subitems?: { text: string; value: string | number }[]
 }
 
 describe('<DropdownMenu />', () => {
@@ -147,6 +148,28 @@ describe('<DropdownMenu />', () => {
       cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
       cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
       cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
+    })
+
+    it('highlights a submenu parent when a subitem is selected', () => {
+      const itemsWithSubmenu: DropdownMenuItem[] = [
+        { text: 'Simple', value: 'simple' },
+        {
+          text: 'Parent',
+          value: 'parent',
+          subitems: [
+            { text: 'Sub 1', value: 'sub1' },
+            { text: 'Sub 2', value: 'sub2' }
+          ]
+        }
+      ]
+      const isItemSelected = (item: DropdownMenuItem) => item.value === 'sub2'
+      cy.mount(
+        <DropdownMenu {...defaultProps} items={itemsWithSubmenu} focusedIndex={-1} openSubmenuIndex={1} highlightSelected isItemSelected={isItemSelected} />
+      )
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-yellow-400')
+      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-yellow-400')
+      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-yellow-400')
     })
 
     it('scrolls focused item into view', () => {

--- a/cypress/tests/components/ui/DropdownMenu.cy.tsx
+++ b/cypress/tests/components/ui/DropdownMenu.cy.tsx
@@ -130,8 +130,8 @@ describe('<DropdownMenu />', () => {
   describe('Focus and Selection', () => {
     it('applies focused styling to focused item', () => {
       cy.mount(<DropdownMenu {...defaultProps} focusedIndex={1} />)
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'bg-dropdown-item-focused')
     })
 
     it('calls onItemMouseOver when an item is hovered', () => {
@@ -144,10 +144,10 @@ describe('<DropdownMenu />', () => {
     it('applies selected highlight independently of focused styling', () => {
       const isItemSelected = (item: DropdownMenuItem) => item.value === 'option2'
       cy.mount(<DropdownMenu {...defaultProps} focusedIndex={0} highlightSelected isItemSelected={isItemSelected} />)
-      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-selected')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(0).should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('not.have.class', 'bg-dropdown-item-focused')
     })
 
     it('highlights a submenu parent when a subitem is selected', () => {
@@ -166,10 +166,10 @@ describe('<DropdownMenu />', () => {
       cy.mount(
         <DropdownMenu {...defaultProps} items={itemsWithSubmenu} focusedIndex={-1} openSubmenuIndex={1} highlightSelected isItemSelected={isItemSelected} />
       )
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-dropdown-item-highlight')
-      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(0).should('not.have.class', 'text-dropdown-item-selected')
+      cy.get('[role="menu"] li[role="option"]').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="menu"] li[role="option"]').eq(0).should('not.have.class', 'text-dropdown-item-selected')
     })
 
     it('scrolls focused item into view', () => {
@@ -183,7 +183,7 @@ describe('<DropdownMenu />', () => {
       const isItemSelected = (item: DropdownMenuItem) => item.value === 'option2'
       cy.mount(<DropdownMenu {...defaultProps} showSelectedIndicator={true} isItemSelected={isItemSelected} />)
       cy.get('[role="listbox"] > li').eq(1).find('.material-symbols').should('contain.text', 'check')
-      cy.get('[role="listbox"] > li').eq(1).find('.material-symbols').should('have.class', 'text-dropdown-item-highlight')
+      cy.get('[role="listbox"] > li').eq(1).find('.material-symbols').should('have.class', 'text-dropdown-item-selected')
     })
 
     it('does not show selected indicator when showSelectedIndicator is false', () => {

--- a/cypress/tests/components/ui/InputDropdown.cy.tsx
+++ b/cypress/tests/components/ui/InputDropdown.cy.tsx
@@ -48,6 +48,7 @@ describe('<InputDropdown />', () => {
     cy.get('input').focus()
     cy.get('[role="listbox"]').should('be.visible')
     cy.get('[role="listbox"] > li').should('have.length', mockItems.length)
+    cy.get('[role="listbox"] > li').should('not.have.class', 'bg-dropdown-item-focused')
   })
 
   it('filters items based on input', () => {
@@ -84,11 +85,14 @@ describe('<InputDropdown />', () => {
     cy.get('[role="listbox"]').should('not.exist')
   })
 
-  it('shows selected item with checkmark', () => {
+  it('highlights the selected item without a check indicator', () => {
     cy.mount(<InputDropdown items={mockItems} value="Banana" />)
     cy.get('input').focus()
+    cy.get('input').clear().type('a')
     cy.get('[role="listbox"]').should('be.visible')
-    cy.get('[role="listbox"] > li').first().find('.material-symbols').should('have.text', 'check')
+    cy.contains('[role="listbox"] > li', 'Banana').should('have.class', 'text-dropdown-item-selected')
+    cy.contains('[role="listbox"] > li', 'Apple').should('not.have.class', 'text-dropdown-item-selected')
+    cy.get('[role="listbox"] > li .material-symbols').should('not.exist')
   })
 
   it('shows "No items" when no matches found', () => {
@@ -99,6 +103,16 @@ describe('<InputDropdown />', () => {
   })
 
   describe('Keyboard Navigation', () => {
+    it('does not move keyboard focus when an item is hovered', () => {
+      cy.mount(<InputDropdown items={mockItems} showAllWhenEmpty />)
+      cy.get('input').focus()
+      cy.get('input').type('{downarrow}')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(2).trigger('mouseover')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="listbox"] > li').eq(2).should('not.have.class', 'bg-dropdown-item-focused')
+    })
+
     it('opens menu with ArrowDown', () => {
       cy.mount(<InputDropdown items={mockItems} />)
       cy.get('input').focus()

--- a/cypress/tests/components/ui/InputDropdown.cy.tsx
+++ b/cypress/tests/components/ui/InputDropdown.cy.tsx
@@ -104,7 +104,7 @@ describe('<InputDropdown />', () => {
       cy.get('input').focus()
       cy.get('input').type('a')
       cy.get('input').type('{downarrow}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('opens menu with ArrowUp', () => {
@@ -113,7 +113,7 @@ describe('<InputDropdown />', () => {
       cy.get('input').type('a')
       cy.get('[role="listbox"]').should('be.visible')
       cy.get('input').type('{uparrow}')
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('forces open menu on empty input with ArrowDown even when showAllWhenEmpty is false', () => {
@@ -123,7 +123,7 @@ describe('<InputDropdown />', () => {
       cy.get('input').type('{downarrow}')
       cy.get('[role="listbox"]').should('be.visible')
       cy.get('[role="listbox"] > li').should('have.length', mockItems.length)
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('forces open menu on empty input with ArrowUp even when showAllWhenEmpty is false', () => {
@@ -133,7 +133,7 @@ describe('<InputDropdown />', () => {
       cy.get('input').type('{uparrow}')
       cy.get('[role="listbox"]').should('be.visible')
       cy.get('[role="listbox"] > li').should('have.length', mockItems.length)
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('navigates through items with ArrowDown', () => {
@@ -141,9 +141,9 @@ describe('<InputDropdown />', () => {
       cy.get('input').focus()
       cy.get('input').type('a')
       cy.get('input').type('{downarrow}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
       cy.get('input').type('{downarrow}')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('navigates through items with ArrowUp', () => {
@@ -152,9 +152,9 @@ describe('<InputDropdown />', () => {
       cy.get('input').type('a')
       cy.get('input').type('{uparrow}')
       cy.get('[role="listbox"]').should('be.visible')
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
       cy.get('input').type('{uparrow}')
-      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').eq(1).should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('selects item with Enter', () => {
@@ -192,7 +192,7 @@ describe('<InputDropdown />', () => {
       cy.get('input').type('{downarrow}')
       cy.get('input').type('{downarrow}')
       cy.get('input').type('{home}')
-      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').first().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('navigates to last item with End', () => {
@@ -200,7 +200,7 @@ describe('<InputDropdown />', () => {
       cy.get('input').focus()
       cy.get('input').type('a')
       cy.get('input').type('{end}')
-      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-selected')
+      cy.get('[role="listbox"] > li').last().should('have.class', 'bg-dropdown-item-focused')
     })
 
     it('closes menu with Tab', () => {

--- a/cypress/tests/components/ui/MultiSelect.cy.tsx
+++ b/cypress/tests/components/ui/MultiSelect.cy.tsx
@@ -133,11 +133,45 @@ describe('<MultiSelect />', () => {
       cy.get('input[role="combobox"]').should('not.have.attr', 'aria-activedescendant')
     })
 
+    it('highlights selected items without a check indicator', () => {
+      cy.mount(<MultiSelect items={basicItems} selectedItems={selectedItems} onItemAdded={cy.stub()} onItemRemoved={cy.stub()} />)
+
+      cy.get('input[role="combobox"]').focus()
+      cy.get('[role="option"]').eq(0).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="option"]').eq(1).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="option"]').eq(2).should('not.have.class', 'text-dropdown-item-selected')
+      cy.get('[role="option"] .material-symbols').should('not.exist')
+    })
+
+    it('focuses the first item with ArrowDown after the menu is already open', () => {
+      cy.mount(<MultiSelect items={basicItems} selectedItems={[]} onItemAdded={cy.stub()} onItemRemoved={cy.stub()} />)
+
+      cy.get('input[role="combobox"]').focus()
+      cy.get('[role="option"]').should('not.have.class', 'bg-dropdown-item-focused')
+      cy.get('input[role="combobox"]').type('{downarrow}')
+      cy.get('[role="option"]').first().should('have.class', 'bg-dropdown-item-focused')
+    })
+
+    it('does not move keyboard focus when an item is hovered', () => {
+      cy.mount(<MultiSelect items={basicItems} selectedItems={selectedItems} onItemAdded={cy.stub()} onItemRemoved={cy.stub()} />)
+
+      cy.get('input[role="combobox"]').focus()
+      cy.get('input[role="combobox"]').type('{downarrow}')
+      cy.get('[role="option"]').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="option"]').eq(2).trigger('mouseover')
+      cy.get('[role="option"]').first().should('have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="option"]').eq(2).should('not.have.class', 'bg-dropdown-item-focused')
+      cy.get('[role="option"]').eq(0).should('have.class', 'text-dropdown-item-selected')
+      cy.get('[role="option"]').eq(2).should('not.have.class', 'text-dropdown-item-selected')
+    })
+
     it('navigates dropdown with up/downarrow keys', () => {
       cy.mount(<MultiSelect items={basicItems} selectedItems={[]} onItemAdded={cy.stub()} onItemRemoved={cy.stub()} />)
 
       cy.get('input[role="combobox"]').focus()
       cy.get('input[role="combobox"]').type('{downarrow}')
+
+      cy.get('[role="option"]').first().should('have.class', 'bg-dropdown-item-focused')
 
       // Check that aria-activedescendant points to the first option
       cy.get('[role="option"]')
@@ -148,6 +182,8 @@ describe('<MultiSelect />', () => {
         })
 
       cy.get('input[role="combobox"]').type('{downarrow}')
+
+      cy.get('[role="option"]').eq(1).should('have.class', 'bg-dropdown-item-focused')
 
       // Check that aria-activedescendant points to the second option
       cy.get('[role="option"]')

--- a/src/app/(main)/GlobalSearchMenu.tsx
+++ b/src/app/(main)/GlobalSearchMenu.tsx
@@ -145,7 +145,7 @@ export default function GlobalSearchMenu({
             {hasImage ? (
               <div
                 className={mergeClasses(
-                  'bg-bg-secondary relative flex flex-shrink-0 items-center justify-center overflow-hidden rounded-sm shadow-sm',
+                  'bg-bg-secondary relative flex shrink-0 items-center justify-center overflow-hidden rounded-sm shadow-sm',
                   containerClass
                 )}
               >
@@ -158,7 +158,7 @@ export default function GlobalSearchMenu({
               </div>
             ) : (
               // Placeholder or Icon for items without images (Tags/Genres)
-              <div className="bg-bg-secondary flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full">
+              <div className="bg-bg-secondary flex h-8 w-8 shrink-0 items-center justify-center rounded-full">
                 <span className="material-symbols text-lg text-gray-400">{getMaterialSymbolIcon(result.type)}</span>
               </div>
             )}
@@ -192,7 +192,7 @@ export default function GlobalSearchMenu({
           className: mergeClasses(
             'block px-3 py-2 cursor-pointer no-underline select-none',
             'hover:bg-dropdown-item-hover',
-            isSelected ? 'bg-dropdown-item-selected' : ''
+            isSelected ? 'bg-dropdown-item-focused' : ''
           ),
           role: 'option' as const,
           'aria-selected': isSelected

--- a/src/app/(main)/UserAppBarNav.tsx
+++ b/src/app/(main)/UserAppBarNav.tsx
@@ -219,7 +219,7 @@ export default function UserAppBarNav() {
       'hover:bg-dropdown-item-hover text-foreground flex w-full items-center justify-start px-4 py-3 transition-colors outline-none',
       item.className,
       item.mobileOnly && 'md:hidden',
-      focusedIndex === index && 'bg-dropdown-item-selected'
+      focusedIndex === index && 'bg-dropdown-item-focused'
     )
 
   const menuContent = (

--- a/src/app/(main)/components_catalog/examples/DropdownExamples.tsx
+++ b/src/app/(main)/components_catalog/examples/DropdownExamples.tsx
@@ -94,7 +94,7 @@ export function DropdownExamples() {
         </p>
         <p className="mb-2">
           <span className="font-bold">Props:</span> <Code>value</Code>, <Code>onChange</Code>, <Code>items</Code> (DropdownItem[]), <Code>label</Code>,{' '}
-          <Code>disabled</Code>, <Code>small</Code>, <Code>menuMaxHeight</Code>, <Code>wrapText</Code>, <Code>className</Code>
+          <Code>disabled</Code>, <Code>small</Code>, <Code>menuMaxHeight</Code>, <Code>wrapText</Code>, <Code>highlightSelected</Code>, <Code>className</Code>
         </p>
       </ComponentInfo>
 

--- a/src/assets/globals.css
+++ b/src/assets/globals.css
@@ -71,8 +71,8 @@
   --color-button-foreground: var(--tc-button-foreground);
   --color-button-foreground-muted: var(--tc-button-foreground-muted);
   --color-dropdown-item-hover: var(--tc-dropdown-item-hover);
+  --color-dropdown-item-focused: var(--tc-dropdown-item-focused);
   --color-dropdown-item-selected: var(--tc-dropdown-item-selected);
-  --color-dropdown-item-highlight: var(--tc-dropdown-item-highlight);
   --color-dropdown-menu-border: var(--tc-dropdown-menu-border);
   --color-nav-item-hover: var(--tc-nav-item-hover);
   --color-nav-item-selected: var(--tc-nav-item-selected);

--- a/src/assets/globals.css
+++ b/src/assets/globals.css
@@ -72,6 +72,7 @@
   --color-button-foreground-muted: var(--tc-button-foreground-muted);
   --color-dropdown-item-hover: var(--tc-dropdown-item-hover);
   --color-dropdown-item-selected: var(--tc-dropdown-item-selected);
+  --color-dropdown-item-highlight: var(--tc-dropdown-item-highlight);
   --color-dropdown-menu-border: var(--tc-dropdown-menu-border);
   --color-nav-item-hover: var(--tc-nav-item-hover);
   --color-nav-item-selected: var(--tc-nav-item-selected);

--- a/src/assets/themes.css
+++ b/src/assets/themes.css
@@ -23,8 +23,8 @@
   --tc-button-foreground: #ffffff;
 
   --tc-dropdown-item-hover: #333333;
-  --tc-dropdown-item-selected: #444444;
-  --tc-dropdown-item-highlight: #facc15;
+  --tc-dropdown-item-focused: #444444;
+  --tc-dropdown-item-selected: #facc15;
   --tc-dropdown-menu-border: #555555;
 
   --tc-nav-item-hover: #2c2c2c;
@@ -104,8 +104,8 @@
   --tc-button-foreground: #000000;
 
   --tc-dropdown-item-hover: #f0f0f0;
-  --tc-dropdown-item-selected: #e5e5e5;
-  --tc-dropdown-item-highlight: #ca8a04;
+  --tc-dropdown-item-focused: #e5e5e5;
+  --tc-dropdown-item-selected: #ca8a04;
   --tc-dropdown-menu-border: #d4d4d4;
 
   --tc-nav-item-hover: #f0f0f0;
@@ -171,8 +171,8 @@
   --tc-button-foreground: #ffffff;
 
   --tc-dropdown-item-hover: #1a1a1a;
-  --tc-dropdown-item-selected: #2a2a2a;
-  --tc-dropdown-item-highlight: #facc15;
+  --tc-dropdown-item-focused: #2a2a2a;
+  --tc-dropdown-item-selected: #facc15;
   --tc-dropdown-menu-border: #262626;
 
   --tc-nav-item-hover: #1a1a1a;

--- a/src/assets/themes.css
+++ b/src/assets/themes.css
@@ -24,6 +24,7 @@
 
   --tc-dropdown-item-hover: #333333;
   --tc-dropdown-item-selected: #444444;
+  --tc-dropdown-item-highlight: #facc15;
   --tc-dropdown-menu-border: #555555;
 
   --tc-nav-item-hover: #2c2c2c;
@@ -104,6 +105,7 @@
 
   --tc-dropdown-item-hover: #f0f0f0;
   --tc-dropdown-item-selected: #e5e5e5;
+  --tc-dropdown-item-highlight: #ca8a04;
   --tc-dropdown-menu-border: #d4d4d4;
 
   --tc-nav-item-hover: #f0f0f0;
@@ -170,6 +172,7 @@
 
   --tc-dropdown-item-hover: #1a1a1a;
   --tc-dropdown-item-selected: #2a2a2a;
+  --tc-dropdown-item-highlight: #facc15;
   --tc-dropdown-menu-border: #262626;
 
   --tc-nav-item-hover: #1a1a1a;

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -526,7 +526,7 @@ export default function Dropdown({
         showNoItemsMessage={false}
         ref={menuRef}
         highlightSelected={highlightSelected}
-        isItemSelected={(item) => item.value === value}
+        isItemSelected={(item) => item.value === value || item.value === CLEAR_ITEM_VALUE}
         usePortal={usePortal}
         triggerRef={controlWrapperRef as React.RefObject<HTMLElement>}
         wrapText={wrapText}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -55,6 +55,8 @@ interface DropdownProps {
   onClear?: () => void
 }
 
+const UNICODE_LETTER_OR_NUMBER = new RegExp('[\\p{L}\\p{N}]', 'u')
+
 /**
  * A dropdown component that displays a list of selectable items.
  * The dropdown shows the selected item and allows users to choose from a list of options.
@@ -71,7 +73,7 @@ export default function Dropdown({
   onChange,
   className,
   rightIcon,
-  highlightSelected = false,
+  highlightSelected = true,
   displayText,
   usePortal = false,
   wrapText = false,
@@ -93,7 +95,7 @@ export default function Dropdown({
   const dropdownId = useId()
   const isMobile = useIsMobile() && !!mobileIcon
 
-  const openMenu = (index: number = 0) => {
+  const openMenu = (index: number = -1) => {
     setShowMenu(true)
     setFocusedIndex(index)
     setFocusedSubIndex(-1)
@@ -220,7 +222,7 @@ export default function Dropdown({
   const handleVerticalNavigation = (direction: 'up' | 'down') => {
     if (direction === 'down') {
       if (!showMenu) {
-        openMenu()
+        openMenu(0)
       } else if (focusedSubIndex !== -1 && openSubmenuIndex !== null) {
         // Navigating within submenu - use filtered list
         const filteredSubitems = getFilteredSubitems()
@@ -229,7 +231,7 @@ export default function Dropdown({
         }
       } else {
         closeSubMenu()
-        setFocusedIndex((prev) => (prev < itemsToShow.length - 1 ? prev + 1 : prev))
+        setFocusedIndex((prev) => (prev === -1 ? 0 : prev < itemsToShow.length - 1 ? prev + 1 : prev))
       }
     } else {
       if (!showMenu) {
@@ -242,7 +244,7 @@ export default function Dropdown({
         }
       } else {
         closeSubMenu()
-        setFocusedIndex((prev) => (prev > 0 ? prev - 1 : prev))
+        setFocusedIndex((prev) => (prev === -1 ? itemsToShow.length - 1 : prev > 0 ? prev - 1 : prev))
       }
     }
   }
@@ -266,7 +268,7 @@ export default function Dropdown({
 
   const handleEnterSpace = () => {
     if (!showMenu) {
-      openMenu()
+      openMenu(0)
     } else if (focusedSubIndex !== -1 && focusedSubIndex >= 0 && openSubmenuIndex !== null) {
       // Select subitem from filtered list
       const filteredSubitems = getFilteredSubitems()
@@ -403,7 +405,7 @@ export default function Dropdown({
 
       default:
         // Handle letters and numbers for type-to-filter in submenu (supports Unicode)
-        if (e.key.length === 1 && /[\p{L}\p{N}]/u.test(e.key)) {
+        if (e.key.length === 1 && UNICODE_LETTER_OR_NUMBER.test(e.key)) {
           e.preventDefault()
           handleTypeToFilter(e.key)
         }
@@ -477,7 +479,7 @@ export default function Dropdown({
                 <DropdownItemLabel text={selectedText} subtext={selectedSubtext || undefined} />
               </span>
             </span>
-            <span className="pointer-events-none ms-3 flex flex-shrink-0 items-center">
+            <span className="pointer-events-none ms-3 flex shrink-0 items-center">
               {rightIcon || <span className="material-symbols text-2xl">expand_more</span>}
             </span>
           </button>
@@ -508,14 +510,17 @@ export default function Dropdown({
         }}
         onSubitemClick={(subitem) => handleSubitemClick(subitem.value)}
         onOpenSubmenu={(index) => {
+          setFocusedIndex(index)
           if (openSubmenuIndex !== index) {
             setOpenSubmenuIndex(index)
             setSubmenuFilterText('')
+            setFocusedSubIndex(-1)
           }
         }}
         onCloseSubmenu={() => {
           setOpenSubmenuIndex(null)
           setSubmenuFilterText('')
+          setFocusedSubIndex(-1)
         }}
         submenuFilterText={submenuFilterText}
         menuMaxHeight={menuMaxHeight}

--- a/src/components/ui/Dropdown.tsx
+++ b/src/components/ui/Dropdown.tsx
@@ -510,7 +510,6 @@ export default function Dropdown({
         }}
         onSubitemClick={(subitem) => handleSubitemClick(subitem.value)}
         onOpenSubmenu={(index) => {
-          setFocusedIndex(index)
           if (openSubmenuIndex !== index) {
             setOpenSubmenuIndex(index)
             setSubmenuFilterText('')

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -74,6 +74,7 @@ function DropdownSubmenu({
   focusedSubIndex,
   onSubitemClick,
   onMouseOver,
+  onSubitemMouseOver,
   onMouseLeave,
   referenceElement,
   filterText,
@@ -86,6 +87,7 @@ function DropdownSubmenu({
   focusedSubIndex: number
   onSubitemClick?: (subitem: DropdownMenuSubitem) => void
   onMouseOver: () => void
+  onSubitemMouseOver?: (subIndex: number) => void
   onMouseLeave: () => void
   referenceElement: HTMLElement | null
   filterText: string
@@ -181,7 +183,7 @@ function DropdownSubmenu({
       ref={submenuRef}
       role="menu"
       data-dropdown-id={dropdownId}
-      className="bg-primary border-dropdown-menu-border absolute z-[9999] overflow-y-auto rounded-md border py-1 shadow-lg"
+      className="bg-primary border-dropdown-menu-border absolute z-9999 overflow-y-auto rounded-md border py-1 shadow-lg"
       style={{
         ...floatingStyles,
         width: `${floatingSize?.width ?? PREFERRED_SUBMENU_WIDTH}px`,
@@ -215,9 +217,10 @@ function DropdownSubmenu({
             onSubitemClick?.(subitem)
           }}
           onMouseDown={(e) => e.preventDefault()}
+          onMouseOver={() => onSubitemMouseOver?.(subitemIndex)}
         >
           <span
-            className={mergeClasses('ms-3 block min-w-0 font-sans text-sm', wrapText ? 'line-clamp-2 break-words whitespace-normal' : 'truncate')}
+            className={mergeClasses('ms-3 block min-w-0 font-sans text-sm', wrapText ? 'line-clamp-2 wrap-break-word whitespace-normal' : 'truncate')}
             title={subitem.text}
           >
             {subitem.text}
@@ -250,6 +253,8 @@ interface DropdownMenuProps {
   dropdownId: string
   onItemClick?: (item: DropdownMenuItem) => void
   onSubitemClick?: (subitem: DropdownMenuSubitem) => void
+  onItemMouseOver?: (index: number) => void
+  onSubitemMouseOver?: (subIndex: number) => void
   onOpenSubmenu?: (index: number) => void
   onCloseSubmenu?: () => void
   isItemSelected?: (item: DropdownMenuItem) => boolean
@@ -282,6 +287,8 @@ export default function DropdownMenu({
   dropdownId,
   onItemClick,
   onSubitemClick,
+  onItemMouseOver,
+  onSubitemMouseOver,
   onOpenSubmenu,
   onCloseSubmenu,
   isItemSelected,
@@ -473,7 +480,10 @@ export default function DropdownMenu({
               onItemClick?.(item)
             }}
             onMouseDown={(e) => e.preventDefault()}
-            onMouseOver={hasSubitems ? () => handleMouseoverParent(index) : undefined}
+            onMouseOver={() => {
+              onItemMouseOver?.(index)
+              if (hasSubitems) handleMouseoverParent(index)
+            }}
             onMouseLeave={hasSubitems ? handleMouseleaveParent : undefined}
           >
             <div
@@ -498,7 +508,7 @@ export default function DropdownMenu({
             )}
             {item.rightIcon && !hasSubitems && <div className="pointer-events-none absolute inset-y-0 right-2 flex h-full items-center">{item.rightIcon}</div>}
             {showSelectedIndicator && isItemSelected && isItemSelected(item) && !hasSubitems && (
-              <span className="absolute inset-y-0 end-0 flex items-center pe-4">
+              <span className="absolute inset-y-0 inset-e-0 flex items-center pe-4">
                 <span className="material-symbols text-xl text-yellow-400">check</span>
               </span>
             )}
@@ -512,6 +522,7 @@ export default function DropdownMenu({
                 focusedSubIndex={focusedSubIndex}
                 onSubitemClick={onSubitemClick}
                 onMouseOver={handleMouseoverSubmenu}
+                onSubitemMouseOver={onSubitemMouseOver}
                 onMouseLeave={handleMouseleaveSubmenu}
                 referenceElement={menuItemRefs.current[index]}
                 filterText={submenuFilterText}
@@ -532,6 +543,8 @@ export default function DropdownMenu({
       showSelectedIndicator,
       onItemClick,
       onSubitemClick,
+      onItemMouseOver,
+      onSubitemMouseOver,
       highlightSelected,
       handleMouseoverParent,
       handleMouseleaveParent,
@@ -571,7 +584,9 @@ export default function DropdownMenu({
       aria-activedescendant={
         focusedSubIndex !== -1 && openSubmenuIndex !== null
           ? `${dropdownId}-subitem-${openSubmenuIndex}-${focusedSubIndex}`
-          : `${dropdownId}-item-${focusedIndex}`
+          : focusedIndex >= 0
+            ? `${dropdownId}-item-${focusedIndex}`
+            : undefined
       }
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -220,8 +220,8 @@ function DropdownSubmenu({
           id={`${dropdownId}-subitem-${parentIndex}-${subitemIndex}`}
           className={mergeClasses(
             'text-foreground hover:bg-dropdown-item-hover relative cursor-pointer py-2',
-            focusedSubIndex === subitemIndex ? 'bg-dropdown-item-selected' : '',
-            highlightSelected && isSelectedValue(isItemSelected, subitem) ? 'text-dropdown-item-highlight' : ''
+            focusedSubIndex === subitemIndex ? 'bg-dropdown-item-focused' : '',
+            highlightSelected && isSelectedValue(isItemSelected, subitem) ? 'text-dropdown-item-selected' : ''
           )}
           role="option"
           tabIndex={-1}
@@ -479,9 +479,9 @@ export default function DropdownMenu({
             className={mergeClasses(
               'text-foreground hover:bg-dropdown-item-hover relative cursor-pointer py-2',
               wrapText ? 'overflow-x-hidden' : 'overflow-hidden',
-              focusedIndex === index && focusedSubIndex === -1 ? 'bg-dropdown-item-selected' : '',
+              focusedIndex === index && focusedSubIndex === -1 ? 'bg-dropdown-item-focused' : '',
               isSubmenuOpen ? 'bg-dropdown-item-hover' : '',
-              highlightSelected && isParentOrSubitemSelected(isItemSelected, item) ? 'text-dropdown-item-highlight' : ''
+              highlightSelected && isParentOrSubitemSelected(isItemSelected, item) ? 'text-dropdown-item-selected' : ''
             )}
             role={hasSubitems ? 'menuitem' : 'option'}
             tabIndex={-1}
@@ -523,7 +523,7 @@ export default function DropdownMenu({
             {item.rightIcon && !hasSubitems && <div className="pointer-events-none absolute inset-y-0 right-2 flex h-full items-center">{item.rightIcon}</div>}
             {showSelectedIndicator && isItemSelected && isItemSelected(item) && !hasSubitems && (
               <span className="absolute inset-y-0 inset-e-0 flex items-center pe-4">
-                <span className="material-symbols text-dropdown-item-highlight text-xl">check</span>
+                <span className="material-symbols text-dropdown-item-selected text-xl">check</span>
               </span>
             )}
 

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -221,7 +221,7 @@ function DropdownSubmenu({
           className={mergeClasses(
             'text-foreground hover:bg-dropdown-item-hover relative cursor-pointer py-2',
             focusedSubIndex === subitemIndex ? 'bg-dropdown-item-selected' : '',
-            highlightSelected && isSelectedValue(isItemSelected, subitem) ? 'text-yellow-400' : ''
+            highlightSelected && isSelectedValue(isItemSelected, subitem) ? 'text-dropdown-item-highlight' : ''
           )}
           role="option"
           tabIndex={-1}
@@ -481,7 +481,7 @@ export default function DropdownMenu({
               wrapText ? 'overflow-x-hidden' : 'overflow-hidden',
               focusedIndex === index && focusedSubIndex === -1 ? 'bg-dropdown-item-selected' : '',
               isSubmenuOpen ? 'bg-dropdown-item-hover' : '',
-              highlightSelected && isParentOrSubitemSelected(isItemSelected, item) ? 'text-yellow-400' : ''
+              highlightSelected && isParentOrSubitemSelected(isItemSelected, item) ? 'text-dropdown-item-highlight' : ''
             )}
             role={hasSubitems ? 'menuitem' : 'option'}
             tabIndex={-1}
@@ -523,7 +523,7 @@ export default function DropdownMenu({
             {item.rightIcon && !hasSubitems && <div className="pointer-events-none absolute inset-y-0 right-2 flex h-full items-center">{item.rightIcon}</div>}
             {showSelectedIndicator && isItemSelected && isItemSelected(item) && !hasSubitems && (
               <span className="absolute inset-y-0 inset-e-0 flex items-center pe-4">
-                <span className="material-symbols text-xl text-yellow-400">check</span>
+                <span className="material-symbols text-dropdown-item-highlight text-xl">check</span>
               </span>
             )}
 

--- a/src/components/ui/DropdownMenu.tsx
+++ b/src/components/ui/DropdownMenu.tsx
@@ -26,6 +26,15 @@ export interface DropdownMenuItem {
   subitems?: DropdownMenuSubitem[]
 }
 
+function isSelectedValue(isItemSelected: ((item: DropdownMenuItem) => boolean) | undefined, item: { text: string; value: string | number }) {
+  return Boolean(isItemSelected?.(item))
+}
+
+function isParentOrSubitemSelected(isItemSelected: ((item: DropdownMenuItem) => boolean) | undefined, item: DropdownMenuItem) {
+  if (isSelectedValue(isItemSelected, item)) return true
+  return Boolean(item.subitems?.some((subitem) => isSelectedValue(isItemSelected, subitem)))
+}
+
 const PREFERRED_SUBMENU_WIDTH = 192
 const CONTENT_SIZED_MENU_MAX_WIDTH = '50vw'
 
@@ -79,6 +88,8 @@ function DropdownSubmenu({
   referenceElement,
   filterText,
   wrapText = false,
+  highlightSelected = false,
+  isItemSelected,
   t
 }: {
   subitems: DropdownMenuSubitem[]
@@ -92,6 +103,8 @@ function DropdownSubmenu({
   referenceElement: HTMLElement | null
   filterText: string
   wrapText?: boolean
+  highlightSelected?: boolean
+  isItemSelected?: (item: DropdownMenuItem) => boolean
   t: ReturnType<typeof useTypeSafeTranslations>
 }) {
   const submenuRef = useRef<HTMLUListElement>(null)
@@ -207,11 +220,12 @@ function DropdownSubmenu({
           id={`${dropdownId}-subitem-${parentIndex}-${subitemIndex}`}
           className={mergeClasses(
             'text-foreground hover:bg-dropdown-item-hover relative cursor-pointer py-2',
-            focusedSubIndex === subitemIndex ? 'bg-dropdown-item-selected' : ''
+            focusedSubIndex === subitemIndex ? 'bg-dropdown-item-selected' : '',
+            highlightSelected && isSelectedValue(isItemSelected, subitem) ? 'text-yellow-400' : ''
           )}
           role="option"
           tabIndex={-1}
-          aria-selected={focusedSubIndex === subitemIndex}
+          aria-selected={isItemSelected ? isSelectedValue(isItemSelected, subitem) : focusedSubIndex === subitemIndex}
           onClick={(e) => {
             e.stopPropagation()
             onSubitemClick?.(subitem)
@@ -467,7 +481,7 @@ export default function DropdownMenu({
               wrapText ? 'overflow-x-hidden' : 'overflow-hidden',
               focusedIndex === index && focusedSubIndex === -1 ? 'bg-dropdown-item-selected' : '',
               isSubmenuOpen ? 'bg-dropdown-item-hover' : '',
-              highlightSelected && isItemSelected?.(item) ? 'text-yellow-400' : ''
+              highlightSelected && isParentOrSubitemSelected(isItemSelected, item) ? 'text-yellow-400' : ''
             )}
             role={hasSubitems ? 'menuitem' : 'option'}
             tabIndex={-1}
@@ -527,6 +541,8 @@ export default function DropdownMenu({
                 referenceElement={menuItemRefs.current[index]}
                 filterText={submenuFilterText}
                 wrapText={wrapText}
+                highlightSelected={highlightSelected}
+                isItemSelected={isItemSelected}
                 t={t}
               />
             )}

--- a/src/components/ui/InputDropdown.tsx
+++ b/src/components/ui/InputDropdown.tsx
@@ -294,7 +294,7 @@ function InputDropdown({
           dropdownId={dropdownId}
           onItemClick={(item) => handleOptionClick(item.value)}
           isItemSelected={isMenuItemSelected}
-          showSelectedIndicator={true}
+          highlightSelected
           menuMaxHeight="224px"
           className="z-50"
           showNoItemsMessage={true}

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -637,7 +637,7 @@ export function MultiSelect<T = string>({
           dropdownId={multiSelectId}
           onItemClick={handleDropdownItemClick}
           isItemSelected={isItemSelected}
-          showSelectedIndicator={true}
+          highlightSelected
           showNoItemsMessage={true}
           noItemsText={t('LabelNoItems')}
           menuMaxHeight="224px"

--- a/src/components/ui/TableRow.tsx
+++ b/src/components/ui/TableRow.tsx
@@ -9,7 +9,7 @@ interface TableRowProps {
 }
 
 export default function TableRow({ children, className }: TableRowProps) {
-  const rowClasses = mergeClasses('bg-bg odd:bg-primary-hover hover:bg-dropdown-item-selected h-9', className)
+  const rowClasses = mergeClasses('bg-bg odd:bg-primary-hover hover:bg-dropdown-item-focused h-9', className)
 
   return <tr className={rowClasses}>{children}</tr>
 }


### PR DESCRIPTION
Fixes #246

Opening a dropdown by click no longer looks like the first item is chosen. Keyboard focus, hover, and the actual selected value are separate, including nested filter items.

### Notable changes

- Click-open leaves items unfocused; 
  - Arrow Down / Enter / Space focus the first item
  - Arrow Up the focuses the last
- Selected value uses the theme selected color
  - a submenu choice highlights both the parent and the subitem (see library filter dropdown)
- Theme colors:
  - `dropdown-item-focused` for the focus fill (applied to bg)
  - `dropdown-item-selected` for the current-value color (applied to text, darker on light theme)