### PR TITLE
Confirm unsaved changes when closing Details tab in edit modal

### DIFF
--- a/src/components/modals/ChaptersEditModalBody.tsx
+++ b/src/components/modals/ChaptersEditModalBody.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useLibraryItemModal } from '@/components/modals/LibraryItemModal'
+import { useLibraryItemModal, type UnsavedChangesLeaveHandle } from '@/components/modals/LibraryItemModal'
 import Btn from '@/components/ui/Btn'
 import Checkbox from '@/components/ui/Checkbox'
 import HelpTooltipIcon from '@/components/ui/HelpTooltipIcon'
@@ -18,21 +18,16 @@ import { mergeClasses } from '@/lib/merge-classes'
 import { isBookMediaWithTracks, type AudibleChapterSearchResult, type BookLibraryItem } from '@/types/api'
 import { useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState, type Ref } from 'react'
 
-export type ChaptersEditCloseHandle = {
-  /** Confirm unsaved chapter edits, then run `onAllow` (e.g. switch section or close). */
-  requestLeave: (onAllow: () => void) => void
-}
-
 interface ChaptersEditModalBodyProps {
   /** Lets the parent intercept leave (section change, hub back, close) while chapters are dirty. */
-  closeRequestRef?: Ref<ChaptersEditCloseHandle | null>
+  closeRequestRef?: Ref<UnsavedChangesLeaveHandle | null>
   /** True while a chapter save is in flight, so the parent can show processing on the shell. */
   onPendingChange?: (pending: boolean) => void
 }
 
 interface ChaptersEditContentProps {
   libraryItem: BookLibraryItem
-  closeRequestRef?: Ref<ChaptersEditCloseHandle | null>
+  closeRequestRef?: Ref<UnsavedChangesLeaveHandle | null>
   onPendingChange?: (pending: boolean) => void
   onItemUpdated?: (item: BookLibraryItem) => void
 }

--- a/src/components/modals/LibraryItemEditModal.tsx
+++ b/src/components/modals/LibraryItemEditModal.tsx
@@ -5,13 +5,25 @@ import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource 
 import ModalFooter from '@/components/modals/ModalFooter'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import BookDetailsEdit, { BookDetailsEditRef, BookUpdatePayload } from '@/components/widgets/BookDetailsEdit'
+import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import PodcastDetailsEdit, { PodcastDetailsEditRef, PodcastUpdatePayload } from '@/components/widgets/PodcastDetailsEdit'
 import { useLibrary } from '@/contexts/LibraryContext'
 import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import type { BookMedia, BookMetadata, PodcastMedia, PodcastMetadata } from '@/types/api'
 import { BookLibraryItem, PodcastLibraryItem } from '@/types/api'
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useTransition, type TransitionStartFunction } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type Ref,
+  type TransitionStartFunction
+} from 'react'
 
 function createPlaceholderBookLibraryItem(id: string, libraryId: string): BookLibraryItem {
   const metadata: BookMetadata = {
@@ -73,6 +85,11 @@ export type LibraryItemEditModalProps = {
   onClose: () => void
 } & LibraryItemModalItemSource
 
+export type LibraryItemEditModalContentHandle = {
+  /** Confirm unsaved detail edits, then run `onAllow` (e.g. switch section or close). */
+  requestLeave: (onAllow: () => void) => void
+}
+
 export type LibraryItemEditModalContentProps = {
   isOpen: boolean
   startSaveTransition: TransitionStartFunction
@@ -82,6 +99,8 @@ export type LibraryItemEditModalContentProps = {
   stableBodyHeight: boolean
   /** When true, fill a parent with a fixed height (e.g. SectionedModalBody). */
   fillParent?: boolean
+  /** Lets the parent intercept leave (section change, hub back, close) while details are dirty. */
+  closeRequestRef?: Ref<LibraryItemEditModalContentHandle | null>
 }
 
 export function LibraryItemEditModalContent({
@@ -90,7 +109,8 @@ export function LibraryItemEditModalContent({
   isSavePending,
   onClose,
   stableBodyHeight,
-  fillParent = false
+  fillParent = false,
+  closeRequestRef
 }: LibraryItemEditModalContentProps) {
   const { resolvedItem, fetchPending, pendingEntityId } = useLibraryItemModal()
   const t = useTypeSafeTranslations()
@@ -98,6 +118,8 @@ export function LibraryItemEditModalContent({
   const { filterData, library } = useLibrary()
   const [hasChanges, setHasChanges] = useState(false)
   const saveAndCloseRef = useRef(false)
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+  const pendingLeaveRef = useRef<(() => void) | null>(null)
 
   const bookDetailsRef = useRef<BookDetailsEditRef>(null)
   const podcastDetailsRef = useRef<PodcastDetailsEditRef>(null)
@@ -171,7 +193,12 @@ export function LibraryItemEditModalContent({
       if (!itemId) return
 
       if (!details.hasChanges) {
-        if (saveAndCloseRef.current) {
+        if (pendingLeaveRef.current) {
+          const onAllow = pendingLeaveRef.current
+          pendingLeaveRef.current = null
+          setShowCloseConfirm(false)
+          onAllow()
+        } else if (saveAndCloseRef.current) {
           onClose()
         }
         return
@@ -185,7 +212,12 @@ export function LibraryItemEditModalContent({
           })
           showToast(t('ToastItemUpdateSuccess'), { type: 'success' })
           setHasChanges(false)
-          if (saveAndCloseRef.current) {
+          if (pendingLeaveRef.current) {
+            const onAllow = pendingLeaveRef.current
+            pendingLeaveRef.current = null
+            setShowCloseConfirm(false)
+            onAllow()
+          } else if (saveAndCloseRef.current) {
             onClose()
           }
         } catch (error) {
@@ -197,15 +229,48 @@ export function LibraryItemEditModalContent({
     [onClose, resolvedItem?.id, showToast, startSaveTransition, t]
   )
 
-  const handleSave = (close: boolean = false) => {
-    saveAndCloseRef.current = close
-    if (!resolvedItem) return
-    if (resolvedItem.mediaType === 'podcast') {
-      podcastDetailsRef.current?.submit()
-    } else {
-      bookDetailsRef.current?.submit()
-    }
-  }
+  const handleSave = useCallback(
+    (close: boolean = false) => {
+      saveAndCloseRef.current = close
+      if (!resolvedItem) return
+      if (resolvedItem.mediaType === 'podcast') {
+        podcastDetailsRef.current?.submit()
+      } else {
+        bookDetailsRef.current?.submit()
+      }
+    },
+    [resolvedItem]
+  )
+
+  const requestLeave = useCallback(
+    (onAllow: () => void) => {
+      if (!hasChanges) {
+        onAllow()
+        return
+      }
+      pendingLeaveRef.current = onAllow
+      setShowCloseConfirm(true)
+    },
+    [hasChanges]
+  )
+
+  const handleCancelLeave = useCallback(() => {
+    pendingLeaveRef.current = null
+    setShowCloseConfirm(false)
+  }, [])
+
+  const handleDiscardAndLeave = useCallback(() => {
+    const onAllow = pendingLeaveRef.current
+    pendingLeaveRef.current = null
+    setShowCloseConfirm(false)
+    onAllow?.()
+  }, [])
+
+  const handleSaveAndLeave = useCallback(() => {
+    handleSave(false)
+  }, [handleSave])
+
+  useImperativeHandle(closeRequestRef, () => ({ requestLeave }), [requestLeave])
 
   const isPodcast = resolvedItem?.mediaType === 'podcast'
   const saveDisabled = !hasChanges || isSavePending || !resolvedItem || fetchPending
@@ -313,6 +378,17 @@ export function LibraryItemEditModalContent({
           onClick: () => handleSave(true),
           disabled: saveDisabled
         }}
+      />
+
+      <ConfirmDialog
+        isOpen={showCloseConfirm}
+        message={t('MessageConfirmCloseDetailsWithChanges')}
+        altButtonText={t('ButtonDiscard')}
+        yesButtonText={t('ButtonSave')}
+        processing={isSavePending}
+        onClose={handleCancelLeave}
+        onAlt={handleDiscardAndLeave}
+        onConfirm={handleSaveAndLeave}
       />
     </div>
   )

--- a/src/components/modals/LibraryItemEditModal.tsx
+++ b/src/components/modals/LibraryItemEditModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { updateLibraryItemMediaAction } from '@/app/actions/mediaActions'
-import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource } from '@/components/modals/LibraryItemModal'
+import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource, type UnsavedChangesLeaveHandle } from '@/components/modals/LibraryItemModal'
 import ModalFooter from '@/components/modals/ModalFooter'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import BookDetailsEdit, { BookDetailsEditRef, BookUpdatePayload } from '@/components/widgets/BookDetailsEdit'
@@ -85,11 +85,6 @@ export type LibraryItemEditModalProps = {
   onClose: () => void
 } & LibraryItemModalItemSource
 
-export type LibraryItemEditModalContentHandle = {
-  /** Confirm unsaved detail edits, then run `onAllow` (e.g. switch section or close). */
-  requestLeave: (onAllow: () => void) => void
-}
-
 export type LibraryItemEditModalContentProps = {
   isOpen: boolean
   startSaveTransition: TransitionStartFunction
@@ -100,7 +95,7 @@ export type LibraryItemEditModalContentProps = {
   /** When true, fill a parent with a fixed height (e.g. SectionedModalBody). */
   fillParent?: boolean
   /** Lets the parent intercept leave (section change, hub back, close) while details are dirty. */
-  closeRequestRef?: Ref<LibraryItemEditModalContentHandle | null>
+  closeRequestRef?: Ref<UnsavedChangesLeaveHandle | null>
 }
 
 export function LibraryItemEditModalContent({

--- a/src/components/modals/LibraryItemMetadataEditModal.tsx
+++ b/src/components/modals/LibraryItemMetadataEditModal.tsx
@@ -2,7 +2,7 @@
 
 import { ChaptersEditModalBody, type ChaptersEditCloseHandle } from '@/components/modals/ChaptersEditModalBody'
 import { CoverEditModalBody } from '@/components/modals/CoverEditModal'
-import { LibraryItemEditModalContent } from '@/components/modals/LibraryItemEditModal'
+import { LibraryItemEditModalContent, type LibraryItemEditModalContentHandle } from '@/components/modals/LibraryItemEditModal'
 import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource } from '@/components/modals/LibraryItemModal'
 import { MatchModalBody } from '@/components/modals/MatchModal'
 import { SectionedModalBody, type Section } from '@/components/modals/SectionedModal'
@@ -38,10 +38,17 @@ function isBookWithAudioTracks(item: BookLibraryItem | PodcastLibraryItem | null
   return !!item && item.mediaType === 'book' && isBookMediaWithTracks(item.media)
 }
 
-/** If the chapters editor is mounted, confirm unsaved edits first; otherwise run `proceed` now. */
-function requestChaptersLeaveOrProceed(handle: ChaptersEditCloseHandle | null, proceed: () => void) {
-  if (handle) {
-    handle.requestLeave(proceed)
+/**
+ * Only one section (details/chapters) is mounted at a time, so at most one of these handles
+ * is non-null. If that section has unsaved edits, confirm first; otherwise run `proceed` now.
+ */
+function requestSectionLeaveOrProceed(
+  handles: Array<{ requestLeave: (onAllow: () => void) => void } | null>,
+  proceed: () => void
+) {
+  const activeHandle = handles.find((handle) => handle != null)
+  if (activeHandle) {
+    activeHandle.requestLeave(proceed)
     return
   }
   proceed()
@@ -58,6 +65,7 @@ interface LibraryItemMetadataEditModalBodyProps {
   startSaveTransition: TransitionStartFunction
   isSavePending: boolean
   chaptersCloseRef: Ref<ChaptersEditCloseHandle | null>
+  detailsCloseRef: Ref<LibraryItemEditModalContentHandle | null>
   onChaptersPendingChange: (pending: boolean) => void
 }
 
@@ -72,6 +80,7 @@ function LibraryItemMetadataEditModalBody({
   startSaveTransition,
   isSavePending,
   chaptersCloseRef,
+  detailsCloseRef,
   onChaptersPendingChange
 }: LibraryItemMetadataEditModalBodyProps) {
   const t = useTypeSafeTranslations()
@@ -118,6 +127,7 @@ function LibraryItemMetadataEditModalBody({
           onClose={onClose}
           stableBodyHeight={false}
           fillParent
+          closeRequestRef={detailsCloseRef}
         />
       ) : selectedSection === 'cover' ? (
         <CoverEditModalBody stableBodyHeight={false} fillParent />
@@ -141,6 +151,7 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
   const [selectedSection, setSelectedSection] = useState<MetadataEditSection>(initialSection ?? 'details')
   const [isChaptersPending, setIsChaptersPending] = useState(false)
   const chaptersCloseRef = useRef<ChaptersEditCloseHandle | null>(null)
+  const detailsCloseRef = useRef<LibraryItemEditModalContentHandle | null>(null)
 
   useEffect(() => {
     if (!isOpen) return
@@ -151,17 +162,17 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
     (sectionId: string) => {
       const next = sectionId as MetadataEditSection
       if (next === selectedSection) return
-      requestChaptersLeaveOrProceed(chaptersCloseRef.current, () => setSelectedSection(next))
+      requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], () => setSelectedSection(next))
     },
     [selectedSection]
   )
 
   const handleHubBack = useCallback((proceed: () => void) => {
-    requestChaptersLeaveOrProceed(chaptersCloseRef.current, proceed)
+    requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], proceed)
   }, [])
 
   const handleClose = useCallback(() => {
-    requestChaptersLeaveOrProceed(chaptersCloseRef.current, onClose)
+    requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], onClose)
   }, [onClose])
 
   const mobileInitialSection = initialSection === 'details' ? undefined : initialSection
@@ -173,7 +184,7 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
       {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem })}
       additionalProcessing={isSavePending || filterDataLoading || isChaptersPending}
       className="md:max-w-[min(95vw,60rem)]"
-      onBeforeNavigate={(proceed) => requestChaptersLeaveOrProceed(chaptersCloseRef.current, proceed)}
+      onBeforeNavigate={(proceed) => requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], proceed)}
     >
       <LibraryItemMetadataEditModalBody
         isOpen={isOpen}
@@ -186,6 +197,7 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
         startSaveTransition={startSaveTransition}
         isSavePending={isSavePending}
         chaptersCloseRef={chaptersCloseRef}
+        detailsCloseRef={detailsCloseRef}
         onChaptersPendingChange={setIsChaptersPending}
       />
     </LibraryItemModal>

--- a/src/components/modals/LibraryItemMetadataEditModal.tsx
+++ b/src/components/modals/LibraryItemMetadataEditModal.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { ChaptersEditModalBody, type ChaptersEditCloseHandle } from '@/components/modals/ChaptersEditModalBody'
+import { ChaptersEditModalBody } from '@/components/modals/ChaptersEditModalBody'
 import { CoverEditModalBody } from '@/components/modals/CoverEditModal'
-import { LibraryItemEditModalContent, type LibraryItemEditModalContentHandle } from '@/components/modals/LibraryItemEditModal'
-import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource } from '@/components/modals/LibraryItemModal'
+import { LibraryItemEditModalContent } from '@/components/modals/LibraryItemEditModal'
+import LibraryItemModal, { useLibraryItemModal, type LibraryItemModalItemSource, type UnsavedChangesLeaveHandle } from '@/components/modals/LibraryItemModal'
 import { MatchModalBody } from '@/components/modals/MatchModal'
 import { SectionedModalBody, type Section } from '@/components/modals/SectionedModal'
 import { useLibrary } from '@/contexts/LibraryContext'
@@ -42,7 +42,7 @@ function isBookWithAudioTracks(item: BookLibraryItem | PodcastLibraryItem | null
  * Only one section (details/chapters) is mounted at a time, so at most one of these handles
  * is non-null. If that section has unsaved edits, confirm first; otherwise run `proceed` now.
  */
-function requestSectionLeaveOrProceed(handles: Array<{ requestLeave: (onAllow: () => void) => void } | null>, proceed: () => void) {
+function requestSectionLeaveOrProceed(handles: Array<UnsavedChangesLeaveHandle | null>, proceed: () => void) {
   const activeHandle = handles.find((handle) => handle != null)
   if (activeHandle) {
     activeHandle.requestLeave(proceed)
@@ -61,8 +61,8 @@ interface LibraryItemMetadataEditModalBodyProps {
   onRequestHubBack: (proceed: () => void) => void
   startSaveTransition: TransitionStartFunction
   isSavePending: boolean
-  chaptersCloseRef: Ref<ChaptersEditCloseHandle | null>
-  detailsCloseRef: Ref<LibraryItemEditModalContentHandle | null>
+  chaptersCloseRef: Ref<UnsavedChangesLeaveHandle | null>
+  detailsCloseRef: Ref<UnsavedChangesLeaveHandle | null>
   onChaptersPendingChange: (pending: boolean) => void
 }
 
@@ -147,8 +147,8 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
   const [isSavePending, startSaveTransition] = useTransition()
   const [selectedSection, setSelectedSection] = useState<MetadataEditSection>(initialSection ?? 'details')
   const [isChaptersPending, setIsChaptersPending] = useState(false)
-  const chaptersCloseRef = useRef<ChaptersEditCloseHandle | null>(null)
-  const detailsCloseRef = useRef<LibraryItemEditModalContentHandle | null>(null)
+  const chaptersCloseRef = useRef<UnsavedChangesLeaveHandle | null>(null)
+  const detailsCloseRef = useRef<UnsavedChangesLeaveHandle | null>(null)
 
   useEffect(() => {
     if (!isOpen) return

--- a/src/components/modals/LibraryItemMetadataEditModal.tsx
+++ b/src/components/modals/LibraryItemMetadataEditModal.tsx
@@ -42,10 +42,7 @@ function isBookWithAudioTracks(item: BookLibraryItem | PodcastLibraryItem | null
  * Only one section (details/chapters) is mounted at a time, so at most one of these handles
  * is non-null. If that section has unsaved edits, confirm first; otherwise run `proceed` now.
  */
-function requestSectionLeaveOrProceed(
-  handles: Array<{ requestLeave: (onAllow: () => void) => void } | null>,
-  proceed: () => void
-) {
+function requestSectionLeaveOrProceed(handles: Array<{ requestLeave: (onAllow: () => void) => void } | null>, proceed: () => void) {
   const activeHandle = handles.find((handle) => handle != null)
   if (activeHandle) {
     activeHandle.requestLeave(proceed)
@@ -188,7 +185,8 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
     >
       <LibraryItemMetadataEditModalBody
         isOpen={isOpen}
-        onClose={handleClose}
+        // Unguarded: footer Save and Close must not re-enter requestLeave.
+        onClose={onClose}
         initialSection={mobileInitialSection}
         selectedSection={selectedSection}
         setSelectedSection={setSelectedSection}

--- a/src/components/modals/LibraryItemModal.tsx
+++ b/src/components/modals/LibraryItemModal.tsx
@@ -37,6 +37,11 @@ export function useLibraryItemModal(): LibraryItemModalContextValue {
   return ctx
 }
 
+/** Confirm unsaved edits, then run `onAllow` (e.g. switch section or close). */
+export type UnsavedChangesLeaveHandle = {
+  requestLeave: (onAllow: () => void) => void
+}
+
 /** Either `navCtx` (fetch + prev/next) or `libraryItem` (no fetch); object literals cannot include both. */
 export type LibraryItemModalItemSource = { navCtx: EntityNavigationContext } | { libraryItem: BookLibraryItem | PodcastLibraryItem }
 

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -959,6 +959,7 @@
   "MessageCollectionNotFound": "Collection not found",
   "MessageConfirmClearEpisodeFetchQueue": "Are you sure you want to clear the episode fetch queue?",
   "MessageConfirmCloseChaptersWithChanges": "You have unsaved chapter changes.",
+  "MessageConfirmCloseDetailsWithChanges": "You have unsaved changes.",
   "MessageConfirmCloseFeed": "Are you sure you want to close this feed?",
   "MessageConfirmContinueWithUnsavedChapters": "You have unsaved chapter changes.<br></br>Continue anyway?",
   "MessageConfirmCreateRootUserNoPassword": "Are you sure you want to create the root user with no password?",


### PR DESCRIPTION
Related to #233

The Chapters tab already warns before discarding unsaved edits when the modal is closed or the section is switched. The Details tab had no such guard — editing the title, authors, genres, explicit/abridged flags, etc. and then closing the modal silently discarded the changes with no warning.

This adds the same requestLeave + confirm-dialog pattern already used by ChaptersEditModalBody to LibraryItemEditModalContent, and updates the parent modal to check whichever section (details or chapters) is currently mounted before allowing navigation away.

The Match tab still needs the same treatment — happy to follow up with that in a separate PR if useful.

**Testing:**
- Edited the title, authors, genres, and explicit/abridged checkboxes in the Details tab, then closed without saving — confirm dialog now appears (previously it did not)
- Confirmed Save / Discard / Cancel in the dialog all behave correctly
- Confirmed switching tabs (e.g. to Chapters) while Details has unsaved edits also triggers the confirm dialog
- Confirmed editing only whitespace (e.g. trailing spaces in the title) does not trigger a false-positive warning, since those fields are trimmed before comparison
- Confirmed the Chapters tab's existing unsaved-changes behavior is unaffected