### PR TITLE
fix(chapters): keep first chapter start fixed at zero

### DIFF
--- a/cypress/tests/components/widgets/chapters-edit/ChapterEditTableRow.cy.tsx
+++ b/cypress/tests/components/widgets/chapters-edit/ChapterEditTableRow.cy.tsx
@@ -1,0 +1,75 @@
+import ChapterEditTableRow from '@/components/widgets/chapters-edit/ChapterEditTableRow'
+import type { EditableChapter } from '@/lib/chapters/chapterEditorUtils'
+import type { ComponentProps } from 'react'
+
+const mediaDuration = 3600
+
+function makeChapter(partial: Partial<EditableChapter> & Pick<EditableChapter, 'id' | 'start'>): EditableChapter {
+  return {
+    end: partial.end ?? partial.start + 60,
+    title: partial.title ?? `Chapter ${partial.id + 1}`,
+    error: partial.error ?? null,
+    clientKey: partial.clientKey ?? `ch-${partial.id}`,
+    ...partial
+  }
+}
+
+function mountRow(overrides: Partial<ComponentProps<typeof ChapterEditTableRow>> = {}) {
+  const onStartChange = cy.spy().as('onStartChange')
+
+  cy.mount(
+    <table>
+      <tbody>
+        <ChapterEditTableRow
+          chapter={makeChapter({ id: 0, start: 0, title: 'Intro' })}
+          chapterCount={2}
+          mediaDuration={mediaDuration}
+          isFirstChapter={false}
+          isChecked={false}
+          isPlaySelected={false}
+          isPlayingChapter={false}
+          isLoadingChapter={false}
+          elapsedTime={0}
+          canPlay={true}
+          startHeaderId="start-header"
+          titleHeaderId="title-header"
+          onCheckedChange={cy.stub()}
+          onStartChange={onStartChange}
+          onTitleDraft={cy.stub()}
+          onTitleCommit={cy.stub()}
+          onRemove={cy.stub()}
+          onInsertBelow={cy.stub()}
+          onPlay={cy.stub()}
+          {...overrides}
+        />
+      </tbody>
+    </table>
+  )
+}
+
+describe('<ChapterEditTableRow /> first chapter timestamp', () => {
+  it('disables the first row DurationPicker at 00:00:00', () => {
+    mountRow({
+      isFirstChapter: true,
+      chapter: makeChapter({ id: 0, start: 0, title: 'Intro' })
+    })
+
+    cy.get('[cy-id="duration-picker-wrapper"] input').should('have.length', 3).and('be.disabled')
+    cy.get('[cy-id="duration-picker-wrapper"] input').eq(0).should('have.value', '00')
+    cy.get('[cy-id="duration-picker-wrapper"] input').eq(1).should('have.value', '00')
+    cy.get('[cy-id="duration-picker-wrapper"] input').eq(2).should('have.value', '00')
+    cy.get('[cy-id="duration-picker-wrapper"] input').eq(2).type('7', { force: true })
+    cy.get('@onStartChange').should('not.have.been.called')
+  })
+
+  it('keeps a later-row DurationPicker editable', () => {
+    mountRow({
+      isFirstChapter: false,
+      chapter: makeChapter({ id: 1, start: 90, title: 'Chapter 2' })
+    })
+
+    cy.get('[cy-id="duration-picker-wrapper"] input').should('not.be.disabled')
+    cy.get('[cy-id="duration-picker-wrapper"] input').eq(2).focus().type('{uparrow}')
+    cy.get('@onStartChange').should('have.been.called')
+  })
+})

--- a/cypress/tests/lib/chapterEditorUtils.cy.ts
+++ b/cypress/tests/lib/chapterEditorUtils.cy.ts
@@ -2,6 +2,7 @@ import {
   buildBulkChapters,
   buildChapterDirtyBaseline,
   buildIdenticalChapters,
+  computeChapterEnds,
   detectBulkChapterPattern,
   getChapterDirtyFields,
   initChapters,
@@ -9,7 +10,11 @@ import {
   mergeAudibleChapterData,
   mergeAudibleChapterTitles,
   removeBrandingFromAudibleData,
-  savedChapterListsMatch
+  savedChapterListsMatch,
+  shiftChapterTimes,
+  updateChapterStart,
+  validateChapters,
+  type EditableChapter
 } from '@/lib/chapters/chapterEditorUtils'
 import type { AudibleChapterSearchResult, Chapter } from '@/types/api'
 
@@ -235,5 +240,103 @@ describe('savedChapterListsMatch', () => {
     const b: Chapter[] = [{ id: 0, start: 0, end: 100, title: 'Opening' }]
 
     expect(savedChapterListsMatch(a, b)).to.equal(false)
+  })
+})
+
+describe('first chapter start invariant', () => {
+  const mediaDuration = 1000
+  const messages = {
+    startLtPrev: 'Start must be greater than previous',
+    startGteDuration: 'Start must be less than duration'
+  }
+
+  function chapter(partial: Partial<EditableChapter> & Pick<EditableChapter, 'id' | 'start'>): EditableChapter {
+    return {
+      end: partial.end ?? partial.start + 60,
+      title: partial.title ?? `Chapter ${partial.id + 1}`,
+      error: partial.error ?? null,
+      ...partial
+    }
+  }
+
+  it('initializes a non-zero first start as 0 and leaves later starts unchanged', () => {
+    const existing: Chapter[] = [
+      { id: 0, start: 7, end: 80, title: 'Opening' },
+      { id: 1, start: 80, end: 200, title: 'Chapter 2' },
+      { id: 2, start: 200, end: mediaDuration, title: 'Chapter 3' }
+    ]
+
+    const initialized = initChapters(existing, mediaDuration)
+
+    expect(initialized[0].start).to.eq(0)
+    expect(initialized[0].title).to.eq('Opening')
+    expect(initialized[1].start).to.eq(80)
+    expect(initialized[2].start).to.eq(200)
+  })
+
+  it('validateChapters normalizes a non-zero first start without changing later chapters', () => {
+    const existing: Chapter[] = [
+      { id: 0, start: 7, end: 90, title: 'Intro' },
+      { id: 1, start: 90, end: mediaDuration, title: 'Chapter 2' }
+    ]
+    const chapters = [chapter({ id: 0, start: 7, title: 'Intro' }), chapter({ id: 1, start: 90, title: 'Chapter 2' })]
+
+    const result = validateChapters(chapters, existing, mediaDuration, messages)
+
+    expect(result.chapters[0].start).to.eq(0)
+    expect(result.chapters[0].error).to.eq(null)
+    expect(result.chapters[1].start).to.eq(90)
+    expect(result.chapters[1].error).to.eq(null)
+    expect(result.hasChanges).to.eq(true)
+  })
+
+  it('cannot change the first chapter start through update or shift', () => {
+    const chapters = [chapter({ id: 0, start: 0, title: 'Intro' }), chapter({ id: 1, start: 90, title: 'Chapter 2' })]
+
+    expect(updateChapterStart(chapters, 0, 7)).to.eq(chapters)
+    expect(shiftChapterTimes(chapters, 5, null, mediaDuration)[0].start).to.eq(0)
+    expect(shiftChapterTimes(chapters, 5, null, mediaDuration)[1].start).to.eq(95)
+  })
+
+  it('still allows later chapter start edits and a valid save payload', () => {
+    const existing: Chapter[] = [
+      { id: 0, start: 0, end: 90, title: 'Intro' },
+      { id: 1, start: 90, end: mediaDuration, title: 'Chapter 2' }
+    ]
+    const chapters = [chapter({ id: 0, start: 0, title: 'Intro' }), chapter({ id: 1, start: 90, title: 'Chapter 2' })]
+
+    const withUpdatedStart = updateChapterStart(chapters, 1, 120)
+    expect(withUpdatedStart[0].start).to.eq(0)
+    expect(withUpdatedStart[1].start).to.eq(120)
+
+    const result = validateChapters(withUpdatedStart, existing, mediaDuration, messages)
+    expect(result.chapters.every((item) => !item.error)).to.eq(true)
+    expect(result.hasChanges).to.eq(true)
+
+    const payload = computeChapterEnds(result.chapters, mediaDuration)
+    expect(payload).to.deep.eq([
+      { id: 0, start: 0, end: 120, title: 'Intro' },
+      { id: 1, start: 120, end: mediaDuration, title: 'Chapter 2' }
+    ])
+  })
+
+  it('normalizes a non-zero first Audible start when the list is validated', () => {
+    const existing = [chapter({ id: 0, start: 0, title: 'Local intro' }), chapter({ id: 1, start: 90, title: 'Local 2' })]
+    const audibleData: AudibleChapterSearchResult = {
+      runtimeLengthSec: 1000,
+      runtimeLengthMs: 1000000,
+      chapters: [
+        { title: 'Audible Intro', startOffsetSec: 4, startOffsetMs: 4000, lengthMs: 60000 },
+        { title: 'Audible Two', startOffsetSec: 64, startOffsetMs: 64000, lengthMs: 120000 }
+      ]
+    }
+
+    const { chapters: merged } = mergeAudibleChapterData(audibleData, mediaDuration, existing)
+    const result = validateChapters(merged, existing, mediaDuration, messages)
+
+    expect(result.chapters[0].start).to.eq(0)
+    expect(result.chapters[0].title).to.eq('Audible Intro')
+    expect(result.chapters[1].start).to.eq(64)
+    expect(result.chapters[1].title).to.eq('Audible Two')
   })
 })

--- a/cypress/tests/lib/chapterEditorUtils.cy.ts
+++ b/cypress/tests/lib/chapterEditorUtils.cy.ts
@@ -10,6 +10,7 @@ import {
   mergeAudibleChapterData,
   mergeAudibleChapterTitles,
   removeBrandingFromAudibleData,
+  removeChapterAt,
   savedChapterListsMatch,
   shiftChapterTimes,
   updateChapterStart,
@@ -338,5 +339,36 @@ describe('first chapter start invariant', () => {
     expect(result.chapters[0].title).to.eq('Audible Intro')
     expect(result.chapters[1].start).to.eq(64)
     expect(result.chapters[1].title).to.eq('Audible Two')
+  })
+
+  it('forces the remaining first start to 0 after removing the first chapter', () => {
+    const existing: Chapter[] = [
+      { id: 0, start: 0, end: 90, title: 'Intro' },
+      { id: 1, start: 90, end: 200, title: 'Chapter 2' },
+      { id: 2, start: 200, end: mediaDuration, title: 'Chapter 3' }
+    ]
+    const chapters = [
+      chapter({ id: 0, start: 0, title: 'Intro' }),
+      chapter({ id: 1, start: 90, title: 'Chapter 2' }),
+      chapter({ id: 2, start: 200, title: 'Chapter 3' })
+    ]
+
+    const remaining = removeChapterAt(chapters, 0)
+    expect(remaining).to.have.length(2)
+    expect(remaining[0].start).to.eq(90)
+
+    const result = validateChapters(remaining, existing, mediaDuration, messages)
+
+    expect(result.chapters[0].start).to.eq(0)
+    expect(result.chapters[0].title).to.eq('Chapter 2')
+    expect(result.chapters[0].error).to.eq(null)
+    expect(result.chapters[1].start).to.eq(200)
+    expect(result.chapters[1].title).to.eq('Chapter 3')
+    expect(result.hasChanges).to.eq(true)
+
+    expect(computeChapterEnds(result.chapters, mediaDuration)).to.deep.eq([
+      { id: 0, start: 0, end: 200, title: 'Chapter 2' },
+      { id: 1, start: 200, end: mediaDuration, title: 'Chapter 3' }
+    ])
   })
 })

--- a/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
+++ b/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
@@ -73,6 +73,7 @@ export interface ChapterEditTableRowProps {
   chapter: EditableChapter
   chapterCount: number
   mediaDuration: number
+  isFirstChapter?: boolean
   startDirty?: boolean
   baselineTitle?: string
   isChecked: boolean
@@ -106,6 +107,7 @@ function ChapterEditTableRow({
   chapter,
   chapterCount,
   mediaDuration,
+  isFirstChapter = false,
   startDirty = false,
   baselineTitle,
   isChecked,
@@ -212,6 +214,7 @@ function ChapterEditTableRow({
               size="small"
               className={startDirty ? 'text-info' : undefined}
               ariaLabelledBy={startHeaderId}
+              disabled={isFirstChapter}
               onChange={onStartChange}
             />
             {showMatchDebug ? (

--- a/src/components/widgets/chapters-edit/ChaptersModalTable.tsx
+++ b/src/components/widgets/chapters-edit/ChaptersModalTable.tsx
@@ -186,6 +186,7 @@ export default function ChaptersModalTable({
           chapter={chapter}
           chapterCount={chapters.length}
           mediaDuration={mediaDuration}
+          isFirstChapter={index === 0}
           startDirty={dirty.start}
           baselineTitle={chapter.clientKey ? dirtyBaseline.get(chapter.clientKey)?.title : undefined}
           showMatchDebug={showMatchDebug}

--- a/src/hooks/useChapterEditor.ts
+++ b/src/hooks/useChapterEditor.ts
@@ -73,7 +73,7 @@ export function useChapterEditor({ initialLibraryItem, onItemUpdated }: UseChapt
   const newChaptersRef = useRef(newChapters)
   newChaptersRef.current = newChapters
   const dirtyBaseline = useMemo(() => buildChapterDirtyBaseline(newChapters, savedChapters, mediaDuration), [mediaDuration, newChapters, savedChapters])
-  const [hasChanges, setHasChanges] = useState(false)
+  const [hasChanges, setHasChanges] = useState(() => computeHasChanges(initChapters(savedChapters, mediaDuration), savedChapters, mediaDuration))
   const hasChangesRef = useRef(hasChanges)
   hasChangesRef.current = hasChanges
   const [titleResetKey, setTitleResetKey] = useState(0)
@@ -117,7 +117,6 @@ export function useChapterEditor({ initialLibraryItem, onItemUpdated }: UseChapt
 
   const validationMessages = useMemo(
     () => ({
-      firstNotZero: t('MessageChapterErrorFirstNotZero'),
       startLtPrev: t('MessageChapterErrorStartLtPrev'),
       startGteDuration: t('MessageChapterErrorStartGteDuration')
     }),

--- a/src/lib/chapters/chapterEditorUtils.ts
+++ b/src/lib/chapters/chapterEditorUtils.ts
@@ -158,9 +158,18 @@ export function getChapterDirtyFields(chapter: EditableChapter, baseline: Map<st
 }
 
 export interface ChapterValidationMessages {
-  firstNotZero: string
   startLtPrev: string
   startGteDuration: string
+}
+
+export function ensureFirstChapterStartsAtZero(chapters: EditableChapter[]): EditableChapter[] {
+  const first = chapters[0]
+  if (!first || first.start === 0) {
+    return chapters
+  }
+  const next = chapters.slice()
+  next[0] = { ...first, start: 0 }
+  return next
 }
 
 export function initChapters(existing: Chapter[], mediaDuration: number): EditableChapter[] {
@@ -176,11 +185,13 @@ export function initChapters(existing: Chapter[], mediaDuration: number): Editab
       }
     ]
   }
-  return existing.map((chapter, index) => ({
-    ...chapter,
-    error: null as string | null,
-    clientKey: createStableChapterClientKey(index)
-  }))
+  return ensureFirstChapterStartsAtZero(
+    existing.map((chapter, index) => ({
+      ...chapter,
+      error: null as string | null,
+      clientKey: createStableChapterClientKey(index)
+    }))
+  )
 }
 
 /** True when the editor shows a single empty row at start time 0 (no title). */
@@ -214,13 +225,11 @@ export function validateChapters(
   messages: ChapterValidationMessages
 ): { chapters: EditableChapter[]; hasChanges: boolean } {
   let previousStart = 0
-  const updated = chapters.map((chapter, i) => {
-    const start = normalizeChapterStartSec(Number(chapter.start))
+  const updated = ensureFirstChapterStartsAtZero(chapters).map((chapter, i) => {
+    const start = i === 0 ? 0 : normalizeChapterStartSec(Number(chapter.start))
 
     let error: string | null
-    if (i === 0 && start !== 0) {
-      error = messages.firstNotZero
-    } else if (start <= previousStart && i > 0) {
+    if (start <= previousStart && i > 0) {
       error = messages.startLtPrev
     } else if (start >= mediaDuration) {
       error = messages.startGteDuration
@@ -510,6 +519,9 @@ export function buildIdenticalChapters(title: string, count: number, existingCha
 }
 
 export function updateChapterStart(chapters: EditableChapter[], id: number, start: number): EditableChapter[] {
+  if (chapters[0]?.id === id) {
+    return chapters
+  }
   return chapters.map((c) => (c.id === id ? { ...c, start } : c))
 }
 


### PR DESCRIPTION
## Brief summary

Keeps the first chapter start fixed at `00:00:00` in the chapter editor.

## Which issue is fixed?

Fixes an inconsistency where Chapter #1 could be edited away from `00:00:00` even though validation requires the first chapter to start at zero.

## In-depth Description

The chapter editor previously allowed users to modify the start timestamp of Chapter #1.

This created an invalid editor state because the first chapter is required to start at `00:00:00`, and attempting to save a non-zero first chapter start resulted in a validation error.

This change:

- Keeps the first chapter start normalized to `00:00:00`
- Disables the first chapter timestamp controls in the UI
- Prevents shared editor update functions from moving the first chapter away from zero
- Preserves all later chapter start times
- Keeps the existing start-only chapter boundary model unchanged

## How have you tested this?

- Relevant Cypress tests: 9 passing
- `pnpm typecheck`
- ESLint on changed files
- `prettier --check` on changed files

Regression coverage includes:

- non-zero first chapter start is normalized to `00:00:00`
- later chapter start times remain unchanged
- first chapter timestamp controls are disabled
- later chapter timestamps remain editable
- chapter end calculation remains correct
