### PR TITLE
fix(chapters): detect one-second timestamp edits

### DIFF
--- a/cypress/tests/lib/chapterEditorUtils.cy.ts
+++ b/cypress/tests/lib/chapterEditorUtils.cy.ts
@@ -1,7 +1,9 @@
 import {
+  applyMatchedClientKeys,
   buildBulkChapters,
   buildChapterDirtyBaseline,
   buildIdenticalChapters,
+  computeHasChanges,
   detectBulkChapterPattern,
   getChapterDirtyFields,
   initChapters,
@@ -9,7 +11,8 @@ import {
   mergeAudibleChapterData,
   mergeAudibleChapterTitles,
   removeBrandingFromAudibleData,
-  savedChapterListsMatch
+  savedChapterListsMatch,
+  updateChapterStart
 } from '@/lib/chapters/chapterEditorUtils'
 import type { AudibleChapterSearchResult, Chapter } from '@/types/api'
 
@@ -56,22 +59,54 @@ describe('removeBrandingFromAudibleData', () => {
 })
 
 describe('chapter start dirty comparison', () => {
-  it('treats starts within one second as unchanged', () => {
-    const saved: Chapter[] = [{ id: 0, start: 100, end: 500, title: 'Chapter 1' }]
-    const mediaDuration = 500
-    const chapter = { id: 0, start: 101, end: 500, title: 'Chapter 1', clientKey: 'ch-0', error: null }
-    const baseline = buildChapterDirtyBaseline([chapter], saved, mediaDuration)
+  const mediaDuration = 500
+  const saved: Chapter[] = [
+    { id: 0, start: 0, end: 100, title: 'Chapter 1' },
+    { id: 1, start: 100, end: 500, title: 'Chapter 2' }
+  ]
 
-    expect(getChapterDirtyFields(chapter, baseline).start).to.equal(false)
+  function editorChapters(secondStart: number) {
+    return initChapters(saved, mediaDuration).map((chapter) => (chapter.id === 1 ? { ...chapter, start: secondStart } : chapter))
+  }
+
+  it('marks a 1-second later-chapter edit as dirty (100 -> 101)', () => {
+    const chapters = editorChapters(101)
+    const baseline = buildChapterDirtyBaseline(chapters, saved, mediaDuration)
+
+    expect(computeHasChanges(chapters, saved, mediaDuration)).to.equal(true)
+    expect(getChapterDirtyFields(chapters[1], baseline).start).to.equal(true)
   })
 
-  it('still marks a two-second start change as dirty', () => {
-    const saved: Chapter[] = [{ id: 0, start: 100, end: 500, title: 'Chapter 1' }]
-    const mediaDuration = 500
-    const chapter = { id: 0, start: 102, end: 500, title: 'Chapter 1', clientKey: 'ch-0', error: null }
-    const baseline = buildChapterDirtyBaseline([chapter], saved, mediaDuration)
+  it('marks a 1-second later-chapter edit as dirty (100 -> 99)', () => {
+    const chapters = editorChapters(99)
+    const baseline = buildChapterDirtyBaseline(chapters, saved, mediaDuration)
 
-    expect(getChapterDirtyFields(chapter, baseline).start).to.equal(true)
+    expect(computeHasChanges(chapters, saved, mediaDuration)).to.equal(true)
+    expect(getChapterDirtyFields(chapters[1], baseline).start).to.equal(true)
+  })
+
+  it('stays clean when the only difference disappears after whole-second normalization', () => {
+    const fractionalSaved: Chapter[] = [
+      { id: 0, start: 0, end: 90.4, title: 'Chapter 1' },
+      { id: 1, start: 90.4, end: 500, title: 'Chapter 2' }
+    ]
+    const chapters = initChapters(fractionalSaved, mediaDuration)
+    chapters[1] = { ...chapters[1], start: 90 }
+    const baseline = buildChapterDirtyBaseline(chapters, fractionalSaved, mediaDuration)
+
+    expect(computeHasChanges(chapters, fractionalSaved, mediaDuration)).to.equal(false)
+    expect(getChapterDirtyFields(chapters[1], baseline).start).to.equal(false)
+  })
+
+  it('keeps Save dirty state and row highlighting in agreement after updateChapterStart', () => {
+    const chapters = updateChapterStart(initChapters(saved, mediaDuration), 1, 101)
+    const baseline = buildChapterDirtyBaseline(chapters, saved, mediaDuration)
+    const saveDirty = computeHasChanges(chapters, saved, mediaDuration)
+    const rowDirty = getChapterDirtyFields(chapters[1], baseline).start
+
+    expect(chapters[1].start).to.equal(101)
+    expect(saveDirty).to.equal(true)
+    expect(rowDirty).to.equal(saveDirty)
   })
 })
 
@@ -135,6 +170,48 @@ describe('mergeAudibleChapterData after remove branding', () => {
     expect(merged[1].clientKey).to.equal('ch-1')
     expect(getChapterDirtyFields(merged[0], baseline).start).to.equal(false)
     expect(getChapterDirtyFields(merged[1], baseline).start).to.equal(false)
+  })
+
+  it('keeps an existing start when imported time is within ±1 second', () => {
+    const existing = [
+      { id: 1, start: 100, end: 500, title: 'Chapter 2', error: null, clientKey: 'ch-1' },
+      { id: 2, start: 200, end: 500, title: 'Chapter 3', error: null, clientKey: 'ch-2' }
+    ]
+    const incoming = [
+      { id: 1, start: 101, end: 500, title: 'Chapter 2', error: null },
+      { id: 2, start: 199, end: 500, title: 'Chapter 3', error: null }
+    ]
+    const matchResult = {
+      matches: new Map([
+        [0, 0],
+        [1, 1]
+      ]),
+      costs: new Map([
+        [0, 0],
+        [1, 0]
+      ])
+    }
+
+    const merged = applyMatchedClientKeys(existing, incoming, matchResult)
+
+    expect(merged[0].start).to.equal(100)
+    expect(merged[0].clientKey).to.equal('ch-1')
+    expect(merged[1].start).to.equal(200)
+    expect(merged[1].clientKey).to.equal('ch-2')
+  })
+
+  it('uses the imported start when drift is more than ±1 second', () => {
+    const existing = [{ id: 1, start: 100, end: 500, title: 'Chapter 2', error: null, clientKey: 'ch-1' }]
+    const incoming = [{ id: 1, start: 102, end: 500, title: 'Chapter 2', error: null }]
+    const matchResult = {
+      matches: new Map([[0, 0]]),
+      costs: new Map([[0, 0]])
+    }
+
+    const merged = applyMatchedClientKeys(existing, incoming, matchResult)
+
+    expect(merged[0].start).to.equal(102)
+    expect(merged[0].clientKey).to.equal('ch-1')
   })
 })
 

--- a/cypress/tests/lib/chapterEditorUtils.cy.ts
+++ b/cypress/tests/lib/chapterEditorUtils.cy.ts
@@ -318,6 +318,26 @@ describe('savedChapterListsMatch', () => {
 
     expect(savedChapterListsMatch(a, b)).to.equal(false)
   })
+
+  it('treats a 1-second start change as a mismatch so socket updates reload the editor', () => {
+    const a: Chapter[] = [
+      { id: 0, start: 0, end: 100, title: 'Intro' },
+      { id: 1, start: 100, end: 500, title: 'Chapter 1' }
+    ]
+    const b: Chapter[] = [
+      { id: 0, start: 0, end: 100, title: 'Intro' },
+      { id: 1, start: 101, end: 500, title: 'Chapter 1' }
+    ]
+
+    expect(savedChapterListsMatch(a, b)).to.equal(false)
+  })
+
+  it('still matches when the only start difference disappears after whole-second rounding', () => {
+    const a: Chapter[] = [{ id: 0, start: 90.4, end: 500, title: 'Intro' }]
+    const b: Chapter[] = [{ id: 0, start: 90, end: 500, title: 'Intro' }]
+
+    expect(savedChapterListsMatch(a, b)).to.equal(true)
+  })
 })
 
 describe('first chapter start invariant', () => {

--- a/src/lib/chapters/chapterEditorUtils.ts
+++ b/src/lib/chapters/chapterEditorUtils.ts
@@ -56,8 +56,8 @@ export function computeHasChanges(chapters: EditableChapter[], existingChapters:
     const chapterEnd = chapters[i + 1] ? chapters[i + 1].start : mediaDuration
     const existingEnd = existingChapters[i + 1] ? existingChapters[i + 1].start : mediaDuration
     if (
-      !chapterTimesEqual(chapter.start, existingChapter.start) ||
-      !chapterTimesEqual(chapterEnd, existingEnd) ||
+      !normalizedChapterTimesEqual(chapter.start, existingChapter.start) ||
+      !normalizedChapterTimesEqual(chapterEnd, existingEnd) ||
       (chapter.title || '').trim() !== (existingChapter.title || '').trim()
     ) {
       return true
@@ -95,7 +95,12 @@ export function audibleMsToChapterStartSec(ms: number): number {
 /** Starts within this many seconds compare equal (Audible ms rounding vs saved whole seconds). */
 const CHAPTER_START_TOLERANCE_SEC = 1
 
-/** DurationPicker and timestamps are whole seconds; ignore sub-second and ±1s Audible drift. */
+/** Exact whole-second equality after DurationPicker-style rounding. Used for editor dirty state. */
+function normalizedChapterTimesEqual(a: number, b: number): boolean {
+  return normalizeChapterStartSec(a) === normalizeChapterStartSec(b)
+}
+
+/** ±1s after rounding. Used for Audible/import matching, not user-edit dirty detection. */
 function chapterTimesEqual(a: number, b: number): boolean {
   return Math.abs(normalizeChapterStartSec(a) - normalizeChapterStartSec(b)) <= CHAPTER_START_TOLERANCE_SEC
 }
@@ -148,12 +153,12 @@ export function getChapterDirtyFields(chapter: EditableChapter, baseline: Map<st
   if (!snapshot) {
     return { start: true, title: true, duration: true }
   }
-  const startDirty = !chapterTimesEqual(chapter.start, snapshot.start)
+  const startDirty = !normalizedChapterTimesEqual(chapter.start, snapshot.start)
   const titleDirty = (chapter.title || '').trim() !== snapshot.title
   return {
     start: startDirty,
     title: titleDirty,
-    duration: startDirty || !chapterTimesEqual(chapter.end, snapshot.end)
+    duration: startDirty || !normalizedChapterTimesEqual(chapter.end, snapshot.end)
   }
 }
 

--- a/src/lib/chapters/chapterEditorUtils.ts
+++ b/src/lib/chapters/chapterEditorUtils.ts
@@ -70,7 +70,7 @@ export function computeHasChanges(chapters: EditableChapter[], existingChapters:
 export function savedChapterListsMatch(a: Chapter[], b: Chapter[]): boolean {
   if (a.length !== b.length) return false
   for (let i = 0; i < a.length; i++) {
-    if (!chapterTimesEqual(a[i].start, b[i].start)) return false
+    if (!normalizedChapterTimesEqual(a[i].start, b[i].start)) return false
     if ((a[i].title || '').trim() !== (b[i].title || '').trim()) return false
   }
   return true
@@ -95,12 +95,12 @@ export function audibleMsToChapterStartSec(ms: number): number {
 /** Starts within this many seconds compare equal (Audible ms rounding vs saved whole seconds). */
 const CHAPTER_START_TOLERANCE_SEC = 1
 
-/** Exact whole-second equality after DurationPicker-style rounding. Used for editor dirty state. */
+/** Exact whole-second equality after DurationPicker-style rounding. Used for editor dirty state and saved-list identity. */
 function normalizedChapterTimesEqual(a: number, b: number): boolean {
   return normalizeChapterStartSec(a) === normalizeChapterStartSec(b)
 }
 
-/** ±1s after rounding. Used for Audible/import matching, not user-edit dirty detection. */
+/** ±1s after rounding. Used for Audible/import matching, not user-edit dirty detection or socket identity. */
 function chapterTimesEqual(a: number, b: number): boolean {
   return Math.abs(normalizeChapterStartSec(a) - normalizeChapterStartSec(b)) <= CHAPTER_START_TOLERANCE_SEC
 }


### PR DESCRIPTION
## Brief summary

Fixes chapter editor dirty detection so real one-second timestamp edits are recognized as unsaved changes.

## Which issue is fixed?

Fixes #264

## In-depth Description

The chapter editor previously used the same ±1 second timestamp tolerance for both imported chapter matching and user-edit dirty detection.

As a result, changing a chapter start time by exactly one second was treated as unchanged. The Save button remained unavailable until another field, such as the chapter title, was modified.

This change separates the two behaviours:

- User edits now use exact whole-second comparison after timestamp normalization.
- The existing ±1 second tolerance is preserved for Audible/import matching.
- Dirty row highlighting now matches the Save state.
- The existing chapter matching window and start/end model are unchanged.

## How have you tested this?

- Relevant chapter Cypress tests: 22 passing
- ESLint on changed files: passing
- Prettier check on changed files: passing
- Cypress TypeScript check: passing

Regression coverage includes:

- `100 -> 101` is dirty
- `100 -> 99` is dirty
- `90.4 vs 90` remains clean after normalization
- row dirty highlighting agrees with Save state
- Audible/import matching still preserves ±1 second timestamp tolerance

`pnpm typecheck` currently fails on master due to an unrelated existing `GlobalSearchInput.tsx` / `useEffectEvent` error.