### PR TITLE
Bring back +/- buttons for chapter timestamps

### DIFF
--- a/src/components/ui/DurationPicker.tsx
+++ b/src/components/ui/DurationPicker.tsx
@@ -16,6 +16,8 @@ export interface DurationPickerProps {
   borderless?: boolean
   size?: 'small' | 'medium' | 'large'
   className?: string
+  /** Extra classes on the bordered InputWrapper (e.g. glued input groups). */
+  wrapperClassName?: string
   /** Accessible name for the time group. Defaults to LabelDuration. Ignored when ariaLabelledBy is set. */
   ariaLabel?: string
   /** When set, names the time group from that element (e.g. a column header) instead of the legend. */
@@ -41,6 +43,7 @@ export default function DurationPicker({
   borderless = false,
   size = 'medium',
   className,
+  wrapperClassName,
   ariaLabel,
   ariaLabelledBy,
   onChange
@@ -276,7 +279,13 @@ export default function DurationPicker({
 
   return (
     <div className={mergeClasses(size === 'small' && 'w-fit', sizeText, className)}>
-      <InputWrapper disabled={disabled} readOnly={readOnly} borderless={borderless} size={size} className="items-center px-2.5">
+      <InputWrapper
+        disabled={disabled}
+        readOnly={readOnly}
+        borderless={borderless}
+        size={size}
+        className={mergeClasses('items-center px-2.5', wrapperClassName)}
+      >
         <fieldset
           cy-id="duration-picker-wrapper"
           className={wrapperClass}

--- a/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
+++ b/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
@@ -103,6 +103,9 @@ const MATCH_DEBUG_CLASS = 'text-foreground-muted text-[9px] leading-none ps-3'
 const MATCH_DEBUG_PREFIX = 'was: '
 const MATCH_DEBUG_NONE = '—'
 
+const TIME_INCREMENT = 1
+const START_STEP_BTN_CLASS = 'size-6 min-h-0 min-w-0 shrink-0 p-0 text-sm text-foreground-muted hover:not-disabled:text-foreground'
+
 function ChapterEditTableRow({
   chapter,
   chapterCount,
@@ -135,8 +138,10 @@ function ChapterEditTableRow({
   const overflowTooltip = overflow === 'start' ? t('MessageChapterStartIsAfter') : overflow === 'end' ? t('MessageChapterEndIsAfter') : undefined
   const startTimeCellClass =
     mediaDuration >= 360000
-      ? 'w-[7.5rem] min-w-[7.5rem] px-1 py-2 align-top md:w-[8.75rem] md:min-w-[8.75rem] md:px-2'
-      : 'w-[6.5rem] min-w-[6.5rem] px-1 py-2 align-top md:w-[7.25rem] md:min-w-[7.25rem] md:px-2'
+      ? 'w-[11rem] min-w-[11rem] px-1 py-2 align-top md:w-[12.25rem] md:min-w-[12.25rem] md:px-2'
+      : 'w-[10rem] min-w-[10rem] px-1 py-2 align-top md:w-[10.75rem] md:min-w-[10.75rem] md:px-2'
+  const cannotDecrementStart = isFirstChapter || chapter.start - TIME_INCREMENT < 0
+  const cannotIncrementStart = isFirstChapter || chapter.start + TIME_INCREMENT >= mediaDuration
   const rowBgClass = overflow === 'start' ? 'bg-error/20' : overflow === 'end' ? 'bg-warning/20' : isEvenRow ? 'bg-table-row-bg-even' : undefined
   const rowClass = mergeClasses('border-border hover:bg-table-row-bg-hover', rowBgClass)
 
@@ -208,15 +213,45 @@ function ChapterEditTableRow({
 
         <td className={startTimeCellClass}>
           <div className="flex flex-col gap-0.5">
-            <DurationPicker
-              value={chapter.start}
-              showThreeDigitHour={mediaDuration >= 360000}
-              size="small"
-              className={startDirty ? 'text-info' : undefined}
-              ariaLabelledBy={startHeaderId}
-              disabled={isFirstChapter}
-              onChange={onStartChange}
-            />
+            <div className="flex items-center gap-1">
+              <Tooltip lazy text={t('TooltipSubtractOneSecond')} position="bottom">
+                <IconBtn
+                  ariaLabel={t('TooltipSubtractOneSecond')}
+                  borderless
+                  size="custom"
+                  className={START_STEP_BTN_CLASS}
+                  disabled={cannotDecrementStart}
+                  onClick={() => onStartChange(Math.max(0, chapter.start - TIME_INCREMENT))}
+                >
+                  remove
+                </IconBtn>
+              </Tooltip>
+
+              <div className="min-w-0 flex-1">
+                <DurationPicker
+                  value={chapter.start}
+                  showThreeDigitHour={mediaDuration >= 360000}
+                  size="small"
+                  className={startDirty ? 'text-info' : undefined}
+                  ariaLabelledBy={startHeaderId}
+                  disabled={isFirstChapter}
+                  onChange={onStartChange}
+                />
+              </div>
+
+              <Tooltip lazy text={t('TooltipAddOneSecond')} position="bottom">
+                <IconBtn
+                  ariaLabel={t('TooltipAddOneSecond')}
+                  borderless
+                  size="custom"
+                  className={START_STEP_BTN_CLASS}
+                  disabled={cannotIncrementStart}
+                  onClick={() => onStartChange(chapter.start + TIME_INCREMENT)}
+                >
+                  add
+                </IconBtn>
+              </Tooltip>
+            </div>
             {showMatchDebug ? (
               matchDebug ? (
                 <Tooltip

--- a/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
+++ b/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
@@ -104,7 +104,10 @@ const MATCH_DEBUG_PREFIX = 'was: '
 const MATCH_DEBUG_NONE = '—'
 
 const TIME_INCREMENT = 1
-const START_STEP_BTN_CLASS = 'size-6 min-h-0 min-w-0 shrink-0 p-0 text-sm text-foreground-muted hover:not-disabled:text-foreground'
+const START_STEP_BTN_CLASS =
+  'h-9 w-7 shrink-0 p-0 shadow-none text-sm text-foreground-muted hover:not-disabled:text-foreground disabled:border disabled:border-solid disabled:border-border'
+const START_STEP_MINUS_CLASS = mergeClasses(START_STEP_BTN_CLASS, 'rounded-e-none')
+const START_STEP_PLUS_CLASS = mergeClasses(START_STEP_BTN_CLASS, 'rounded-s-none')
 
 function ChapterEditTableRow({
   chapter,
@@ -213,13 +216,12 @@ function ChapterEditTableRow({
 
         <td className={startTimeCellClass}>
           <div className="flex flex-col gap-0.5">
-            <div className="flex items-center gap-1">
-              <Tooltip lazy text={t('TooltipSubtractOneSecond')} position="bottom">
+            <div className="flex w-fit items-stretch">
+              <Tooltip lazy className="relative z-1 -me-px flex h-9 shrink-0" text={t('TooltipSubtractOneSecond')} position="bottom">
                 <IconBtn
                   ariaLabel={t('TooltipSubtractOneSecond')}
-                  borderless
                   size="custom"
-                  className={START_STEP_BTN_CLASS}
+                  className={START_STEP_MINUS_CLASS}
                   disabled={cannotDecrementStart}
                   onClick={() => onStartChange(Math.max(0, chapter.start - TIME_INCREMENT))}
                 >
@@ -227,24 +229,24 @@ function ChapterEditTableRow({
                 </IconBtn>
               </Tooltip>
 
-              <div className="min-w-0 flex-1">
+              <div className="relative focus-within:z-2">
                 <DurationPicker
                   value={chapter.start}
                   showThreeDigitHour={mediaDuration >= 360000}
                   size="small"
                   className={startDirty ? 'text-info' : undefined}
+                  wrapperClassName="rounded-none"
                   ariaLabelledBy={startHeaderId}
                   disabled={isFirstChapter}
                   onChange={onStartChange}
                 />
               </div>
 
-              <Tooltip lazy text={t('TooltipAddOneSecond')} position="bottom">
+              <Tooltip lazy className="relative z-1 -ms-px flex h-9 shrink-0" text={t('TooltipAddOneSecond')} position="bottom">
                 <IconBtn
                   ariaLabel={t('TooltipAddOneSecond')}
-                  borderless
                   size="custom"
-                  className={START_STEP_BTN_CLASS}
+                  className={START_STEP_PLUS_CLASS}
                   disabled={cannotIncrementStart}
                   onClick={() => onStartChange(chapter.start + TIME_INCREMENT)}
                 >

--- a/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
+++ b/src/components/widgets/chapters-edit/ChapterEditTableRow.tsx
@@ -206,119 +206,114 @@ function ChapterEditTableRow({
   )
 
   return (
-    <>
-      <tr title={overflowTooltip} className={mergeClasses(rowClass, 'border-b-0 md:border-b')}>
-        <td className="w-12 min-w-12 py-2 ps-3 pe-2 text-center align-top">
-          <div className="flex items-center justify-center">
-            <Checkbox value={isChecked} size="small" ariaLabel={chapter.title.trim() || t('LabelTitle')} onChange={onCheckedChange} />
-          </div>
-        </td>
+    <tr title={overflowTooltip} className={mergeClasses(rowClass, 'border-b max-md:grid max-md:grid-cols-[3rem_minmax(0,1fr)_auto] max-md:items-start')}>
+      <td className="w-12 min-w-12 py-2 ps-3 pe-2 text-center align-top max-md:col-start-1 max-md:row-start-1 max-md:flex max-md:items-center max-md:justify-center">
+        <div className="flex items-center justify-center">
+          <Checkbox value={isChecked} size="small" ariaLabel={chapter.title.trim() || t('LabelTitle')} onChange={onCheckedChange} />
+        </div>
+      </td>
 
-        <td className={startTimeCellClass}>
-          <div className="flex flex-col gap-0.5">
-            <div className="flex w-fit items-stretch">
-              <Tooltip lazy className="relative z-1 -me-px flex h-9 shrink-0" text={t('TooltipSubtractOneSecond')} position="bottom">
-                <IconBtn
-                  ariaLabel={t('TooltipSubtractOneSecond')}
-                  size="custom"
-                  className={START_STEP_MINUS_CLASS}
-                  disabled={cannotDecrementStart}
-                  onClick={() => onStartChange(Math.max(0, chapter.start - TIME_INCREMENT))}
-                >
-                  remove
-                </IconBtn>
-              </Tooltip>
+      <td className={mergeClasses(startTimeCellClass, 'max-md:col-start-2 max-md:row-start-1 max-md:block max-md:w-auto max-md:min-w-0')}>
+        <div className="flex flex-col gap-0.5">
+          <div className="flex w-fit items-stretch">
+            <Tooltip lazy className="relative z-1 -me-px flex h-9 shrink-0" text={t('TooltipSubtractOneSecond')} position="bottom">
+              <IconBtn
+                ariaLabel={t('TooltipSubtractOneSecond')}
+                size="custom"
+                className={START_STEP_MINUS_CLASS}
+                disabled={cannotDecrementStart}
+                onClick={() => onStartChange(Math.max(0, chapter.start - TIME_INCREMENT))}
+              >
+                remove
+              </IconBtn>
+            </Tooltip>
 
-              <div className="relative focus-within:z-2">
-                <DurationPicker
-                  value={chapter.start}
-                  showThreeDigitHour={mediaDuration >= 360000}
-                  size="small"
-                  className={startDirty ? 'text-info' : undefined}
-                  wrapperClassName="rounded-none"
-                  ariaLabelledBy={startHeaderId}
-                  disabled={isFirstChapter}
-                  onChange={onStartChange}
-                />
-              </div>
-
-              <Tooltip lazy className="relative z-1 -ms-px flex h-9 shrink-0" text={t('TooltipAddOneSecond')} position="bottom">
-                <IconBtn
-                  ariaLabel={t('TooltipAddOneSecond')}
-                  size="custom"
-                  className={START_STEP_PLUS_CLASS}
-                  disabled={cannotIncrementStart}
-                  onClick={() => onStartChange(chapter.start + TIME_INCREMENT)}
-                >
-                  add
-                </IconBtn>
-              </Tooltip>
+            <div className="relative focus-within:z-2">
+              <DurationPicker
+                value={chapter.start}
+                showThreeDigitHour={mediaDuration >= 360000}
+                size="small"
+                className={startDirty ? 'text-info' : undefined}
+                wrapperClassName="rounded-none"
+                ariaLabelledBy={startHeaderId}
+                disabled={isFirstChapter}
+                onChange={onStartChange}
+              />
             </div>
-            {showMatchDebug ? (
-              matchDebug ? (
-                <Tooltip
-                  lazy
-                  text={`${MATCH_DEBUG_PREFIX}${secondsToHmsTimestamp(matchDebug.oldStart)} (match cost: ${matchDebug.matchCost.toFixed(3)})`}
-                  position="bottom"
-                >
-                  <span className={mergeClasses(MATCH_DEBUG_CLASS, 'font-mono')}>
+
+            <Tooltip lazy className="relative z-1 -ms-px flex h-9 shrink-0" text={t('TooltipAddOneSecond')} position="bottom">
+              <IconBtn
+                ariaLabel={t('TooltipAddOneSecond')}
+                size="custom"
+                className={START_STEP_PLUS_CLASS}
+                disabled={cannotIncrementStart}
+                onClick={() => onStartChange(chapter.start + TIME_INCREMENT)}
+              >
+                add
+              </IconBtn>
+            </Tooltip>
+          </div>
+          {showMatchDebug ? (
+            matchDebug ? (
+              <Tooltip
+                lazy
+                text={`${MATCH_DEBUG_PREFIX}${secondsToHmsTimestamp(matchDebug.oldStart)} (match cost: ${matchDebug.matchCost.toFixed(3)})`}
+                position="bottom"
+              >
+                <span className={mergeClasses(MATCH_DEBUG_CLASS, 'font-mono')}>
+                  {MATCH_DEBUG_PREFIX}
+                  {secondsToHmsTimestamp(matchDebug.oldStart)}
+                </span>
+              </Tooltip>
+            ) : (
+              <span className={MATCH_DEBUG_CLASS}>
+                {MATCH_DEBUG_PREFIX}
+                {MATCH_DEBUG_NONE}
+              </span>
+            )
+          ) : null}
+        </div>
+      </td>
+
+      <td className="min-w-0 px-1 py-2 align-top max-md:col-span-2 max-md:col-start-1 max-md:row-start-2 max-md:block max-md:min-w-0 max-md:pt-0 md:px-2">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <ChapterTitleInput
+            key={`${chapter.clientKey ?? chapter.id}-${titleResetKey}`}
+            title={chapter.title}
+            baselineTitle={baselineTitle}
+            ariaLabelledBy={titleHeaderId}
+            onDraft={onTitleDraft}
+            onCommit={onTitleCommit}
+          />
+          {showMatchDebug ? (
+            matchDebug ? (
+              <Tooltip
+                lazy
+                text={`${MATCH_DEBUG_PREFIX}${matchDebug.oldTitle || MATCH_DEBUG_NONE} (match cost: ${matchDebug.matchCost.toFixed(3)})`}
+                position="bottom"
+              >
+                <span className={mergeClasses(MATCH_DEBUG_CLASS, 'flex min-w-0 items-baseline gap-1')}>
+                  <span className="min-w-0 truncate">
                     {MATCH_DEBUG_PREFIX}
-                    {secondsToHmsTimestamp(matchDebug.oldStart)}
+                    {matchDebug.oldTitle || MATCH_DEBUG_NONE}
                   </span>
-                </Tooltip>
-              ) : (
-                <span className={MATCH_DEBUG_CLASS}>
-                  {MATCH_DEBUG_PREFIX}
-                  {MATCH_DEBUG_NONE}
+                  <span className="shrink-0 font-mono">({matchDebug.matchCost.toFixed(3)})</span>
                 </span>
-              )
-            ) : null}
-          </div>
-        </td>
+              </Tooltip>
+            ) : (
+              <span className={mergeClasses(MATCH_DEBUG_CLASS, 'block min-w-0 truncate')}>
+                {MATCH_DEBUG_PREFIX}
+                {MATCH_DEBUG_NONE}
+              </span>
+            )
+          ) : null}
+        </div>
+      </td>
 
-        <td className="min-w-0 px-1 py-2 align-top md:px-2">
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <ChapterTitleInput
-              key={`${chapter.clientKey ?? chapter.id}-${titleResetKey}`}
-              title={chapter.title}
-              baselineTitle={baselineTitle}
-              ariaLabelledBy={titleHeaderId}
-              onDraft={onTitleDraft}
-              onCommit={onTitleCommit}
-            />
-            {showMatchDebug ? (
-              matchDebug ? (
-                <Tooltip
-                  lazy
-                  text={`${MATCH_DEBUG_PREFIX}${matchDebug.oldTitle || MATCH_DEBUG_NONE} (match cost: ${matchDebug.matchCost.toFixed(3)})`}
-                  position="bottom"
-                >
-                  <span className={mergeClasses(MATCH_DEBUG_CLASS, 'flex min-w-0 items-baseline gap-1')}>
-                    <span className="min-w-0 truncate">
-                      {MATCH_DEBUG_PREFIX}
-                      {matchDebug.oldTitle || MATCH_DEBUG_NONE}
-                    </span>
-                    <span className="shrink-0 font-mono">({matchDebug.matchCost.toFixed(3)})</span>
-                  </span>
-                </Tooltip>
-              ) : (
-                <span className={mergeClasses(MATCH_DEBUG_CLASS, 'block min-w-0 truncate')}>
-                  {MATCH_DEBUG_PREFIX}
-                  {MATCH_DEBUG_NONE}
-                </span>
-              )
-            ) : null}
-          </div>
-        </td>
-
-        <td className="hidden w-40 min-w-40 px-2 py-2 align-top md:table-cell">{actions}</td>
-      </tr>
-      <tr title={overflowTooltip} className={mergeClasses(rowClass, 'border-b md:hidden')}>
-        <td colSpan={3} className="pt-0 pb-2 align-top">
-          <div className="flex justify-end">{actions}</div>
-        </td>
-      </tr>
-    </>
+      <td className="w-40 min-w-40 px-2 py-2 align-top max-md:col-start-3 max-md:row-start-2 max-md:flex max-md:w-auto max-md:min-w-0 max-md:items-center max-md:pt-0 md:table-cell">
+        {actions}
+      </td>
+    </tr>
   )
 }
 

--- a/src/components/widgets/chapters-edit/ChaptersModalTable.tsx
+++ b/src/components/widgets/chapters-edit/ChaptersModalTable.tsx
@@ -28,7 +28,7 @@ const HEADER_CELL_CLASS = 'text-foreground-muted px-2 py-2 text-start text-xs fo
 
 function startTimeColumnClass(mediaDuration: number, base: 'header' | 'cell'): string {
   const width =
-    mediaDuration >= 360000 ? 'w-[7.5rem] min-w-[7.5rem] md:w-[8.75rem] md:min-w-[8.75rem]' : 'w-[6.5rem] min-w-[6.5rem] md:w-[7.25rem] md:min-w-[7.25rem]'
+    mediaDuration >= 360000 ? 'w-[11rem] min-w-[11rem] md:w-[12.25rem] md:min-w-[12.25rem]' : 'w-[10rem] min-w-[10rem] md:w-[10.75rem] md:min-w-[10.75rem]'
   return base === 'header' ? mergeClasses('text-start px-1 md:px-2', width) : mergeClasses('px-1 align-top md:px-2', width)
 }
 

--- a/src/components/widgets/chapters-edit/ChaptersModalTable.tsx
+++ b/src/components/widgets/chapters-edit/ChaptersModalTable.tsx
@@ -6,6 +6,7 @@ import IconBtn from '@/components/ui/IconBtn'
 import TextInput from '@/components/ui/TextInput'
 import Tooltip from '@/components/ui/Tooltip'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
+import { CHAPTERS_EDIT_TABLE_ATTR } from '@/lib/chapterEditorFocus'
 import {
   BULK_CHAPTER_COUNT_MAX,
   BULK_CHAPTER_COUNT_MIN,
@@ -19,7 +20,6 @@ import {
   type EditableChapter
 } from '@/lib/chapters/chapterEditorUtils'
 import { mergeClasses } from '@/lib/merge-classes'
-import { CHAPTERS_EDIT_TABLE_ATTR } from '@/lib/chapterEditorFocus'
 import { useCallback, useEffect, useId, useMemo, useState, type RefObject } from 'react'
 import ChapterEditTableRow from './ChapterEditTableRow'
 


### PR DESCRIPTION
Closes #265. Adds small +/- buttons next to each chapter's start time so you can nudge it by a second without typing. They're disabled once you hit the start or end of the track.