### PR TITLE
Confirm unsaved changes when leaving the Match tab in the edit modal

### DIFF
--- a/src/components/modals/LibraryItemMetadataEditModal.tsx
+++ b/src/components/modals/LibraryItemMetadataEditModal.tsx
@@ -39,7 +39,7 @@ function isBookWithAudioTracks(item: BookLibraryItem | PodcastLibraryItem | null
 }
 
 /**
- * Only one section (details/chapters) is mounted at a time, so at most one of these handles
+ * Only one section (details/chapters/match) is mounted at a time, so at most one of these handles
  * is non-null. If that section has unsaved edits, confirm first; otherwise run `proceed` now.
  */
 function requestSectionLeaveOrProceed(handles: Array<UnsavedChangesLeaveHandle | null>, proceed: () => void) {
@@ -63,6 +63,7 @@ interface LibraryItemMetadataEditModalBodyProps {
   isSavePending: boolean
   chaptersCloseRef: Ref<UnsavedChangesLeaveHandle | null>
   detailsCloseRef: Ref<UnsavedChangesLeaveHandle | null>
+  matchCloseRef: Ref<UnsavedChangesLeaveHandle | null>
   onChaptersPendingChange: (pending: boolean) => void
 }
 
@@ -78,6 +79,7 @@ function LibraryItemMetadataEditModalBody({
   isSavePending,
   chaptersCloseRef,
   detailsCloseRef,
+  matchCloseRef,
   onChaptersPendingChange
 }: LibraryItemMetadataEditModalBodyProps) {
   const t = useTypeSafeTranslations()
@@ -131,7 +133,7 @@ function LibraryItemMetadataEditModalBody({
       ) : selectedSection === 'chapters' ? (
         <ChaptersEditModalBody closeRequestRef={chaptersCloseRef} onPendingChange={onChaptersPendingChange} />
       ) : (
-        <MatchModalBody fillParent />
+        <MatchModalBody fillParent closeRequestRef={matchCloseRef} />
       )}
     </SectionedModalBody>
   )
@@ -149,6 +151,7 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
   const [isChaptersPending, setIsChaptersPending] = useState(false)
   const chaptersCloseRef = useRef<UnsavedChangesLeaveHandle | null>(null)
   const detailsCloseRef = useRef<UnsavedChangesLeaveHandle | null>(null)
+  const matchCloseRef = useRef<UnsavedChangesLeaveHandle | null>(null)
 
   useEffect(() => {
     if (!isOpen) return
@@ -159,17 +162,17 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
     (sectionId: string) => {
       const next = sectionId as MetadataEditSection
       if (next === selectedSection) return
-      requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], () => setSelectedSection(next))
+      requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current, matchCloseRef.current], () => setSelectedSection(next))
     },
     [selectedSection]
   )
 
   const handleHubBack = useCallback((proceed: () => void) => {
-    requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], proceed)
+    requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current, matchCloseRef.current], proceed)
   }, [])
 
   const handleClose = useCallback(() => {
-    requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], onClose)
+    requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current, matchCloseRef.current], onClose)
   }, [onClose])
 
   const mobileInitialSection = initialSection === 'details' ? undefined : initialSection
@@ -181,7 +184,7 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
       {...(navCtxMode ? { navCtx: props.navCtx } : { libraryItem: props.libraryItem })}
       additionalProcessing={isSavePending || filterDataLoading || isChaptersPending}
       className="md:max-w-[min(95vw,60rem)]"
-      onBeforeNavigate={(proceed) => requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current], proceed)}
+      onBeforeNavigate={(proceed) => requestSectionLeaveOrProceed([detailsCloseRef.current, chaptersCloseRef.current, matchCloseRef.current], proceed)}
     >
       <LibraryItemMetadataEditModalBody
         isOpen={isOpen}
@@ -196,6 +199,7 @@ export default function LibraryItemMetadataEditModal(props: LibraryItemMetadataE
         isSavePending={isSavePending}
         chaptersCloseRef={chaptersCloseRef}
         detailsCloseRef={detailsCloseRef}
+        matchCloseRef={matchCloseRef}
         onChaptersPendingChange={setIsChaptersPending}
       />
     </LibraryItemModal>

--- a/src/components/modals/MatchModal.tsx
+++ b/src/components/modals/MatchModal.tsx
@@ -1,15 +1,22 @@
 'use client'
 
-import LibraryItemModal, { type LibraryItemModalItemSource, useLibraryItemModal } from '@/components/modals/LibraryItemModal'
+import LibraryItemModal, { type LibraryItemModalItemSource, type UnsavedChangesLeaveHandle, useLibraryItemModal } from '@/components/modals/LibraryItemModal'
 import LoadingIndicator from '@/components/ui/LoadingIndicator'
 import Match from '@/components/widgets/Match'
+import type { Ref } from 'react'
 
 export type MatchModalProps = {
   isOpen: boolean
   onClose: () => void
 } & LibraryItemModalItemSource
 
-export function MatchModalBody({ fillParent = false }: { fillParent?: boolean }) {
+export type MatchModalBodyProps = {
+  fillParent?: boolean
+  /** Lets the parent intercept leave (section change, hub back, close) while a match is selected but not yet applied. */
+  closeRequestRef?: Ref<UnsavedChangesLeaveHandle | null>
+}
+
+export function MatchModalBody({ fillParent = false, closeRequestRef }: MatchModalBodyProps) {
   const { resolvedItem, fetchPending } = useLibraryItemModal()
   return (
     <div className={fillParent ? 'flex h-full min-h-0 flex-col overflow-hidden' : 'flex h-[80vh] flex-col overflow-hidden'}>
@@ -18,7 +25,7 @@ export function MatchModalBody({ fillParent = false }: { fillParent?: boolean })
           <LoadingIndicator variant="inline" />
         </div>
       ) : resolvedItem ? (
-        <Match libraryItem={resolvedItem} />
+        <Match libraryItem={resolvedItem} closeRequestRef={closeRequestRef} />
       ) : null}
     </div>
   )

--- a/src/components/widgets/Match.tsx
+++ b/src/components/widgets/Match.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { searchBooksAction, searchPodcastsAction } from '@/app/actions/matchActions'
+import type { UnsavedChangesLeaveHandle } from '@/components/modals/LibraryItemModal'
 import Btn from '@/components/ui/Btn'
 import Dropdown from '@/components/ui/Dropdown'
 import { MultiSelectItem } from '@/components/ui/MultiSelect'
 import TextInput from '@/components/ui/TextInput'
+import ConfirmDialog from '@/components/widgets/ConfirmDialog'
 import BookMatchView from '@/components/widgets/match/BookMatchView'
 import MatchCard from '@/components/widgets/match/MatchCard'
 import PodcastMatchView from '@/components/widgets/match/PodcastMatchView'
@@ -13,7 +15,7 @@ import { useGlobalToast } from '@/contexts/ToastContext'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { BookLibraryItem, BookSearchResult, isBookMedia, isPodcastMedia, PodcastLibraryItem, PodcastSearchResult } from '@/types/api'
-import React, { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react'
+import React, { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState, useTransition, type Ref } from 'react'
 
 interface MatchProps {
   libraryItem: BookLibraryItem | PodcastLibraryItem
@@ -22,6 +24,8 @@ interface MatchProps {
   availableGenres?: MultiSelectItem<string>[]
   availableTags?: MultiSelectItem<string>[]
   availableSeries?: MultiSelectItem<string>[]
+  /** Lets the parent intercept leave (section change, hub back, close) while a match is selected but not yet applied. */
+  closeRequestRef?: Ref<UnsavedChangesLeaveHandle | null>
 }
 
 type MatchResult = BookSearchResult | PodcastSearchResult
@@ -41,7 +45,14 @@ function getDefaultBookProvider(providers: { value: string }[]): string {
   }
 }
 
-export default function Match({ libraryItem, availableNarrators = [], availableGenres = [], availableTags = [], availableSeries = [] }: MatchProps) {
+export default function Match({
+  libraryItem,
+  availableNarrators = [],
+  availableGenres = [],
+  availableTags = [],
+  availableSeries = [],
+  closeRequestRef
+}: MatchProps) {
   const t = useTypeSafeTranslations()
   const { showToast } = useGlobalToast()
 
@@ -70,6 +81,8 @@ export default function Match({ libraryItem, availableNarrators = [], availableG
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const searchInitItemIdRef = useRef<string | null>(null)
   const [hasScrollbar, setHasScrollbar] = useState(false)
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false)
+  const pendingLeaveRef = useRef<(() => void) | null>(null)
 
   const media = useMemo(() => libraryItem.media || {}, [libraryItem.media])
   const mediaMetadata = useMemo(() => media.metadata || {}, [media.metadata])
@@ -264,6 +277,34 @@ export default function Match({ libraryItem, availableNarrators = [], availableG
     setFocusedCardIndex(null)
   }, [])
 
+  // A selected match is only applied on Submit, so leaving with one selected discards it.
+  const requestLeave = useCallback(
+    (onAllow: () => void) => {
+      if (!selectedMatchOrig) {
+        onAllow()
+        return
+      }
+      pendingLeaveRef.current = onAllow
+      setShowCloseConfirm(true)
+    },
+    [selectedMatchOrig]
+  )
+
+  const handleCancelLeave = useCallback(() => {
+    pendingLeaveRef.current = null
+    setShowCloseConfirm(false)
+  }, [])
+
+  const handleDiscardAndLeave = useCallback(() => {
+    const onAllow = pendingLeaveRef.current
+    pendingLeaveRef.current = null
+    setShowCloseConfirm(false)
+    handleClearSelectedMatch()
+    onAllow?.()
+  }, [handleClearSelectedMatch])
+
+  useImperativeHandle(closeRequestRef, () => ({ requestLeave }), [requestLeave])
+
   const handleCardArrowKey = useCallback(
     (direction: 'up' | 'down', index: number) => {
       if (direction === 'down') {
@@ -431,6 +472,14 @@ export default function Match({ libraryItem, availableNarrators = [], availableG
           />
         )
       ) : null}
+
+      <ConfirmDialog
+        isOpen={showCloseConfirm}
+        message={t('MessageConfirmCloseMatchWithChanges')}
+        yesButtonText={t('ButtonDiscard')}
+        onClose={handleCancelLeave}
+        onConfirm={handleDiscardAndLeave}
+      />
     </>
   )
 }

--- a/src/locales/en-us.json
+++ b/src/locales/en-us.json
@@ -961,6 +961,7 @@
   "MessageConfirmCloseChaptersWithChanges": "You have unsaved chapter changes.",
   "MessageConfirmCloseDetailsWithChanges": "You have unsaved changes.",
   "MessageConfirmCloseFeed": "Are you sure you want to close this feed?",
+  "MessageConfirmCloseMatchWithChanges": "You have unsaved match changes.",
   "MessageConfirmContinueWithUnsavedChapters": "You have unsaved chapter changes.<br></br>Continue anyway?",
   "MessageConfirmCreateRootUserNoPassword": "Are you sure you want to create the root user with no password?",
   "MessageConfirmDeleteApiKey": "Are you sure you want to delete API key \"{0}\"?",


### PR DESCRIPTION
Related to #233. Follows up on #268, which added the unsaved-changes guard for the Details tab; this does the same for the Match tab.

In the Match section a selected match is only applied on Submit, so switching sections, going back to the hub, navigating prev/next, or closing the modal with a match selected silently dropped it. Match now exposes the same requestLeave handle as Details and Chapters, and the sectioned edit modal checks it alongside the other two. The confirm dialog offers Discard / Cancel only, since applying a match the user has not finished reviewing did not seem like a safe default.

## Test plan
- [ ] eslint, prettier, tsc --noEmit and find-hardcoded-strings all pass
- [ ] Open Edit > Match, pick a search result, then close the modal / switch to another section / use hub back on mobile / use prev-next: confirm dialog appears; Cancel stays, Discard leaves and returns Match to the search view
- [ ] Same flows with no match selected: no dialog
- [ ] Submit a match, then leave: no dialog
- [ ] Standalone Match modal (context menu > Match) unchanged