### PR TITLE
Discussion: Reduce item-page update overhead during batch podcast downloads

### DIFF
--- a/cypress/tests/components/hooks/useThrottledLatestSnapshot.cy.tsx
+++ b/cypress/tests/components/hooks/useThrottledLatestSnapshot.cy.tsx
@@ -1,0 +1,86 @@
+import { useThrottledLatestSnapshot } from '@/hooks/useThrottledLatestSnapshot'
+import { useCallback, useState } from 'react'
+
+type Snapshot = { id: string; n: number }
+
+function ItemUpdateHarness({ itemId, intervalMs = 200 }: { itemId: string; intervalMs?: number }) {
+  const [applied, setApplied] = useState<number | null>(null)
+  const apply = useCallback((snapshot: Snapshot) => {
+    setApplied(snapshot.n)
+  }, [])
+  const schedule = useThrottledLatestSnapshot(itemId, apply, intervalMs)
+
+  return (
+    <div>
+      <span data-cy="item-id">{itemId}</span>
+      <span data-cy="applied">{applied === null ? 'none' : String(applied)}</span>
+      <button data-cy="push-1" onClick={() => schedule({ id: itemId, n: 1 })}>
+        Push 1
+      </button>
+      <button data-cy="push-2" onClick={() => schedule({ id: itemId, n: 2 })}>
+        Push 2
+      </button>
+      <button data-cy="push-stale" onClick={() => schedule({ id: 'other-item', n: 99 })}>
+        Push stale
+      </button>
+    </div>
+  )
+}
+
+function SwitchableItemHarness() {
+  const [itemId, setItemId] = useState('item-a')
+  const [applied, setApplied] = useState<number | null>(null)
+  const apply = useCallback((snapshot: Snapshot) => {
+    setApplied(snapshot.n)
+  }, [])
+  const schedule = useThrottledLatestSnapshot(itemId, apply, 200)
+
+  return (
+    <div>
+      <span data-cy="item-id">{itemId}</span>
+      <span data-cy="applied">{applied === null ? 'none' : String(applied)}</span>
+      <button data-cy="push-1" onClick={() => schedule({ id: 'item-a', n: 1 })}>
+        Push 1
+      </button>
+      <button data-cy="switch" onClick={() => setItemId('item-b')}>
+        Switch
+      </button>
+    </div>
+  )
+}
+
+describe('useThrottledLatestSnapshot', () => {
+  it('applies the latest snapshot after the interval and ignores a different item id', () => {
+    cy.clock()
+    cy.mount(<ItemUpdateHarness itemId="item-a" />)
+
+    cy.get('[data-cy="push-1"]').click()
+    cy.get('[data-cy="push-2"]').click()
+    cy.get('[data-cy="push-stale"]').click()
+    cy.get('[data-cy="applied"]').should('have.text', 'none')
+
+    cy.tick(200)
+    cy.get('[data-cy="applied"]').should('have.text', '2')
+  })
+
+  it('does not apply a pending snapshot after the item id changes', () => {
+    cy.clock()
+    cy.mount(<SwitchableItemHarness />)
+
+    cy.get('[data-cy="push-1"]').click()
+    cy.get('[data-cy="switch"]').click()
+    cy.get('[data-cy="item-id"]').should('have.text', 'item-b')
+    cy.tick(200)
+    cy.get('[data-cy="applied"]').should('have.text', 'none')
+  })
+
+  it('does not apply a pending snapshot after unmount', () => {
+    cy.clock()
+    cy.mount(<ItemUpdateHarness itemId="item-a" />)
+
+    cy.get('[data-cy="push-1"]').click()
+    cy.mount(<div data-cy="unmounted">unmounted</div>)
+    cy.tick(200)
+    cy.get('[data-cy="unmounted"]').should('have.text', 'unmounted')
+  })
+})

--- a/cypress/tests/lib/latestSnapshotThrottle.cy.ts
+++ b/cypress/tests/lib/latestSnapshotThrottle.cy.ts
@@ -1,0 +1,109 @@
+import { createLatestSnapshotThrottle } from '@/lib/latestSnapshotThrottle'
+
+type Snapshot = { id: string; n: number }
+
+function createFakeTimers() {
+  let now = 0
+  let nextId = 1
+  const timers = new Map<number, { fireAt: number; fn: () => void }>()
+
+  return {
+    now: () => now,
+    setTimeout(fn: () => void, ms: number) {
+      const id = nextId++
+      timers.set(id, { fireAt: now + ms, fn })
+      return id as unknown as ReturnType<typeof setTimeout>
+    },
+    clearTimeout(id: ReturnType<typeof setTimeout>) {
+      timers.delete(Number(id))
+    },
+    advance(ms: number) {
+      now += ms
+      const due = [...timers.entries()].filter(([, timer]) => timer.fireAt <= now).sort((a, b) => a[1].fireAt - b[1].fireAt)
+      for (const [id, timer] of due) {
+        timers.delete(id)
+        timer.fn()
+      }
+    }
+  }
+}
+
+function createHarness(itemId = 'item-a') {
+  const applied: Snapshot[] = []
+  let currentItemId = itemId
+  const timers = createFakeTimers()
+  const throttle = createLatestSnapshotThrottle<Snapshot>({
+    intervalMs: 200,
+    getCurrentItemId: () => currentItemId,
+    apply: (snapshot) => applied.push(snapshot),
+    setTimeoutFn: timers.setTimeout,
+    clearTimeoutFn: timers.clearTimeout
+  })
+
+  return {
+    applied,
+    setCurrentItemId(id: string) {
+      currentItemId = id
+    },
+    schedule(n: number, id = currentItemId) {
+      throttle.schedule({ id, n })
+    },
+    reset: throttle.reset,
+    advance: timers.advance
+  }
+}
+
+describe('createLatestSnapshotThrottle', () => {
+  it('applies the latest snapshot on a regular interval while events continue', () => {
+    const harness = createHarness()
+
+    harness.schedule(1)
+    harness.schedule(2)
+    harness.schedule(3)
+    harness.advance(199)
+    expect(harness.applied).to.deep.equal([])
+
+    harness.advance(1)
+    expect(harness.applied.map((snapshot) => snapshot.n)).to.deep.equal([3])
+
+    harness.schedule(4)
+    harness.schedule(5)
+    harness.advance(200)
+    expect(harness.applied.map((snapshot) => snapshot.n)).to.deep.equal([3, 5])
+  })
+
+  it('still applies the last snapshot after events stop', () => {
+    const harness = createHarness()
+
+    harness.schedule(1)
+    harness.schedule(8)
+    harness.advance(200)
+    expect(harness.applied.map((snapshot) => snapshot.n)).to.deep.equal([8])
+
+    harness.advance(400)
+    expect(harness.applied.map((snapshot) => snapshot.n)).to.deep.equal([8])
+  })
+
+  it('does not apply a pending snapshot after reset on item change or unmount', () => {
+    const harness = createHarness('item-a')
+
+    harness.schedule(4)
+    harness.setCurrentItemId('item-b')
+    harness.reset()
+    harness.advance(200)
+    expect(harness.applied).to.deep.equal([])
+
+    harness.schedule(1)
+    harness.reset()
+    harness.advance(200)
+    expect(harness.applied).to.deep.equal([])
+  })
+
+  it('ignores snapshots for a different item id', () => {
+    const harness = createHarness('item-a')
+
+    harness.schedule(9, 'item-b')
+    harness.advance(200)
+    expect(harness.applied).to.deep.equal([])
+  })
+})

--- a/cypress/tests/lib/libraryItemUpdatedUtils.cy.ts
+++ b/cypress/tests/lib/libraryItemUpdatedUtils.cy.ts
@@ -1,0 +1,119 @@
+import { mergeLibraryItemUpdate } from '@/lib/libraryItemUpdatedUtils'
+import type { BookLibraryItem, LibraryItem, MediaItemShare, PodcastEpisode, PodcastLibraryItem, RssFeed } from '@/types/api'
+
+const rssFeed = { id: 'feed-1', entityId: 'pod-1' } as RssFeed
+const mediaItemShare = { id: 'share-1', mediaItemId: 'media-1' } as MediaItemShare
+const recentEpisode = { id: 'ep-kept' } as PodcastEpisode
+
+function podcastItem(overrides: Partial<PodcastLibraryItem> & { id: string; episodes?: PodcastEpisode[] }): PodcastLibraryItem {
+  const { id, episodes, media, ...rest } = overrides
+  return {
+    id,
+    mediaType: 'podcast',
+    media: media ?? {
+      metadata: { title: 'Podcast' },
+      tags: [],
+      episodes: episodes ?? []
+    },
+    ...rest
+  } as unknown as PodcastLibraryItem
+}
+
+function bookItem(overrides: Partial<BookLibraryItem> & { id: string }): BookLibraryItem {
+  const { id, media, ...rest } = overrides
+  return {
+    id,
+    mediaType: 'book',
+    media: media ?? {
+      metadata: { title: 'Book', authors: [], series: [] },
+      tags: []
+    },
+    ...rest
+  } as unknown as BookLibraryItem
+}
+
+describe('mergeLibraryItemUpdate', () => {
+  it('keeps client-only rssFeed, mediaItemShare, and recentEpisode across snapshot replaces', () => {
+    const existing = podcastItem({
+      id: 'pod-1',
+      rssFeed,
+      mediaItemShare,
+      recentEpisode,
+      episodes: [recentEpisode, { id: 'ep-2' } as PodcastEpisode]
+    })
+    const updated = podcastItem({
+      id: 'pod-1',
+      media: {
+        metadata: { title: 'Updated podcast' },
+        tags: [],
+        episodes: [recentEpisode, { id: 'ep-2' } as PodcastEpisode, { id: 'ep-3' } as PodcastEpisode]
+      } as unknown as PodcastLibraryItem['media']
+    })
+
+    const merged = mergeLibraryItemUpdate(existing, updated)
+
+    expect(merged.media.metadata.title).to.equal('Updated podcast')
+    expect(merged.rssFeed).to.equal(rssFeed)
+    expect(merged.mediaItemShare).to.equal(mediaItemShare)
+    expect(merged.recentEpisode).to.equal(recentEpisode)
+  })
+
+  it('drops recentEpisode when that episode is no longer on the snapshot', () => {
+    const existing = podcastItem({
+      id: 'pod-1',
+      recentEpisode,
+      episodes: [recentEpisode]
+    })
+    const updated = podcastItem({
+      id: 'pod-1',
+      episodes: [{ id: 'ep-other' } as PodcastEpisode]
+    })
+
+    expect(mergeLibraryItemUpdate(existing, updated).recentEpisode).to.equal(undefined)
+  })
+
+  it('preserves a personalized shelf series ref on books', () => {
+    const seriesRef = { id: 'series-1', name: 'Shelf series' }
+    const existing = bookItem({
+      id: 'book-1',
+      media: {
+        metadata: { title: 'Old title', authors: [], series: seriesRef },
+        tags: []
+      } as unknown as BookLibraryItem['media']
+    })
+    const updated = bookItem({
+      id: 'book-1',
+      media: {
+        metadata: { title: 'New title', authors: [], series: [{ id: 'series-1', name: 'Expanded series', books: [] }] },
+        tags: []
+      } as unknown as BookLibraryItem['media']
+    })
+
+    const merged = mergeLibraryItemUpdate(existing, updated) as BookLibraryItem
+
+    expect(merged.media.metadata.title).to.equal('New title')
+    expect(merged.media.metadata.series).to.equal(seriesRef)
+  })
+
+  it('still preserves client-only fields when only the latest throttled snapshot is merged', () => {
+    const existing = podcastItem({
+      id: 'pod-1',
+      rssFeed,
+      mediaItemShare,
+      recentEpisode,
+      episodes: [recentEpisode]
+    })
+    const snapshots: LibraryItem[] = [
+      podcastItem({ id: 'pod-1', episodes: [recentEpisode, { id: 'ep-2' } as PodcastEpisode] }),
+      podcastItem({ id: 'pod-1', episodes: [recentEpisode, { id: 'ep-2' } as PodcastEpisode, { id: 'ep-3' } as PodcastEpisode] })
+    ]
+    const latest = snapshots[snapshots.length - 1]
+
+    const merged = mergeLibraryItemUpdate(existing, latest)
+
+    expect(merged.rssFeed).to.equal(rssFeed)
+    expect(merged.mediaItemShare).to.equal(mediaItemShare)
+    expect(merged.recentEpisode).to.equal(recentEpisode)
+    expect((merged.media as PodcastLibraryItem['media']).episodes).to.have.length(3)
+  })
+})

--- a/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
+++ b/src/app/(main)/library/[library]/item/[item]/LibraryItemClient.tsx
@@ -15,6 +15,7 @@ import { useGlobalToast } from '@/contexts/ToastContext'
 import { useUser } from '@/contexts/UserContext'
 import { useCoverAccentColor } from '@/hooks/useCoverAccentColor'
 import { useItemPageSocket } from '@/hooks/useItemPageSocket'
+import { useThrottledLatestSnapshot } from '@/hooks/useThrottledLatestSnapshot'
 import { useTypeSafeTranslations } from '@/hooks/useTypeSafeTranslations'
 import { getLibraryItemCoverUrl } from '@/lib/coverUtils'
 import { secondsToTimestamp } from '@/lib/datefns'
@@ -80,9 +81,14 @@ export default function LibraryItemClient({ libraryItem: initialLibraryItem }: L
     setMetadataEditSection(null)
   }
 
-  const handleItemUpdated = (updatedItem: BookLibraryItem | PodcastLibraryItem) => {
-    setLibraryItem((prev) => mergeLibraryItemUpdate(prev, updatedItem) as BookLibraryItem | PodcastLibraryItem)
-  }
+  const applyLibraryItemUpdate = useCallback((updatedItem: BookLibraryItem | PodcastLibraryItem) => {
+    setLibraryItem((prev) => {
+      if (prev.id !== updatedItem.id) return prev
+      return mergeLibraryItemUpdate(prev, updatedItem) as BookLibraryItem | PodcastLibraryItem
+    })
+  }, [])
+
+  const handleItemUpdated = useThrottledLatestSnapshot(initialLibraryItem.id, applyLibraryItemUpdate)
 
   const { rssFeed, episodesDownloading, episodeDownloadsQueued } = useItemPageSocket({
     libraryItemId: libraryItem.id,

--- a/src/hooks/useItemPageSocket.ts
+++ b/src/hooks/useItemPageSocket.ts
@@ -48,7 +48,6 @@ export function useItemPageSocket({
   const handleItemUpdated = useCallback(
     (libraryItem: BookLibraryItem | PodcastLibraryItem) => {
       if (libraryItem.id === libraryItemId) {
-        console.log('Item was updated', libraryItem)
         onItemUpdated?.(libraryItem)
       }
     },

--- a/src/hooks/useThrottledLatestSnapshot.ts
+++ b/src/hooks/useThrottledLatestSnapshot.ts
@@ -1,0 +1,40 @@
+'use client'
+
+import { createLatestSnapshotThrottle, ITEM_PAGE_UPDATE_THROTTLE_MS, type LatestSnapshotThrottle } from '@/lib/latestSnapshotThrottle'
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+/**
+ * Coalesce rapid snapshots for the current item id. The latest snapshot is applied at most once per
+ * interval while events continue, and the final pending snapshot is still applied after they stop.
+ * Pending work is discarded when the item id changes or the component unmounts.
+ */
+export function useThrottledLatestSnapshot<T extends { id: string }>(
+  currentItemId: string,
+  apply: (snapshot: T) => void,
+  intervalMs = ITEM_PAGE_UPDATE_THROTTLE_MS
+): (snapshot: T) => void {
+  const applyRef = useRef(apply)
+  applyRef.current = apply
+
+  const itemIdRef = useRef(currentItemId)
+  itemIdRef.current = currentItemId
+
+  const throttleRef = useRef<LatestSnapshotThrottle<T> | null>(null)
+  if (!throttleRef.current) {
+    throttleRef.current = createLatestSnapshotThrottle<T>({
+      intervalMs,
+      getCurrentItemId: () => itemIdRef.current,
+      apply: (snapshot) => applyRef.current(snapshot)
+    })
+  }
+
+  useLayoutEffect(() => {
+    return () => {
+      throttleRef.current?.reset()
+    }
+  }, [currentItemId])
+
+  return useCallback((snapshot: T) => {
+    throttleRef.current?.schedule(snapshot)
+  }, [])
+}

--- a/src/lib/latestSnapshotThrottle.ts
+++ b/src/lib/latestSnapshotThrottle.ts
@@ -1,0 +1,52 @@
+export const ITEM_PAGE_UPDATE_THROTTLE_MS = 200
+
+type TimeoutHandle = ReturnType<typeof setTimeout>
+
+export type LatestSnapshotThrottleOptions<T extends { id: string }> = {
+  intervalMs: number
+  getCurrentItemId: () => string
+  apply: (snapshot: T) => void
+  setTimeoutFn?: (fn: () => void, ms: number) => TimeoutHandle
+  clearTimeoutFn?: (id: TimeoutHandle) => void
+}
+
+export type LatestSnapshotThrottle<T extends { id: string }> = {
+  schedule(snapshot: T): void
+  reset(): void
+}
+
+/**
+ * Trailing throttle that keeps only the latest snapshot and flushes it at most once per interval.
+ * A new interval starts after each flush while snapshots continue to arrive (not debounce-until-idle).
+ * `reset` drops pending work without applying it. Use on item change and unmount.
+ */
+export function createLatestSnapshotThrottle<T extends { id: string }>(options: LatestSnapshotThrottleOptions<T>): LatestSnapshotThrottle<T> {
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout
+  const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout
+  let pending: T | null = null
+  let timer: TimeoutHandle | 0 = 0
+
+  const flush = () => {
+    timer = 0
+    const last = pending
+    pending = null
+    if (!last) return
+    if (last.id !== options.getCurrentItemId()) return
+    options.apply(last)
+  }
+
+  return {
+    schedule(snapshot) {
+      if (snapshot.id !== options.getCurrentItemId()) return
+      pending = snapshot
+      if (!timer) {
+        timer = setTimeoutFn(flush, options.intervalMs)
+      }
+    },
+    reset() {
+      if (timer) clearTimeoutFn(timer)
+      timer = 0
+      pending = null
+    }
+  }
+}


### PR DESCRIPTION
﻿During large podcast downloads, each completed episode produces a full item snapshot. Applying every snapshot on the item page can create substantial update and memory overhead.

This draft coalesces item-page updates into 200ms intervals, applies the latest pending snapshot after events stop, clears pending work on item changes or unmount, and removes full-object debug logging. It does not change the socket protocol. Isolated metadata updates may appear up to approximately 200ms later under normal scheduling.

## Verification

- ESLint on the changed files passed with no findings.
- `pnpm typecheck` (`tsc --noEmit` and the Cypress `tsconfig`) passed.
- 11 Cypress component tests passed: 4 in `latestSnapshotThrottle.cy.ts`, 4 in `libraryItemUpdatedUtils.cy.ts`, and 3 in `useThrottledLatestSnapshot.cy.tsx`.
- Local production build, real Find Episodes UI, 1200-episode short-description fixture:
  - The unthrottled baseline was stopped on purpose at about 957 episodes with JS heap around 1.5GB. That was not a browser crash.
  - The 200ms candidate completed 1200 episodes in two earlier runs, with peak heap around 210-292MB, an empty download queue, and no manual refresh.
- Those numbers are local observations, not a memory cap or a general guarantee.
- The original issue's Aw Snap was not reproduced. The overhead we saw was mainly on the item page.

## Discussion

I'd appreciate feedback on whether coalescing item-page updates is an acceptable small improvement. A separate experimental approach using negotiated incremental episode events reduced socket traffic substantially, but it requires coordinated server and client changes and is not included in this PR. Would that be a useful follow-up direction?

Related to #267
